### PR TITLE
Optimize SoundLevelMeter GUI update rate

### DIFF
--- a/src/gui/widgets/sound_level_meter.py
+++ b/src/gui/widgets/sound_level_meter.py
@@ -553,6 +553,7 @@ class SoundLevelMeterWidget(QWidget):
         self.module = module
         self.init_ui()
 
+        self.last_ln_update_time = 0.0
         self.timer = QTimer()
         self.timer.timeout.connect(self.update_display)
         self.timer.start(50)  # 20Hz refresh
@@ -843,22 +844,23 @@ class SoundLevelMeterWidget(QWidget):
 
         if (is_hist_tab or is_stats_tab) and self.module.ln_history:
             # We can optimize by not calculating every GUI frame (50ms), maybe every 250ms?
-            # But let's try direct first.
+            if time.monotonic() - self.last_ln_update_time >= 0.25:
+                self.last_ln_update_time = time.monotonic()
 
-            # For Stats tab
-            if is_stats_tab:
-                ln_stats = self.module.calculate_ln_statistics()
-                for key, lbl in self.ln_labels.items():
-                    val = ln_stats.get(key, -np.inf)
-                    lbl.setText(fmt(val) + " dB")
+                # For Stats tab
+                if is_stats_tab:
+                    ln_stats = self.module.calculate_ln_statistics()
+                    for key, lbl in self.ln_labels.items():
+                        val = ln_stats.get(key, -np.inf)
+                        lbl.setText(fmt(val) + " dB")
 
-            # For Histogram tab
-            if is_hist_tab:
-                centers, probs = self.module.get_ln_histogram(bin_size=0.5)
-                if len(centers) > 0:
-                    # Update bar graph
-                    # BarGraphItem needs x, height, width
-                    self.hist_item.setOpts(x=centers, height=probs, width=0.4)
+                # For Histogram tab
+                if is_hist_tab:
+                    centers, probs = self.module.get_ln_histogram(bin_size=0.5)
+                    if len(centers) > 0:
+                        # Update bar graph
+                        # BarGraphItem needs x, height, width
+                        self.hist_item.setOpts(x=centers, height=probs, width=0.4)
 
-                    # Auto range y?
-                    # self.plot_widget.setYRange(0, np.max(probs)*1.1)
+                        # Auto range y?
+                        # self.plot_widget.setYRange(0, np.max(probs)*1.1)


### PR DESCRIPTION
Implemented throttling for LN statistics and histogram updates in `SoundLevelMeterWidget`.
The updates now happen at most every 250ms, regardless of the GUI refresh rate (which defaults to 50ms).
This reduces the computational overhead when viewing the Statistics or Histogram tabs.
Used `time.monotonic()` for timing measurements as per code review feedback.
Verified functionality using a reproduction script (showing call count reduction from ~11 to ~3 calls per 0.5s) and ensured no regressions with `pytest tests/test_sound_level_meter_logic.py`.

---
*PR created automatically by Jules for task [7685729468774712064](https://jules.google.com/task/7685729468774712064) started by @youtube-at-vach*