### PR TITLE
Clarify and fix Overall SPL weighting in Spectrum Analyzer

### DIFF
--- a/src/gui/widgets/spectrum_analyzer.py
+++ b/src/gui/widgets/spectrum_analyzer.py
@@ -663,32 +663,8 @@ class SpectrumAnalyzerWidget(QWidget):
             # Unroll ring buffer for display/analysis
             data = np.roll(self.module.input_data, -self.module.write_head, axis=0)
 
-        # Calculate Overall RMS (dBFS) - Raw Time Domain (Unweighted)
-        # This is calculated for reference, but we will overwrite it with weighted value later
-        rms = np.sqrt(np.mean(data**2))
-        overall_db = 20 * np.log10(rms + 1e-12)
-
-        if self.module.display_unit == "dBV":
-            # Convert to dBV
-            offset = self.module.audio_engine.calibration.get_input_offset_db()
-            overall_db += offset
-        elif self.module.display_unit == "dB SPL":
-            # Convert to SPL
-            # We need to use the method from calibration that includes offset
-            # But here we have the "Unweighted" raw dBFS.
-            # Ideally "Overall" for SPL should be C-weighted or whatever the user calibrated with?
-            # Usually Sound Level Meters show A-weighted or C-weighted overall.
-            # The user calibrated "dBFS_C" -> "SPL".
-            # If we just add offset to unweighted dBFS, it's "Unweighted SPL" (Linear).
-            # That's probably fine for "Overall" if we qualify it.
-            # Or we should apply C-weighting to overall?
-            # Let's stick to adding offset for now.
-
-            spl_offset = self.module.audio_engine.calibration.get_spl_offset_db()
-            if spl_offset is not None:
-                overall_db += spl_offset
-        else:
-            pass
+        # Overall RMS is calculated later from the power spectrum (see overall_weighted_db)
+        # to correctly apply weighting (A/C/Z) and calibration.
 
         # Frequency axis
         sample_rate = self.module.audio_engine.sample_rate

