### PR TITLE
⚡ Optimize _calculate_ra_raw by removing redundant check

### DIFF
--- a/src/core/analysis.py
+++ b/src/core/analysis.py
@@ -23,8 +23,6 @@ def _calculate_ra_raw(f):
     f2 = f**2
     const = 12194**2 * f**4
     denom = (f2 + 20.6**2) * np.sqrt((f2 + 107.7**2) * (f2 + 737.9**2)) * (f2 + 12194**2)
-    # Avoid division by zero
-    denom[denom == 0] = 1.0
     Ra = const / denom
     return Ra
 


### PR DESCRIPTION
Removed the redundant `denom[denom == 0] = 1.0` check in `src/core/analysis.py`.
Verified correctness with `tests/logic_verification/test_analysis_a_weighting_cache.py` and `tests/test_analysis_edge_cases.py`.
Micro-benchmark confirmed ~540us saving per call for 1M element arrays.

---
*PR created automatically by Jules for task [18232941393224776812](https://jules.google.com/task/18232941393224776812) started by @youtube-at-vach*