### PR TITLE
chore: prepare release v0.3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [v0.3.8] - 2026-01-25
+
+### Added
+
+* UI: オシロスコープの残光表示（`Persistence / Eye Pattern`）機能を追加（減衰・強度設定付き）
+* Core: `AllanWorker` を導入し、Allan Deviation の非同期計算に対応
+
+### Changed
+
+* Perf: `AudioCalc` の A-weighting 計算を `lru_cache` で最適化
+* Perf: スペクトル平滑化のビン探索をバイナリサーチにより最適化
+* I18n: 初回起動時のシステム言語自動検出機能を実装
+* Docs: `PROPOSED_FEATURES.md` を信号計測フォーカスへリファクタリングし、全体を整理
+
+### Fixed
+
+* Core: Oscilloscope および Spectrogram ウィジェットにおけるオーディオコールバック等のリソースリークを修正
+* I18n: 翻訳キーの不足と重複、および他言語への漏れを修正
+* Chore: Allan Deviation 関連の不要なテスト・再現スクリプトを削除
+
 ## [v0.3.7] - 2026-01-24
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "measurelab"
-version = "0.3.7"
+version = "0.3.8"
 description = "DIY audio measurement and analysis suite (GUI + CLI)"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Description
This PR prepares the v0.3.8 release.

- Updated `CHANGELOG.md` with changes since v0.3.7.
- Bumped version to `0.3.8` in `pyproject.toml`.
- Ran `ruff check --fix` and `markdownlint-cli2` to ensure quality.

Please merge this PR to proceed with the release.
