### PR TITLE
⚡ Optimize AudioCalc.optimize_frequency with cached time array

### DIFF
--- a/src/core/analysis.py
+++ b/src/core/analysis.py
@@ -30,6 +30,16 @@ def _compute_a_weighting_curve(n_bins, step):
     f = np.arange(n_bins) * step
     return _calculate_ra_raw(f)
 
+@functools.lru_cache(maxsize=32)
+def _get_time_array(N, sampling_rate):
+    """
+    Cached time array generation.
+    Returns read-only array to prevent modification.
+    """
+    t = np.arange(N) / sampling_rate
+    t.flags.writeable = False
+    return t
+
 class AudioCalc:
     """
     Shared audio calculation utilities.
@@ -97,7 +107,7 @@ class AudioCalc:
         Optimizes frequency estimate using Sine Fitting (minimizing residual RMS).
         """
         N = len(signal)
-        t = np.arange(N) / sampling_rate
+        t = _get_time_array(N, sampling_rate)
 
         # Pre-allocate arrays to avoid repeated allocation in loop
         M = np.empty((N, 3), dtype=t.dtype)


### PR DESCRIPTION
This PR optimizes `AudioCalc.optimize_frequency` in `src/core/analysis.py` by caching the time array `t` using `functools.lru_cache`.

### Changes
- Added `_get_time_array(N, sampling_rate)` which returns a cached, read-only numpy array.
- Updated `optimize_frequency` to use `_get_time_array`.

### Rationale
Previously, `t = np.arange(N) / sampling_rate` was executed on every call, allocating a new float array. Since `N` and `sampling_rate` are typically constant during an analysis session (or limited to a few standard combinations), caching this array avoids repeated allocations and arithmetic operations.

### Verification
- **Benchmark**: A micro-benchmark showed an improvement from ~38.1ms to ~36.1ms per call (approx 5% speedup) and avoided ~38MB of allocation over 100 calls (for 1s @ 48kHz).
- **Correctness**: Existing tests in `tests/test_thd_calculation.py` and `tests/test_analysis_correctness.py` passed successfully.


---
*PR created automatically by Jules for task [11977334610763288496](https://jules.google.com/task/11977334610763288496) started by @youtube-at-vach*