### PR TITLE
Refactor widgets to use shared utilities and remove dead code

### DIFF
--- a/src/core/analysis.py
+++ b/src/core/analysis.py
@@ -98,17 +98,6 @@ class AudioCalc:
         return sosfiltfilt(sos, signal)
 
     @staticmethod
-    def notch_filter(signal, sampling_rate, target_frequency, quality_factor=30):
-        nyquist = 0.5 * sampling_rate
-        w0 = target_frequency / nyquist
-        bandwidth = w0 / quality_factor
-
-        # Wn must be a tuple to be hashable for lru_cache
-        Wn = (w0 - bandwidth / 2, w0 + bandwidth / 2)
-        sos = _get_butter_sos(2, Wn, "bandstop")
-        return sosfiltfilt(sos, signal)
-
-    @staticmethod
     def optimize_frequency(signal, sampling_rate, freq_guess, return_full=False):
         """
         Optimizes frequency estimate using Sine Fitting (minimizing residual RMS).

--- a/src/gui/widgets/lockin_thd_analyzer.py
+++ b/src/gui/widgets/lockin_thd_analyzer.py
@@ -22,6 +22,7 @@ from scipy.signal import butter, sosfiltfilt
 from src.core.audio_engine import AudioEngine
 from src.core.fft_manager import fft_manager
 from src.core.localization import tr
+from src.core.utils import format_si
 from src.measurement_modules.base import MeasurementModule
 
 
@@ -429,16 +430,6 @@ class LockInTHDWidget(QWidget):
         # Initialize amplitude display to current module state
         self.on_amp_unit_changed(self.amp_unit_combo.currentText())
 
-    def _format_si(self, value, unit):
-        if value == 0:
-            return f"0 {unit}"
-        exponent = int(np.floor(np.log10(abs(value)) / 3) * 3)
-        exponent = max(min(exponent, 9), -12)
-        prefixes = {-12: "p", -9: "n", -6: "u", -3: "m", 0: "", 3: "k", 6: "M", 9: "G"}
-        scaled = value / (10**exponent)
-        prefix = prefixes.get(exponent, "")
-        return f"{scaled:.3g} {prefix}{unit}"
-
     def on_toggle(self, checked):
         if checked:
             self.module.start_analysis()
@@ -543,8 +534,8 @@ class LockInTHDWidget(QWidget):
             fund_rms_v = fund_rms_fs * sensitivity
             res_rms_v = res_rms_fs * sensitivity
 
-            fund_str = f"{fund_dbv:.2f} dBV ( {self._format_si(fund_rms_v, 'V')} rms )"
-            res_str = f"{res_dbv:.2f} dBV ( {self._format_si(res_rms_v, 'V')} rms )"
+            fund_str = f"{fund_dbv:.2f} dBV ( {format_si(fund_rms_v, 'V', sig_figs=3)} rms )"
+            res_str = f"{res_dbv:.2f} dBV ( {format_si(res_rms_v, 'V', sig_figs=3)} rms )"
 
         else:  # dBFS
             fund_dbfs = 20 * np.log10(fund_peak_fs + 1e-12)

--- a/src/gui/widgets/sound_quality_analyzer.py
+++ b/src/gui/widgets/sound_quality_analyzer.py
@@ -19,6 +19,7 @@ from PyQt6.QtWidgets import (
     QWidget,
 )
 
+from src.core.analysis import AudioCalc
 from src.core.audio_engine import AudioEngine
 from src.core.localization import tr
 from src.measurement_modules.base import MeasurementModule
@@ -49,7 +50,7 @@ class AnalysisWorker(QThread):
             # This ensures playback speed is correct for the Audio Engine
             if samplerate != self.target_sr:
                 self.progress_update.emit(5, tr("Resampling to {}Hz (Playback)...").format(self.target_sr))
-                data_playback = self._resample(data, samplerate, self.target_sr)
+                data_playback = AudioCalc.resample(data, samplerate, self.target_sr)
             else:
                 data_playback = data
 
@@ -61,7 +62,7 @@ class AnalysisWorker(QThread):
                 data_analysis = data_playback
             else:
                 self.progress_update.emit(10, tr("Resampling to {}Hz (Analysis)...").format(analysis_sr))
-                data_analysis = self._resample(data_playback, self.target_sr, analysis_sr)
+                data_analysis = AudioCalc.resample(data_playback, self.target_sr, analysis_sr)
 
             if self._is_cancelled:
                 return
@@ -137,32 +138,6 @@ class AnalysisWorker(QThread):
 
             traceback.print_exc()
             self.error_occurred.emit(str(e))
-
-    def _resample(self, data, src_sr, target_sr):
-        """
-        High-quality resampling using polyphase filtering (scipy.signal.resample_poly).
-        """
-        if src_sr == target_sr:
-            return data
-
-        # Calculate greatest common divisor to find rational approximate
-        # But resample_poly takes up/down.
-        # e.g. 44100 -> 48000 : up=160, down=147
-        # e.g. 48000 -> 44100 : up=147, down=160
-        import math
-
-        g = math.gcd(target_sr, src_sr)
-        up = target_sr // g
-        down = src_sr // g
-
-        # If factors are too large, fallback to FFT resampling or similar?
-        # resample_poly is efficient but large factors can be slow.
-        # Limit window size if needed, but usually fine for standard rates.
-
-        if data.ndim == 1:
-            return signal.resample_poly(data, up, down)
-        else:
-            return signal.resample_poly(data, up, down, axis=0)
 
     def _calc_loudness(self, audio, sr):
         # Time-series (Momentary)

--- a/src/gui/widgets/spectrum_analyzer.py
+++ b/src/gui/widgets/spectrum_analyzer.py
@@ -20,6 +20,7 @@ from scipy.signal.windows import dpss
 from src.core.audio_engine import AudioEngine
 from src.core.fft_manager import fft_manager
 from src.core.localization import tr
+from src.core.utils import format_si
 from src.measurement_modules.base import MeasurementModule
 
 
@@ -411,20 +412,6 @@ class SpectrumAnalyzerWidget(QWidget):
         layout.addWidget(self.plot_widget)
         self.setLayout(layout)
 
-    def format_si(self, value, unit):
-        if value == 0:
-            return f"0.0 {unit}"
-
-        exponent = int(np.floor(np.log10(abs(value)) / 3) * 3)
-        exponent = max(min(exponent, 9), -15)
-
-        scaled_value = value / (10**exponent)
-
-        prefixes = {-15: "f", -12: "p", -9: "n", -6: "µ", -3: "m", 0: "", 3: "k", 6: "M", 9: "G"}
-
-        prefix = prefixes.get(exponent, "")
-        return f"{scaled_value:.3g} {prefix}{unit}"
-
     def mouse_moved(self, evt):
         pos = evt[0]
         if self.plot_widget.sceneBoundingRect().contains(pos):
@@ -459,10 +446,10 @@ class SpectrumAnalyzerWidget(QWidget):
             if self.module.display_unit == "dB SPL":
                 # For SPL, y is dB SPL. Linear is 10^(y/20) * 20uPa.
                 val_pa = (10 ** (y / 20)) * 20e-6
-                linear_str = self.format_si(val_pa, "Pa")
+                linear_str = format_si(val_pa, "Pa", sig_figs=3)
                 cursor_text = f"Cursor: {freq:.1f} Hz, {y:.1f} {unit_db} ({linear_str})"
             elif self.module.display_unit == "dBV":
-                linear_str = self.format_si(linear_val, unit_linear)
+                linear_str = format_si(linear_val, unit_linear, sig_figs=3)
                 cursor_text = f"Cursor: {freq:.1f} Hz, {y:.1f} {unit_db} ({linear_str})"
             else:  # dBFS
                 cursor_text = f"Cursor: {freq:.1f} Hz, {y:.1f} {unit_db} ({linear_val:.4g})"


### PR DESCRIPTION
- Refactored `SpectrumAnalyzer` and `LockInTHDAnalyzer` to use `src.core.utils.format_si`.
- Refactored `SoundQualityAnalyzer` to use `src.core.analysis.AudioCalc.resample`.
- Removed unused `AudioCalc.notch_filter` method.
- Verified with tests.

---
*PR created automatically by Jules for task [15432483062103483659](https://jules.google.com/task/15432483062103483659) started by @youtube-at-vach*