### PR TITLE
Fix missing and unused translation keys

### DIFF
--- a/src/assets/lang/de.json
+++ b/src/assets/lang/de.json
@@ -955,11 +955,9 @@
     "Delete": "Löschen",
     "Delete profile '{0}'?": "Profil '{0}' löschen?",
     "Device: {0}": "Gerät: {0}",
-    "Load": "Laden",
     "New Profile Name": "Neuer Profilname",
     "Please enter a profile name.": "Bitte geben Sie einen Profilnamen ein.",
     "Profile '{0}' already exists. Overwrite?": "Profil '{0}' existiert bereits. Überschreiben?",
-    "Profile loaded.": "Profil geladen.",
     "Profile saved.": "Profil gespeichert.",
     "Save As...": "Speichern unter...",
     "Saving recording...": "Aufnahme wird gespeichert...",
@@ -1043,5 +1041,7 @@
     "NCO Std Dev:": "NCO-Std.-Abw.:",
     "DSB (AM)": "DSB (AM)",
     "LSB": "LSB",
-    "USB": "USB"
+    "USB": "USB",
+    "Device: {0} ({1})": "Gerät: {0} ({1})",
+    "Failed to load profile: {0}": "Profil konnte nicht geladen werden: {0}"
 }

--- a/src/assets/lang/en.json
+++ b/src/assets/lang/en.json
@@ -966,11 +966,9 @@
     "Delete": "Delete",
     "Delete profile '{0}'?": "Delete profile '{0}'?",
     "Device: {0}": "Device: {0}",
-    "Load": "Load",
     "New Profile Name": "New Profile Name",
     "Please enter a profile name.": "Please enter a profile name.",
     "Profile '{0}' already exists. Overwrite?": "Profile '{0}' already exists. Overwrite?",
-    "Profile loaded.": "Profile loaded.",
     "Profile saved.": "Profile saved.",
     "Save As...": "Save As...",
     "Saving recording...": "Saving recording...",
@@ -1032,5 +1030,7 @@
     "Y-Axis Zoom:": "Y-Axis Zoom:",
     "DSB (AM)": "DSB (AM)",
     "LSB": "LSB",
-    "USB": "USB"
+    "USB": "USB",
+    "Device: {0} ({1})": "Device: {0} ({1})",
+    "Failed to load profile: {0}": "Failed to load profile: {0}"
 }

--- a/src/assets/lang/es.json
+++ b/src/assets/lang/es.json
@@ -955,11 +955,9 @@
     "Delete": "Eliminar",
     "Delete profile '{0}'?": "¿Eliminar perfil '{0}'?",
     "Device: {0}": "Dispositivo: {0}",
-    "Load": "Cargar",
     "New Profile Name": "Nombre del nuevo perfil",
     "Please enter a profile name.": "Por favor, introduzca un nombre de perfil.",
     "Profile '{0}' already exists. Overwrite?": "El perfil '{0}' ya existe. ¿Sobrescribir?",
-    "Profile loaded.": "Perfil cargado.",
     "Profile saved.": "Perfil guardado.",
     "Save As...": "Guardar como...",
     "Saving recording...": "Guardando grabación...",
@@ -1043,5 +1041,7 @@
     "NCO Std Dev:": "Desv. Est. NCO:",
     "DSB (AM)": "DSB (AM)",
     "LSB": "LSB",
-    "USB": "USB"
+    "USB": "USB",
+    "Device: {0} ({1})": "Dispositivo: {0} ({1})",
+    "Failed to load profile: {0}": "Error al cargar el perfil: {0}"
 }

--- a/src/assets/lang/fr.json
+++ b/src/assets/lang/fr.json
@@ -955,11 +955,9 @@
     "Delete": "Supprimer",
     "Delete profile '{0}'?": "Supprimer le profil '{0}' ?",
     "Device: {0}": "Appareil : {0}",
-    "Load": "Charger",
     "New Profile Name": "Nouveau nom de profil",
     "Please enter a profile name.": "Veuillez saisir un nom de profil.",
     "Profile '{0}' already exists. Overwrite?": "Le profil '{0}' existe déjà. Écraser ?",
-    "Profile loaded.": "Profil chargé.",
     "Profile saved.": "Profil enregistré.",
     "Save As...": "Enregistrer sous...",
     "Saving recording...": "Enregistrement en cours...",
@@ -1043,5 +1041,7 @@
     "NCO Std Dev:": "Écart-type NCO :",
     "DSB (AM)": "DSB (AM)",
     "LSB": "LSB",
-    "USB": "USB"
+    "USB": "USB",
+    "Device: {0} ({1})": "Appareil : {0} ({1})",
+    "Failed to load profile: {0}": "Échec du chargement du profil : {0}"
 }

--- a/src/assets/lang/ja.json
+++ b/src/assets/lang/ja.json
@@ -966,11 +966,9 @@
     "Delete": "削除",
     "Delete profile '{0}'?": "プロファイル '{0}' を削除しますか？",
     "Device: {0}": "デバイス: {0}",
-    "Load": "ロード",
     "New Profile Name": "新規プロファイル名",
     "Please enter a profile name.": "プロファイル名を入力してください。",
     "Profile '{0}' already exists. Overwrite?": "プロファイル '{0}' は既に存在します。上書きしますか？",
-    "Profile loaded.": "プロファイルがロードされました。",
     "Profile saved.": "プロファイルが保存されました。",
     "Save As...": "別名で保存...",
     "Saving recording...": "録音を保存中...",
@@ -1032,5 +1030,7 @@
     "Y-Axis Zoom:": "Y軸ズーム:",
     "DSB (AM)": "DSB (AM)",
     "LSB": "LSB",
