### PR TITLE
Clean up translation helper script after verifying all keys are present

### DIFF
--- a/scripts/update_translations.py
+++ b/scripts/update_translations.py
@@ -12,9 +12,7 @@ PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 LANG_DIR = os.path.join(PROJECT_ROOT, "src", "assets", "lang")
 
 # Missing keys in en.json (from check_trn_keys.py output)
-MISSING_EN_KEYS = [
-    "Sweep failed:\n{0}"
-]
+MISSING_EN_KEYS = []
 
 # Missing keys in other language files (de, es, fr, ja, ko, pt, ru, zh)
 MISSING_OTHER_KEYS = MISSING_EN_KEYS


### PR DESCRIPTION
Ran `scripts/check_trn_keys.py` and confirmed it reports "TEST PASSED" on the current codebase.
Verified the script's detection logic by temporarily introducing a missing key, which was correctly flagged.
Cleared the stale entry "Sweep failed:\n{0}" from `MISSING_EN_KEYS` in `scripts/update_translations.py` as this key is already present in all language files.
This ensures the helper script is clean and ready for future use.

---
*PR created automatically by Jules for task [10122534777761358704](https://jules.google.com/task/10122534777761358704) started by @youtube-at-vach*