### PR TITLE
Fix missing translation key: Carrier Mode

### DIFF
--- a/scripts/update_translations.py
+++ b/scripts/update_translations.py
@@ -13,30 +13,7 @@ LANG_DIR = os.path.join(PROJECT_ROOT, "src", "assets", "lang")
 
 # Missing keys in en.json (from check_trn_keys.py output)
 MISSING_EN_KEYS = [
-    " Hz",
-    " dB",
-    "Advanced Options",
-    "Audio LPF:",
-    "Bypass Modulation (Passthrough)",
-    "Carrier Freq:",
-    "Enable √ Pre-distortion",
-    "High intensity ultrasound can be dangerous to hearing (even if inaudible) and pets.\n\nAre you sure you want to start emission?",
-    "Input Gain:",
-    "Input Level",
-    "Mod. Depth (k):",
-    "Modulation",
-    "Output Level (40kHz)",
-    "Routing",
-    "STANDBY",
-    "Safety Warning",
-    "Signal Levels",
-    "Start Modulation",
-    "Stop Modulation",
-    "Ultrasound AM Modulator",
-    "Ultrasound Modulator running from CLI (not fully implemented)",
-    "🔴 DANGEROUS - HIGH INTENSITY 🔴",
-    "🟡 CAUTION - ULTRASOUND ACTIVE 🟡",
-    "🟢 SAFE - LOW INTENSITY 🟢",
+    "Carrier Mode:",
 ]
 
 # Missing keys in other language files (de, es, fr, ja, ko, pt, ru, zh)

--- a/src/assets/lang/de.json
+++ b/src/assets/lang/de.json
@@ -997,5 +997,6 @@
     "Ultrasound AM Modulator": "Ultraschall-AM-Modulator",
     "🔴 DANGEROUS - HIGH INTENSITY 🔴": "🔴 GEFÄHRLICH - HOHE INTENSITÄT 🔴",
     "🟡 CAUTION - ULTRASOUND ACTIVE 🟡": "🟡 VORSICHT - ULTRASCHALL AKTIV 🟡",
-    "🟢 SAFE - LOW INTENSITY 🟢": "🟢 SICHER - NIEDRIGE INTENSITÄT 🟢"
+    "🟢 SAFE - LOW INTENSITY 🟢": "🟢 SICHER - NIEDRIGE INTENSITÄT 🟢",
+    "Carrier Mode:": "Trägermodus:"
 }

--- a/src/assets/lang/en.json
+++ b/src/assets/lang/en.json
@@ -996,5 +996,6 @@
     "Ultrasound AM Modulator": "Ultrasound AM Modulator",
     "🔴 DANGEROUS - HIGH INTENSITY 🔴": "🔴 DANGEROUS - HIGH INTENSITY 🔴",
     "🟡 CAUTION - ULTRASOUND ACTIVE 🟡": "🟡 CAUTION - ULTRASOUND ACTIVE 🟡",
-    "🟢 SAFE - LOW INTENSITY 🟢": "🟢 SAFE - LOW INTENSITY 🟢"
+    "🟢 SAFE - LOW INTENSITY 🟢": "🟢 SAFE - LOW INTENSITY 🟢",
+    "Carrier Mode:": "Carrier Mode:"
 }

--- a/src/assets/lang/es.json
+++ b/src/assets/lang/es.json
@@ -997,5 +997,6 @@
     "Ultrasound AM Modulator": "Modulador AM de ultrasonido",
     "🔴 DANGEROUS - HIGH INTENSITY 🔴": "🔴 PELIGRO - ALTA INTENSIDAD 🔴",
     "🟡 CAUTION - ULTRASOUND ACTIVE 🟡": "🟡 PRECAUCIÓN - ULTRASONIDO ACTIVO 🟡",
-    "🟢 SAFE - LOW INTENSITY 🟢": "🟢 SEGURO - BAJA INTENSIDAD 🟢"
+    "🟢 SAFE - LOW INTENSITY 🟢": "🟢 SEGURO - BAJA INTENSIDAD 🟢",
+    "Carrier Mode:": "Modo portadora:"
 }

--- a/src/assets/lang/fr.json
+++ b/src/assets/lang/fr.json
@@ -997,5 +997,6 @@
     "Ultrasound AM Modulator": "Modulateur AM à ultrasons",
     "🔴 DANGEROUS - HIGH INTENSITY 🔴": "🔴 DANGEREUX - HAUTE INTENSITÉ 🔴",
     "🟡 CAUTION - ULTRASOUND ACTIVE 🟡": "🟡 ATTENTION - ULTRASONS ACTIFS 🟡",
-    "🟢 SAFE - LOW INTENSITY 🟢": "🟢 SÉCURISÉ - FAIBLE INTENSITÉ 🟢"
+    "🟢 SAFE - LOW INTENSITY 🟢": "🟢 SÉCURISÉ - FAIBLE INTENSITÉ 🟢",
+    "Carrier Mode:": "Mode porteuse :"
 }