-    "USB": "USB"
+    "USB": "USB",
+    "Device: {0} ({1})": "デバイス: {0} ({1})",
+    "Failed to load profile: {0}": "プロファイルの読み込みに失敗しました: {0}"
 }

--- a/src/assets/lang/ko.json
+++ b/src/assets/lang/ko.json
@@ -955,11 +955,9 @@
     "Delete": "삭제",
     "Delete profile '{0}'?": "'{0}' 프로필을 삭제하시겠습니까?",
     "Device: {0}": "장치: {0}",
-    "Load": "불러오기",
     "New Profile Name": "새 프로필 이름",
     "Please enter a profile name.": "프로필 이름을 입력해 주세요.",
     "Profile '{0}' already exists. Overwrite?": "'{0}' 프로필이 이미 존재합니다. 덮어쓰시겠습니까?",
-    "Profile loaded.": "프로필을 불러왔습니다.",
     "Profile saved.": "프로필을 저장했습니다.",
     "Save As...": "다른 이름으로 저장...",
     "Saving recording...": "녹음 저장 중...",
@@ -1043,5 +1041,7 @@
     "Statistics & Averaging": "Statistics & Averaging",
     "DSB (AM)": "DSB (AM)",
     "LSB": "LSB",
-    "USB": "USB"
+    "USB": "USB",
+    "Device: {0} ({1})": "장치: {0} ({1})",
+    "Failed to load profile: {0}": "프로필을 로드하지 못했습니다: {0}"
 }

--- a/src/assets/lang/pt.json
+++ b/src/assets/lang/pt.json
@@ -955,11 +955,9 @@
     "Delete": "Excluir",
     "Delete profile '{0}'?": "Excluir perfil '{0}'?",
     "Device: {0}": "Dispositivo: {0}",
-    "Load": "Carregar",
     "New Profile Name": "Nome do novo perfil",
     "Please enter a profile name.": "Por favor, insira um nome de perfil.",
     "Profile '{0}' already exists. Overwrite?": "O perfil '{0}' já existe. Substituir?",
-    "Profile loaded.": "Perfil carregado.",
     "Profile saved.": "Perfil salvo.",
     "Save As...": "Salvar como...",
     "Saving recording...": "Salvando gravação...",
@@ -1043,5 +1041,7 @@
     "NCO Std Dev:": "Desvio Padrão NCO:",
     "DSB (AM)": "DSB (AM)",
     "LSB": "LSB",
-    "USB": "USB"
+    "USB": "USB",
+    "Device: {0} ({1})": "Dispositivo: {0} ({1})",
+    "Failed to load profile: {0}": "Falha ao carregar perfil: {0}"
 }

--- a/src/assets/lang/ru.json
+++ b/src/assets/lang/ru.json
@@ -955,11 +955,9 @@
     "Delete": "Удалить",
     "Delete profile '{0}'?": "Удалить профиль '{0}'?",
     "Device: {0}": "Устройство: {0}",
-    "Load": "Загрузить",
     "New Profile Name": "Имя нового профиля",
     "Please enter a profile name.": "Пожалуйста, введите имя профиля.",
     "Profile '{0}' already exists. Overwrite?": "Профиль '{0}' уже существует. Перезаписать?",
-    "Profile loaded.": "Профиль загружен.",
     "Profile saved.": "Профиль сохранен.",
     "Save As...": "Сохранить как...",
     "Saving recording...": "Сохранение записи...",
@@ -1043,5 +1041,7 @@
     "Statistics & Averaging": "Statistics & Averaging",
     "DSB (AM)": "DSB (AM)",
     "LSB": "LSB",
-    "USB": "USB"
+    "USB": "USB",
+    "Device: {0} ({1})": "Устройство: {0} ({1})",
+    "Failed to load profile: {0}": "Не удалось загрузить профиль: {0}"
 }

--- a/src/assets/lang/zh.json
+++ b/src/assets/lang/zh.json
@@ -955,11 +955,9 @@
     "Delete": "删除",
     "Delete profile '{0}'?": "删除配置文件 '{0}'？",
     "Device: {0}": "设备：{0}",
-    "Load": "加载",
     "New Profile Name": "新配置文件名称",
     "Please enter a profile name.": "请输入配置文件名称。",
     "Profile '{0}' already exists. Overwrite?": "配置文件 '{0}' 已存在。是否覆盖？",
-    "Profile loaded.": "配置文件已加载。",
     "Profile saved.": "配置文件已保存。",
     "Save As...": "另存为...",
     "Saving recording...": "正在保存录音...",
@@ -1043,5 +1041,7 @@
     "NCO Std Dev:": "NCO 标准差:",
     "DSB (AM)": "DSB (AM)",
     "LSB": "LSB",
-    "USB": "USB"
+    "USB": "USB",
+    "Device: {0} ({1})": "设备：{0} ({1})",
+    "Failed to load profile: {0}": "无法加载配置文件：{0}"
 }


### PR DESCRIPTION
This PR addresses missing and unused translation keys identified by `scripts/check_trn_keys.py`.

Changes:
1.  **Added Missing Keys:**
    *   `"Device: {0} ({1})"`
    *   `"Failed to load profile: {0}"`
    *   These keys were added to all supported language JSON files (`de`, `en`, `es`, `fr`, `ja`, `ko`, `pt`, `ru`, `zh`).
    *   Translations were provided for all languages.

2.  **Removed Unused Keys:**
    *   `"Load"`
    *   `"Profile loaded."`
    *   These keys were removed from all language JSON files as they are no longer used in the codebase.

Verification:
*   Ran `scripts/check_trn_keys.py` which now passes with no errors.


---
*PR created automatically by Jules for task [17946521269923903929](https://jules.google.com/task/17946521269923903929) started by @youtube-at-vach*