### PR TITLE
Fix translation leaks and logic robustness in widgets

### DIFF
--- a/src/assets/lang/de.json
+++ b/src/assets/lang/de.json
@@ -1040,5 +1040,8 @@
     "Statistics & Averaging": "Statistics & Averaging",
     "Lock NCO to Signal (FLL)": "NCO auf Signal sperren (FLL)",
     "NCO Avg Count:": "NCO-Mittelungszahl:",
-    "NCO Std Dev:": "NCO-Std.-Abw.:"
+    "NCO Std Dev:": "NCO-Std.-Abw.:",
+    "DSB (AM)": "DSB (AM)",
+    "LSB": "LSB",
+    "USB": "USB"
 }

--- a/src/assets/lang/en.json
+++ b/src/assets/lang/en.json
@@ -1029,5 +1029,8 @@
     "Start Level:": "Start Level:",
     "Sweep failed:\n{0}": "Sweep failed:\n{0}",
     "Plot Controls": "Plot Controls",
-    "Y-Axis Zoom:": "Y-Axis Zoom:"
+    "Y-Axis Zoom:": "Y-Axis Zoom:",
+    "DSB (AM)": "DSB (AM)",
+    "LSB": "LSB",
+    "USB": "USB"
 }

--- a/src/assets/lang/es.json
+++ b/src/assets/lang/es.json
@@ -1040,5 +1040,8 @@
     "Statistics & Averaging": "Statistics & Averaging",
     "Lock NCO to Signal (FLL)": "Bloquear NCO a la señal (FLL)",
     "NCO Avg Count:": "Conteo de promedios NCO:",
-    "NCO Std Dev:": "Desv. Est. NCO:"
+    "NCO Std Dev:": "Desv. Est. NCO:",
+    "DSB (AM)": "DSB (AM)",
+    "LSB": "LSB",
+    "USB": "USB"
 }

--- a/src/assets/lang/fr.json
+++ b/src/assets/lang/fr.json
@@ -1040,5 +1040,8 @@
     "Integral (Ki):": "Intégrale (Ki) :",
     "Lock NCO to Signal (FLL)": "Verrouiller NCO sur le signal (FLL)",
     "NCO Avg Count:": "Nombre de moyennes NCO :",
-    "NCO Std Dev:": "Écart-type NCO :"
+    "NCO Std Dev:": "Écart-type NCO :",
+    "DSB (AM)": "DSB (AM)",
+    "LSB": "LSB",
+    "USB": "USB"
 }

--- a/src/assets/lang/ja.json
+++ b/src/assets/lang/ja.json
@@ -1029,5 +1029,8 @@
     "Start Level:": "開始レベル:",
     "Sweep failed:\n{0}": "スイープに失敗しました：\n{0}",
     "Plot Controls": "プロットコントロール",
-    "Y-Axis Zoom:": "Y軸ズーム:"
+    "Y-Axis Zoom:": "Y軸ズーム:",
+    "DSB (AM)": "DSB (AM)",
+    "LSB": "LSB",
+    "USB": "USB"
 }

--- a/src/assets/lang/ko.json
+++ b/src/assets/lang/ko.json
@@ -1040,5 +1040,8 @@
     "PID Control Loop": "PID Control Loop",
     "Plot Smoothing:": "Plot Smoothing:",
     "Proportional (Kp):": "Proportional (Kp):",
-    "Statistics & Averaging": "Statistics & Averaging"
+    "Statistics & Averaging": "Statistics & Averaging",
+    "DSB (AM)": "DSB (AM)",
+    "LSB": "LSB",
+    "USB": "USB"
 }

--- a/src/assets/lang/pt.json
+++ b/src/assets/lang/pt.json
@@ -1040,5 +1040,8 @@
     "Statistics & Averaging": "Statistics & Averaging",
     "Lock NCO to Signal (FLL)": "Bloquear NCO ao Sinal (FLL)",
     "NCO Avg Count:": "Contagem de Médias NCO:",
-    "NCO Std Dev:": "Desvio Padrão NCO:"
+    "NCO Std Dev:": "Desvio Padrão NCO:",
+    "DSB (AM)": "DSB (AM)",
+    "LSB": "LSB",
+    "USB": "USB"
 }

--- a/src/assets/lang/ru.json
+++ b/src/assets/lang/ru.json
@@ -1040,5 +1040,8 @@
     "PID Control Loop": "PID Control Loop",
     "Plot Smoothing:": "Plot Smoothing:",
     "Proportional (Kp):": "Proportional (Kp):",
