### PR TITLE
Docs: Add missing A/B math mode to Oscilloscope manual

### DIFF
--- a/docs/widgets/oscilloscope.en.md
+++ b/docs/widgets/oscilloscope.en.md
@@ -67,6 +67,7 @@ Displays the results of calculations performed on two channels or signals as a "
 * **A + B**: Left + Right.
 * **A - B**: Left - Right.
 * **A * B**: Left × Right (product).
+* **A / B**: Left / Right (quotient).
 * **Derivative**: Differentiated waveform of the Left channel.
 * **Integral**: Integrated waveform of the Left channel.
 

--- a/docs/widgets/oscilloscope.md
+++ b/docs/widgets/oscilloscope.md
@@ -67,6 +67,7 @@ Oscilloscope（オシロスコープ）は、入力信号の波形をリアル�
 * **A + B**: Left + Right。
 * **A - B**: Left - Right。
 * **A * B**: Left × Right（積）。
+* **A / B**: Left / Right（商）。
 * **Derivative**: Leftチャンネルの微分波形。
 * **Integral**: Leftチャンネルの積分波形。
 


### PR DESCRIPTION
Updated the Oscilloscope documentation to include the "A / B" math mode, which allows for division of the left channel by the right channel. This feature was present in the code but undocumented. Updates were applied to both English and Japanese manuals.

---
*PR created automatically by Jules for task [3117041442850234672](https://jules.google.com/task/3117041442850234672) started by @youtube-at-vach*