### PR TITLE
Support parsing device ID from args in LoopbackFinder

### DIFF
--- a/src/gui/widgets/loopback_finder.py
+++ b/src/gui/widgets/loopback_finder.py
@@ -128,11 +128,15 @@ class LoopbackFinder(MeasurementModule):
         # But run(args) implies we might not have audio_engine initialized fully or we use it.
         # Let's assume audio_engine is available.
 
-        # TODO: Parse device ID from args if provided
-        device_id = self.audio_engine.output_device  # Use current
+        # Parse device ID from args if provided
+        device_id = getattr(args, "device_id", None)
+        if device_id is None:
+            device_id = self.audio_engine.output_device  # Use current
         sample_rate = self.audio_engine.sample_rate
 
-        results = self.perform_scan(device_id, sample_rate, progress_callback=lambda p, m: print(f"{p}%: {m}"))
+        results = self.perform_scan(
+            device_id, sample_rate, progress_callback=lambda p, m: print(f"{p}%: {m}")
+        )
 
         print("Found Paths:")
         for p in results:

--- a/tests/test_loopback_finder_cli.py
+++ b/tests/test_loopback_finder_cli.py
@@ -1,0 +1,46 @@
+import unittest
+from unittest.mock import MagicMock, patch
+from argparse import Namespace
+from src.gui.widgets.loopback_finder import LoopbackFinder
+
+class TestLoopbackFinderCLI(unittest.TestCase):
+    def setUp(self):
+        self.mock_audio_engine = MagicMock()
+        self.mock_audio_engine.output_device = 1
+        self.mock_audio_engine.sample_rate = 48000
+        self.finder = LoopbackFinder(self.mock_audio_engine)
+
+    def test_run_with_device_id_arg(self):
+        args = Namespace(device_id=2)
+
+        with patch.object(self.finder, 'perform_scan', return_value=[]) as mock_scan:
+            self.finder.run(args)
+
+            mock_scan.assert_called_once()
+            call_args = mock_scan.call_args
+            self.assertEqual(call_args[0][0], 2)  # device_id
+            self.assertEqual(call_args[0][1], 48000) # sample_rate
+
+    def test_run_without_device_id_arg(self):
+        args = Namespace()
+
+        with patch.object(self.finder, 'perform_scan', return_value=[]) as mock_scan:
+            self.finder.run(args)
+
+            mock_scan.assert_called_once()
+            call_args = mock_scan.call_args
+            self.assertEqual(call_args[0][0], 1)  # default from engine
+            self.assertEqual(call_args[0][1], 48000)
+
+    def test_run_with_none_device_id(self):
+        args = Namespace(device_id=None)
+
+        with patch.object(self.finder, 'perform_scan', return_value=[]) as mock_scan:
+            self.finder.run(args)
+
+            mock_scan.assert_called_once()
+            call_args = mock_scan.call_args
+            self.assertEqual(call_args[0][0], 1)  # default from engine
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Implemented parsing of `device_id` from the `args` parameter in the `LoopbackFinder.run` method. This allows the CLI or other entry points to specify a target device for the loopback scan. If the argument is missing or None, it correctly falls back to the audio engine's current output device. Comprehensive unit tests covering provided, missing, and None arguments were added in `tests/test_loopback_finder_cli.py`.

---
*PR created automatically by Jules for task [3521317798137180128](https://jules.google.com/task/3521317798137180128) started by @youtube-at-vach*