-    "Statistics & Averaging": "Statistics & Averaging"
+    "Statistics & Averaging": "Statistics & Averaging",
+    "DSB (AM)": "DSB (AM)",
+    "LSB": "LSB",
+    "USB": "USB"
 }

--- a/src/assets/lang/zh.json
+++ b/src/assets/lang/zh.json
@@ -1040,5 +1040,8 @@
     "Integral (Ki):": "积分 (Ki):",
     "Lock NCO to Signal (FLL)": "锁定 NCO 到信号 (FLL)",
     "NCO Avg Count:": "NCO 平均计数:",
-    "NCO Std Dev:": "NCO 标准差:"
+    "NCO Std Dev:": "NCO 标准差:",
+    "DSB (AM)": "DSB (AM)",
+    "LSB": "LSB",
+    "USB": "USB"
 }

--- a/src/gui/widgets/linearity_analyzer.py
+++ b/src/gui/widgets/linearity_analyzer.py
@@ -294,7 +294,7 @@ class LinearityAnalyzerWidget(QWidget):
         self.module = module
 
         self.zoom_options = {
-            "Auto": None,
+            tr("Auto"): None,
             "20.0 dB": 20.0,
             "10.0 dB": 10.0,
             "5.0 dB": 5.0,

--- a/src/gui/widgets/ultrasound_modulator.py
+++ b/src/gui/widgets/ultrasound_modulator.py
@@ -588,13 +588,17 @@ class UltrasoundModulatorWidget(QWidget):
         mode_label = QLabel(tr("Carrier Mode:"))
         mode_layout = QHBoxLayout()
         self.mode_bg = QButtonGroup()
-        for label, val in [("DSB (AM)", "DSB"), ("USB", "USB"), ("LSB", "LSB")]:
+
+        # ID: 0=DSB, 1=USB, 2=LSB
+        modes = [(tr("DSB (AM)"), "DSB"), (tr("USB"), "USB"), (tr("LSB"), "LSB")]
+
+        for i, (label, val) in enumerate(modes):
             rb = QRadioButton(label)
             if val == self.module.modulation_mode:
                 rb.setChecked(True)
-            self.mode_bg.addButton(rb)
+            self.mode_bg.addButton(rb, i)
             mode_layout.addWidget(rb)
-        self.mode_bg.buttonClicked.connect(self.on_mode_rb_clicked)
+        self.mode_bg.idClicked.connect(self.on_mode_rb_id_clicked)
         form_layout.addRow(mode_label, mode_layout)
 
         tab1_layout.addLayout(form_layout)
@@ -613,13 +617,17 @@ class UltrasoundModulatorWidget(QWidget):
         in_grp = QGroupBox(tr("Input Channel"))
         in_layout = QHBoxLayout()
         self.in_bg = QButtonGroup()
-        for label, val in [(tr("L"), "L"), (tr("R"), "R"), (tr("Stereo"), "Stereo")]:
+
+        # ID: 0=L, 1=R, 2=Stereo
+        in_modes = [(tr("L"), "L"), (tr("R"), "R"), (tr("Stereo"), "Stereo")]
+
+        for i, (label, val) in enumerate(in_modes):
             rb = QRadioButton(label)
             if val == self.module.input_mode:
                 rb.setChecked(True)
-            self.in_bg.addButton(rb)
+            self.in_bg.addButton(rb, i)
             in_layout.addWidget(rb)
-        self.in_bg.buttonClicked.connect(self.on_in_mode_changed)
+        self.in_bg.idClicked.connect(self.on_in_mode_id_clicked)
         in_grp.setLayout(in_layout)
         routing_layout.addWidget(in_grp)
 
@@ -627,13 +635,17 @@ class UltrasoundModulatorWidget(QWidget):
         out_grp = QGroupBox(tr("Output Channel"))
         out_layout = QHBoxLayout()
         self.out_bg = QButtonGroup()
-        for label, val in [(tr("L"), "L"), (tr("R"), "R"), (tr("Stereo"), "Stereo")]:
+
+        # ID: 0=L, 1=R, 2=Stereo
+        out_modes = [(tr("L"), "L"), (tr("R"), "R"), (tr("Stereo"), "Stereo")]
+
+        for i, (label, val) in enumerate(out_modes):
             rb = QRadioButton(label)
             if val == self.module.output_mode:
                 rb.setChecked(True)
-            self.out_bg.addButton(rb)
+            self.out_bg.addButton(rb, i)
             out_layout.addWidget(rb)
-        self.out_bg.buttonClicked.connect(self.on_out_mode_changed)
+        self.out_bg.idClicked.connect(self.on_out_mode_id_clicked)
         out_grp.setLayout(out_layout)
         routing_layout.addWidget(out_grp)
 
@@ -671,22 +683,6 @@ class UltrasoundModulatorWidget(QWidget):
         self.setLayout(layout)
 
         # Meters - Add to bottom (outside tabs) but above button?
-        # User requested shorter height. Meters at bottom might be good.
-        # But earlier implementation had meters inside layout.
-        # Let's put meters ABOVE the Start Button.
-
-        # NOTE: In previous code, Meters were added before Start Button.
-        # My replacement block removed them (lines 480-503 in existing file were not included in my specific replacement block, but I am rewriting the file).
-        # Wait, I need to look at lines 480-503 again.
-        # Check Step 222. Lines 480-503 are creating meter_group and adding to layout.
-        # My replacement block REPLACED Controls Group and Switchs. It stopped before Meters?
-        # NO. Step 222 shows Meters starts at 480.
-        # My replacement block target ended at line 515.
-        # Start of replacement was line 350.
-        # So I DELETED Meters in the replacement block logic above?
-        # Yes.
-        # So I need to add Meters back.
-
         meter_group = QGroupBox(tr("Signal Levels"))
         meter_layout = QVBoxLayout()
         in_label = QLabel(tr("Input Level"))
@@ -707,15 +703,19 @@ class UltrasoundModulatorWidget(QWidget):
 
         meter_group.setLayout(meter_layout)
 
-        # Where to put meters? Global at bottom.
-        # Before start button?
-        # layout is VBox.
-        # widgets: Header, Safety, Tabs, Meters, StartBtn.
-
         layout.insertWidget(layout.indexOf(self.start_btn), meter_group)
 
-    def on_in_mode_changed(self, btn):
-        self.module.input_mode = btn.text()
+    def on_in_mode_id_clicked(self, id):
+        modes = {0: "L", 1: "R", 2: "Stereo"}
+        self.module.input_mode = modes.get(id, "L")
+
+    def on_out_mode_id_clicked(self, id):
+        modes = {0: "L", 1: "R", 2: "Stereo"}
+        self.module.output_mode = modes.get(id, "R")
+
+    def on_mode_rb_id_clicked(self, id):
+        modes = {0: "DSB", 1: "USB", 2: "LSB"}
+        self.module.modulation_mode = modes.get(id, "DSB")
 
     def _lin2db(self, val):
         if val <= 0:
@@ -784,9 +784,6 @@ class UltrasoundModulatorWidget(QWidget):
         self.depth_spin.setValue(depth)
         self.depth_spin.blockSignals(False)
 
-    def on_out_mode_changed(self, btn):
-        self.module.output_mode = btn.text()
-
     def on_gain_changed(self, val):  # val is dB
         self.module.output_gain = self._db2lin(val)
         self.gain_slider.blockSignals(True)
@@ -801,22 +798,6 @@ class UltrasoundModulatorWidget(QWidget):
         self.gain_spin.setValue(gain_db)
         self.gain_spin.blockSignals(False)
         self.update_safety_status()
-
-    def on_mode_rb_clicked(self, btn):
-        # Map label to value if needed, but we stored vals in loop?
-        # QButtonGroup buttonClicked sends the button. We need to find which one.
-        # But we didn't store mapping.
-        # Let's infer from text.
-        text = btn.text()
-        if "DSB" in text:
-            mode = "DSB"
-        elif "USB" in text:
-            mode = "USB"
-        elif "LSB" in text:
-            mode = "LSB"
-        else:
-            mode = "DSB"
-        self.module.modulation_mode = mode
 
     def update_safety_status(self):
         if not self.module.is_running:


### PR DESCRIPTION
Wrap missing strings in `tr()` for `UltrasoundModulator` and `LinearityAnalyzer` widgets.
Refactor `UltrasoundModulatorWidget` to use `QButtonGroup` IDs for logic instead of button text, preventing breakage when translations are applied.
Update language files with new keys.
Verify with `scripts/check_trn_keys.py`.

---
*PR created automatically by Jules for task [4067462233921047168](https://jules.google.com/task/4067462233921047168) started by @youtube-at-vach*