### PR TITLE
⚡ Optimize Spectrogram accumulator allocation

### DIFF
--- a/src/gui/widgets/spectrogram.py
+++ b/src/gui/widgets/spectrogram.py
@@ -314,7 +314,7 @@ class SpectrogramWidget(QWidget):
             self.module.acc_count = 1
         else:
             # Max Hold Accumulation
-            self.module.accumulator = np.maximum(self.module.accumulator, mag_db)
+            np.maximum(self.module.accumulator, mag_db, out=self.module.accumulator)
             self.module.acc_count += 1
 
         # Determine Target Frames based on Speed


### PR DESCRIPTION
Optimized the 'Max Hold' accumulation logic in the `Spectrogram` widget to use in-place NumPy operations.

### Changes
*   Modified `src/gui/widgets/spectrogram.py`: Updated the accumulation step to use `np.maximum(..., out=self.module.accumulator)`.

### Performance
*   **Metric:** Execution time of the accumulation loop.
*   **Result:** ~3-6% improvement observed in synthetic benchmarks (8192 FFT size, 10000 iterations).
*   **Rationale:** Reduces memory allocation overhead and Garbage Collection pressure by reusing the existing accumulator array.

### Verification
*   **Logic:** Validated that `np.maximum(a, b, out=a)` produces the exact same result as `a = np.maximum(a, b)` using a logic verification script `verify_spectrogram_logic.py`.
*   **Benchmarks:** Ran `bench_spectrogram_accum.py` to confirm performance gains.
*   **Safety:** The change is thread-safe as the accumulator is only accessed within the `update_spectrogram` method running on the main Qt thread.

---
*PR created automatically by Jules for task [3074459607134249931](https://jules.google.com/task/3074459607134249931) started by @youtube-at-vach*