--- a/tests/logic_verification/test_spectrum_spl_weighting.py
+++ b/tests/logic_verification/test_spectrum_spl_weighting.py
@@ -1,0 +1,147 @@
+import sys
+import os
+import numpy as np
+from unittest.mock import MagicMock
+import pytest
+import re
+
+# Ensure sounddevice is mocked
+if 'sounddevice' not in sys.modules:
+    sys.modules['sounddevice'] = MagicMock()
+
+# Add src to path
+sys.path.append(os.path.join(os.path.dirname(__file__), '../../'))
+
+from src.gui.widgets.spectrum_analyzer import SpectrumAnalyzer, SpectrumAnalyzerWidget
+from PyQt6.QtWidgets import QApplication
+
+# Initialize QApplication if not exists
+app = QApplication.instance()
+if app is None:
+    app = QApplication([])
+
+def extract_overall_db(widget):
+    text = widget.overall_label.text()
+    match = re.search(r"Overall:\s*([\d\.-]+)\s*", text)
+    if match:
+        return float(match.group(1))
+    return None
+
+def test_spectrum_weighting_at_100hz(qtbot):
+    """
+    Verify that Overall Weighted RMS applies A and C weighting correctly at 100Hz.
+    100Hz is a good test frequency because A-weighting has significant attenuation (~-19.1dB)
+    while C-weighting is nearly flat (~-0.3dB).
+    """
+    # Mock AudioEngine
+    mock_engine = MagicMock()
+    mock_engine.sample_rate = 48000
+    mock_engine.calibration = MagicMock()
+    mock_engine.calibration.input_sensitivity = 1.0
+    mock_engine.calibration.get_input_offset_db.return_value = 0.0
+    mock_engine.calibration.get_spl_offset_db.return_value = 0.0
+
+    # Init SpectrumAnalyzer
+    sa = SpectrumAnalyzer(mock_engine)
+    sa.set_buffer_size(4096)
+    sa.start_analysis()
+
+    # Init Widget
+    widget = SpectrumAnalyzerWidget(sa)
+    qtbot.addWidget(widget)
+
+    # Generate Sine Wave 100Hz, Amplitude 1.0 (Peak 0dBFS)
+    # RMS = -3.01 dBFS (Z)
+    fs = 48000
+    N = 4096
+    t = np.arange(N) / fs
+    sig = 1.0 * np.sin(2 * np.pi * 100 * t)
+
+    # Fill buffer
+    sa.input_data[:, 0] = sig
+    sa.input_data[:, 1] = sig
+    sa.write_head = 0
+    sa.analysis_mode = "Spectrum"
+    sa.multitaper_enabled = False
+
+    # 1. Test Z-weighting (Reference)
+    sa.weighting = "Z"
+    widget.update_plot()
+    val_z = extract_overall_db(widget)
+    print(f"Z-weighted RMS at 100Hz: {val_z} dBFS")
+    assert val_z == pytest.approx(-3.01, abs=0.2)
+
+    # 2. Test A-weighting
+    # A-weighting at 100Hz is approx -19.14 dB
+    # So expected RMS is -3.01 - 19.14 = -22.15 dB
+    sa.weighting = "A"
+    widget.update_plot()
+    val_a = extract_overall_db(widget)
+    print(f"A-weighted RMS at 100Hz: {val_a} dBFS")
+    assert val_a == pytest.approx(-3.01 - 19.14, abs=0.5)
+    assert "dBFS(A)" in widget.overall_label.text()
+
+    # 3. Test C-weighting
+    # C-weighting at 100Hz is approx -0.3 dB
+    # So expected RMS is -3.01 - 0.3 = -3.31 dB
+    sa.weighting = "C"
+    widget.update_plot()
+    val_c = extract_overall_db(widget)
+    print(f"C-weighted RMS at 100Hz: {val_c} dBFS")
+    assert val_c == pytest.approx(-3.01 - 0.3, abs=0.2)
+    assert "dBFS(C)" in widget.overall_label.text()
+
+def test_spectrum_spl_offset(qtbot):
+    """
+    Verify that selecting 'dB SPL' adds the SPL offset to the Overall value.
+    """
+    mock_engine = MagicMock()
+    mock_engine.sample_rate = 48000
+    mock_engine.calibration = MagicMock()
+    mock_engine.calibration.input_sensitivity = 1.0
+    mock_engine.calibration.get_input_offset_db.return_value = 0.0
+    # Set SPL offset to +94 dB
+    mock_engine.calibration.get_spl_offset_db.return_value = 94.0
+
+    sa = SpectrumAnalyzer(mock_engine)
+    sa.set_buffer_size(4096)
+    sa.start_analysis()
+
+    widget = SpectrumAnalyzerWidget(sa)
+    qtbot.addWidget(widget)
+
+    # Generate Sine Wave 1kHz, Amplitude 1.0 (Peak 0dBFS)
+    # RMS = -3.01 dBFS
+    fs = 48000
+    N = 4096
+    t = np.arange(N) / fs
+    sig = 1.0 * np.sin(2 * np.pi * 1000 * t)
+
+    sa.input_data[:, 0] = sig
+    sa.input_data[:, 1] = sig
+    sa.write_head = 0
+    sa.analysis_mode = "Spectrum"
+    sa.weighting = "Z"
+    sa.display_unit = "dBFS" # Start with dBFS
+
+    widget.update_plot()
+    val_dbfs = extract_overall_db(widget)
+    assert val_dbfs == pytest.approx(-3.01, abs=0.2)
+
+    # Switch to SPL
+    sa.display_unit = "dB SPL"
+    widget.update_plot()
+    val_spl = extract_overall_db(widget)
+    print(f"SPL RMS (Z): {val_spl}")
+
+    # Expected: -3.01 + 94.0 = 90.99
+    assert val_spl == pytest.approx(-3.01 + 94.0, abs=0.2)
+    assert "dB SPL(Z)" in widget.overall_label.text()
+
+    # Test SPL with A-weighting at 1kHz (A~0dB)
+    sa.weighting = "A"
+    widget.update_plot()
+    val_spl_a = extract_overall_db(widget)
+    print(f"SPL RMS (A): {val_spl_a}")
+    assert val_spl_a == pytest.approx(-3.01 + 94.0, abs=0.2) # 1kHz A=0dB
+    assert "dB SPL(A)" in widget.overall_label.text()


### PR DESCRIPTION
This PR addresses the issue "Clarify Overall SPL weighting". 

It confirms that the Spectrum Analyzer correctly applies the selected weighting (A, C, Z) to the "Overall" reading by using the weighted power spectrum instead of a raw time-domain calculation. 

Changes:
- Removed a block of dead code in `src/gui/widgets/spectrum_analyzer.py` that calculated an unused unweighted RMS value and contained confusing comments.
- Added a regression test `tests/logic_verification/test_spectrum_spl_weighting.py` which verifies that:
    - 100Hz Sine with Z-weighting matches reference.
    - 100Hz Sine with A-weighting is attenuated by ~19dB.
    - 100Hz Sine with C-weighting is attenuated by ~0.3dB.
    - Switching to "dB SPL" adds the correct calibration offset.

This ensures that the "Overall" display is consistent with standard Sound Level Meter behavior when a specific weighting is selected.

---
*PR created automatically by Jules for task [10852171683629457875](https://jules.google.com/task/10852171683629457875) started by @youtube-at-vach*