### PR TITLE
⚡ Optimize frequency bin search in analyze_harmonics

### DIFF
--- a/src/core/analysis.py
+++ b/src/core/analysis.py
@@ -265,14 +265,20 @@ class AudioCalc:
         harmonic_amplitudes_linear = []
 
         # Up to 10th harmonic
+        if len(freqs) > 1:
+            bin_width = freqs[1]
+        else:
+            bin_width = sampling_rate / len(audio_data)
+        freqs_len = len(freqs)
+
         for i in range(2, 11):
             harmonic_freq = max_freq * i
             if harmonic_freq >= sampling_rate / 2:
                 break
 
             # Search near harmonic
-            h_idx_min = np.searchsorted(freqs, harmonic_freq - search_window)
-            h_idx_max = np.searchsorted(freqs, harmonic_freq + search_window)
+            h_idx_min = max(0, min(freqs_len, int(math.ceil((harmonic_freq - search_window) / bin_width))))
+            h_idx_max = max(0, min(freqs_len, int(math.ceil((harmonic_freq + search_window) / bin_width))))
 
             if h_idx_max < len(amplitude_spectrum) and h_idx_max > h_idx_min:
                 subset = amplitude_spectrum[h_idx_min:h_idx_max]


### PR DESCRIPTION
Optimized `analyze_harmonics` in `src/core/analysis.py` by replacing `np.searchsorted` with direct arithmetic index calculation.
This leverages the linear spacing of FFT frequency bins to achieve O(1) lookup complexity instead of O(log N).

Key changes:
- Calculated `bin_width` once (using `freqs[1]` or `sampling_rate / N`).
- Replaced `np.searchsorted` with `int(math.ceil(val / bin_width))` logic.
- Added clamping to ensure indices remain within valid bounds.

Verified with:
- `tests/test_freq_search_opt.py` (temporary test) to confirm logic equivalence.
- Existing tests `tests/test_analysis_a_weighting_cache.py` and `tests/test_thd_calculation.py`.
- Microbenchmarks showing significant speedup for the search operation.

---
*PR created automatically by Jules for task [14708370236871405645](https://jules.google.com/task/14708370236871405645) started by @youtube-at-vach*