### PR TITLE
Add precomputed Hilbert filter coefficients fallback

### DIFF
--- a/src/gui/widgets/ultrasound_modulator.py
+++ b/src/gui/widgets/ultrasound_modulator.py
@@ -27,6 +27,24 @@ from src.core.localization import tr
 from src.measurement_modules.base import MeasurementModule
 
 
+# Precomputed Hilbert coefficients for fallback (approx 48kHz, width=800, 65 taps)
+_FALLBACK_HILBERT_COEFFS = [
+    -0.0000316474, 0.0105268582, 0.0000140129, 0.0064320416, -0.0000026942,
+    0.0083717445, -0.0000005448, 0.0107013535, 0.0000004666, 0.0134939067,
+    -0.0000005078, 0.0168371142, -0.0000028906, 0.0208555232, -0.0000030355,
+    0.0257464826, -0.0000002995, 0.0318132853, 0.0000007285, 0.0395192771,
+    -0.0000018136, 0.0496883805, 0.0000014406, 0.063920532, -0.0000002686,
+    0.0855646504, 0.0000006833, 0.1234425048, -0.0000003739, 0.2098599827,
+    -0.000001463, 0.6358343337, 0.0, -0.6358343337, 0.000001463,
+    -0.2098599827, 0.0000003739, -0.1234425048, -0.0000006833, -0.0855646504,
+    0.0000002686, -0.063920532, -0.0000014406, -0.0496883805, 0.0000018136,
+    -0.0395192771, -0.0000007285, -0.0318132853, 0.0000002995, -0.0257464826,
+    0.0000030355, -0.0208555232, 0.0000028906, -0.0168371142, 0.0000005078,
+    -0.0134939067, -0.0000004666, -0.0107013535, 0.0000005448, -0.0083717445,
+    0.0000026942, -0.0064320416, -0.0000140129, -0.0105268582, 0.0000316474
+]
+
+
 class UltrasoundModulator(MeasurementModule):
     def __init__(self, audio_engine: AudioEngine):
         self.audio_engine = audio_engine
@@ -103,9 +121,8 @@ class UltrasoundModulator(MeasurementModule):
                     self._hilbert_coeffs = scipy.signal.remez(numtaps, bands, [1], type="hilbert", fs=fs)
                 except Exception as e:
                     print(f"Error designing Hilbert filter: {e}. Fallback to basic.")
-                    # Fallback or strict error. For now, try to proceed or use zeros.
-                    # Ideally we might want a precomputed set or a simpler design if remez fails.
-                    self._hilbert_coeffs = np.zeros(numtaps)
+                    # Fallback to precomputed coefficients
+                    self._hilbert_coeffs = np.array(_FALLBACK_HILBERT_COEFFS)
 
                 # Reset ZI when filter changes
                 self._hilbert_zi = None

--- a/tests/test_ultrasound_modulator.py
+++ b/tests/test_ultrasound_modulator.py
@@ -1,0 +1,45 @@
+import unittest
+from unittest.mock import MagicMock, patch
+import numpy as np
+
+# Import the module under test
+from src.gui.widgets.ultrasound_modulator import UltrasoundModulator
+
+# We can't easily import the constant from the test if it's not exposed,
+# but we can inspect the module.
+import src.gui.widgets.ultrasound_modulator as um_module
+
+class TestUltrasoundModulator(unittest.TestCase):
+    def setUp(self):
+        self.mock_audio_engine = MagicMock()
+        self.modulator = UltrasoundModulator(self.mock_audio_engine)
+
+    def test_update_filter_remez_success(self):
+        # Test that coefficients are generated when remez succeeds
+        with patch('scipy.signal.remez') as mock_remez:
+            mock_remez.return_value = np.ones(65)
+            self.modulator._update_filter(48000)
+            self.assertTrue(np.array_equal(self.modulator._hilbert_coeffs, np.ones(65)))
+            mock_remez.assert_called()
+
+    def test_update_filter_remez_failure_fallback(self):
+        # Test fallback when remez fails
+        with patch('scipy.signal.remez') as mock_remez:
+            mock_remez.side_effect = ValueError("Convergence failed")
+            self.modulator._update_filter(48000)
+
+            self.assertIsNotNone(self.modulator._hilbert_coeffs)
+            self.assertEqual(len(self.modulator._hilbert_coeffs), 65)
+
+    def test_update_filter_remez_failure_fallback_coeffs(self):
+         with patch('scipy.signal.remez') as mock_remez:
+            mock_remez.side_effect = ValueError("Convergence failed")
+            self.modulator._update_filter(48000)
+
+            # Verify it uses the fallback coefficients
+            fallback = getattr(um_module, '_FALLBACK_HILBERT_COEFFS', None)
+            if fallback is not None:
+                self.assertTrue(np.array_equal(self.modulator._hilbert_coeffs, np.array(fallback)))
+            else:
+                # If we can't access the constant, at least check it's not zeros
+                self.assertFalse(np.all(self.modulator._hilbert_coeffs == 0), "Fallback coefficients should not be all zeros")


### PR DESCRIPTION
Implemented a robust fallback for the Hilbert filter design in `UltrasoundModulator`. When `scipy.signal.remez` fails (e.g., due to convergence issues), the system now gracefully falls back to a precomputed set of coefficients instead of failing or using zeros. This ensures the Single-Sideband (SSB) modulation mode remains functional even in adverse conditions. Added unit tests to verify this behavior.

---
*PR created automatically by Jules for task [14484489219311484064](https://jules.google.com/task/14484489219311484064) started by @youtube-at-vach*