--- a/src/assets/lang/ja.json
+++ b/src/assets/lang/ja.json
@@ -996,5 +996,6 @@
     "Ultrasound AM Modulator": "超音波AM変調器",
     "🔴 DANGEROUS - HIGH INTENSITY 🔴": "🔴 危険 - 高強度 🔴",
     "🟡 CAUTION - ULTRASOUND ACTIVE 🟡": "🟡 注意 - 超音波放射中 🟡",
-    "🟢 SAFE - LOW INTENSITY 🟢": "🟢 安全 - 低強度 🟢"
+    "🟢 SAFE - LOW INTENSITY 🟢": "🟢 安全 - 低強度 🟢",
+    "Carrier Mode:": "キャリアモード:"
 }

--- a/src/assets/lang/ko.json
+++ b/src/assets/lang/ko.json
@@ -997,5 +997,6 @@
     "Ultrasound AM Modulator": "초음파 AM 변조기",
     "🔴 DANGEROUS - HIGH INTENSITY 🔴": "🔴 위험 - 고강도 🔴",
     "🟡 CAUTION - ULTRASOUND ACTIVE 🟡": "🟡 주의 - 초음파 활성 🟡",
-    "🟢 SAFE - LOW INTENSITY 🟢": "🟢 안전 - 저강도 🟢"
+    "🟢 SAFE - LOW INTENSITY 🟢": "🟢 안전 - 저강도 🟢",
+    "Carrier Mode:": "캐리어 모드:"
 }

--- a/src/assets/lang/pt.json
+++ b/src/assets/lang/pt.json
@@ -997,5 +997,6 @@
     "Ultrasound AM Modulator": "Modulador AM de Ultrassom",
     "🔴 DANGEROUS - HIGH INTENSITY 🔴": "🔴 PERIGOSO - ALTA INTENSIDADE 🔴",
     "🟡 CAUTION - ULTRASOUND ACTIVE 🟡": "🟡 CUIDADO - ULTRASSOM ATIVO 🟡",
-    "🟢 SAFE - LOW INTENSITY 🟢": "🟢 SEGURO - BAIXA INTENSIDADE 🟢"
+    "🟢 SAFE - LOW INTENSITY 🟢": "🟢 SEGURO - BAIXA INTENSIDADE 🟢",
+    "Carrier Mode:": "Modo portadora:"
 }

--- a/src/assets/lang/ru.json
+++ b/src/assets/lang/ru.json
@@ -997,5 +997,6 @@
     "Ultrasound AM Modulator": "Ультразвуковой AM-модулятор",
     "🔴 DANGEROUS - HIGH INTENSITY 🔴": "🔴 ОПАСНО - ВЫСОКАЯ ИНТЕНСИВНОСТЬ 🔴",
     "🟡 CAUTION - ULTRASOUND ACTIVE 🟡": "🟡 ОСТОРОЖНО - УЛЬТРАЗВУК АКТИВЕН 🟡",
-    "🟢 SAFE - LOW INTENSITY 🟢": "🟢 БЕЗОПАСНО - НИЗКАЯ ИНТЕНСИВНОСТЬ 🟢"
+    "🟢 SAFE - LOW INTENSITY 🟢": "🟢 БЕЗОПАСНО - НИЗКАЯ ИНТЕНСИВНОСТЬ 🟢",
+    "Carrier Mode:": "Режим несущей:"
 }

--- a/src/assets/lang/zh.json
+++ b/src/assets/lang/zh.json
@@ -997,5 +997,6 @@
     "Ultrasound AM Modulator": "超音波 AM 调制器",
     "🔴 DANGEROUS - HIGH INTENSITY 🔴": "🔴 危险 - 高强度 🔴",
     "🟡 CAUTION - ULTRASOUND ACTIVE 🟡": "🟡 注意 - 超音波活跃 🟡",
-    "🟢 SAFE - LOW INTENSITY 🟢": "🟢 安全 - 低强度 🟢"
+    "🟢 SAFE - LOW INTENSITY 🟢": "🟢 安全 - 低强度 🟢",
+    "Carrier Mode:": "载波模式："
 }


### PR DESCRIPTION
This PR addresses the issue of missing translation keys identified by `scripts/check_trn_keys.py`. 

Changes:
1.  Updated `scripts/update_translations.py` to target the missing key "Carrier Mode:".
2.  Executed the script to add the key to `en.json` and propagate it to other language files (`de.json`, `es.json`, `fr.json`, `ja.json`, `ko.json`, `pt.json`, `ru.json`, `zh.json`).
3.  Manually updated all language files with the correct translation for "Carrier Mode:" in their respective languages.
4.  Verified the fix by running `scripts/check_trn_keys.py` which now passes all checks.

---
*PR created automatically by Jules for task [6009016559410968325](https://jules.google.com/task/6009016559410968325) started by @youtube-at-vach*