### PR TITLE
Fix: Remove blocking print statements from audio callbacks

### DIFF
--- a/src/gui/widgets/distortion_analyzer.py
+++ b/src/gui/widgets/distortion_analyzer.py
@@ -253,9 +253,6 @@ class DistortionAnalyzer(MeasurementModule):
 
         def callback(indata, outdata, frames, time, status):
             nonlocal phase
-            if status:
-                print(status)
-
             # Generate Signal
             outdata.fill(0)
             if self.output_enabled:

--- a/src/gui/widgets/lufs_meter.py
+++ b/src/gui/widgets/lufs_meter.py
@@ -266,9 +266,6 @@ class LufsMeter(MeasurementModule):
             return pos, filled, sum_p
 
         def callback(indata, outdata, frames, time, status):
-            if status:
-                print(status)
-
             # --- Stereo RMS & Peak Calculation ---
             # indata is (frames, channels)
             num_channels = indata.shape[1]

--- a/src/gui/widgets/network_analyzer.py
+++ b/src/gui/widgets/network_analyzer.py
@@ -59,9 +59,6 @@ class PlayRecSession:
         return self.completion_event.wait(timeout)
 
     def _callback(self, indata, outdata, frames, time, status):
-        if status:
-            print(f"Stream status: {status}")
-
         with self.lock:
             if self.is_complete:
                 outdata.fill(0)


### PR DESCRIPTION
This PR removes `print` statements that were inadvertently left in the real-time audio callback functions of `LufsMeter`, `NetworkAnalyzer`, and `DistortionAnalyzer`.
Printing to stdout is a blocking I/O operation and is known to cause performance issues (audio dropouts) in high-priority audio threads.
The `AudioEngine` already handles status flag accumulation, so these prints were redundant and harmful.

**Changes:**
- `src/gui/widgets/lufs_meter.py`: Removed `print(status)` in `callback`.
- `src/gui/widgets/network_analyzer.py`: Removed `print(f"Stream status: {status}")` in `_callback`.
- `src/gui/widgets/distortion_analyzer.py`: Removed `print(status)` in `callback`.

**Verification:**
- Verified with a reproduction test (locally created) that the prints are gone.
- Existing tests run (environment limitations noted, but changes are safe).

---
*PR created automatically by Jules for task [12969499856861519009](https://jules.google.com/task/12969499856861519009) started by @youtube-at-vach*