### PR TITLE
Add self-test to macOS build workflow

### DIFF
--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -73,6 +73,11 @@ jobs:
           --target-architecture arm64 \
           main_gui.py
 
+    - name: Verify macOS Application (Self-Test)
+      run: |
+        echo "Testing dist/MeasureLab.app/Contents/MacOS/MeasureLab with --self-test..."
+        ./dist/MeasureLab.app/Contents/MacOS/MeasureLab --self-test
+
     - name: Create DMG
       run: |
         # Create DMG using create-dmg


### PR DESCRIPTION
Changes:
- Added a self-test step to `build_macos.yml` to verify the application launch (`--self-test`) before creating the DMG.