### PR TITLE
docs: Add Persistence Settings to English Oscilloscope manual

### DIFF
--- a/docs/widgets/oscilloscope.en.md
+++ b/docs/widgets/oscilloscope.en.md
@@ -33,6 +33,14 @@ A function to stop (stabilize) the waveform for easier observation.
     * **Single**: Captures the waveform only once when the trigger conditions are met and then automatically stops (useful for observing one-time signals).
 * **Level**: Sets the voltage level at which the trigger occurs.
 
+## Persistence Settings
+
+A feature to display an "afterimage" similar to an analog oscilloscope. It is useful for visually capturing noise distribution and waveform fluctuations (jitter).
+
+* **Enable Persistence**: Enables the persistence display.
+* **Decay**: Adjusts the time until the afterimage disappears (decay rate). Moving it to the right makes it last longer.
+* **Intensity**: Adjusts the brightness and density of the afterimage.
+
 ## Tools and Measurements
 
 ### Measurements


### PR DESCRIPTION
Added the "Persistence Settings" section to `docs/widgets/oscilloscope.en.md` to reflect features added in v0.3.8 (Enable Persistence, Decay, Intensity). This brings the English documentation in parity with the Japanese documentation (`docs/widgets/oscilloscope.md`) and the codebase.

---
*PR created automatically by Jules for task [6093940324633114373](https://jules.google.com/task/6093940324633114373) started by @youtube-at-vach*