### PR TITLE
⚡ Offload Advanced Distortion Meter analysis to worker thread

### DIFF
--- a/src/gui/widgets/advanced_distortion_meter.py
+++ b/src/gui/widgets/advanced_distortion_meter.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pyqtgraph as pg
-from PyQt6.QtCore import Qt, QTimer
+from PyQt6.QtCore import Qt, QTimer, QRunnable, QThreadPool, QObject, pyqtSignal
 from PyQt6.QtWidgets import (
     QComboBox,
     QDoubleSpinBox,
@@ -258,10 +258,63 @@ class AdvancedDistortionMeter(MeasurementModule):
         return self.gen_amplitude * np.sin(2 * np.pi * f * t)
 
 
+class AnalysisSignals(QObject):
+    result_ready = pyqtSignal(dict)
+
+
+class AnalysisWorker(QRunnable):
+    def __init__(self, data, sr, mode, params):
+        super().__init__()
+        self.data = data
+        self.sr = sr
+        self.mode = mode
+        self.params = params
+        self.signals = AnalysisSignals()
+
+    def run(self):
+        # Perform FFT
+        # Coherent sampling allows Rectangular window (no windowing) for max resolution.
+        fft_res = fft_manager.rfft(self.data)
+        freqs = fft_manager.rfftfreq(len(self.data), 1 / self.sr)
+
+        # Magnitude in V (Linear)
+        # Normalize: |FFT| * 2 / N
+        mag = np.abs(fft_res) * 2 / len(self.data)
+        mag_db = 20 * np.log10(mag + 1e-12)
+
+        metrics = {}
+
+        # Calculate Metrics
+        if self.mode == "MIM":
+            # Need expected tone freqs (snapped)
+            mim_freqs = self.params.get('mim_freqs')
+            if mim_freqs is not None:
+                metrics['mim'] = AudioCalc.calculate_multitone_tdn(mag, freqs, mim_freqs)
+
+        elif self.mode == "SPDR":
+            # Assume 1kHz fundamental (snapped check?)
+            metrics['spdr'] = AudioCalc.calculate_spdr(mag, freqs, 1000.0)
+
+        elif self.mode == "PIM":
+            f1 = self.params.get('f1')
+            f2 = self.params.get('f2')
+            metrics['pim'] = AudioCalc.calculate_pim(mag, freqs, f1, f2)
+
+        result = {
+            'freqs': freqs,
+            'mag_db': mag_db,
+            'metrics': metrics,
+            'mode': self.mode
+        }
+        self.signals.result_ready.emit(result)
+
+
 class AdvancedDistortionMeterWidget(QWidget):
     def __init__(self, module: AdvancedDistortionMeter):
         super().__init__()
         self.module = module
+        self.threadpool = QThreadPool()
+        self.is_analyzing = False
         self.init_ui()
 
         self.timer = QTimer()
@@ -517,48 +570,57 @@ class AdvancedDistortionMeterWidget(QWidget):
         if self.module.state != self.module.STATE_DONE:
             return
 
-        data = self.module.recording_buffer
+        if self.is_analyzing:
+            return
+
+        self.is_analyzing = True
+        data = self.module.recording_buffer.copy()
         sr = self.module.audio_engine.sample_rate
+        mode = self.module.mode
 
-        # Perform FFT
-        # Coherent sampling allows Rectangular window (no windowing) for max resolution.
-        # Ensure 'fft_manager' is used.
-        fft_res = fft_manager.rfft(data)
-        freqs = fft_manager.rfftfreq(len(data), 1 / sr)
+        # Collect params
+        params = {}
+        if mode == "MIM":
+            params['mim_freqs'] = self.module._mim_freqs
+        elif mode == "PIM":
+            params['f1'] = self.module._pim_f1_actual if self.module._pim_f1_actual is not None else self.module.pim_f1
+            params['f2'] = self.module._pim_f2_actual if self.module._pim_f2_actual is not None else self.module.pim_f2
 
-        # Magnitude in V (Linear)
-        # Normalize: |FFT| * 2 / N
-        mag = np.abs(fft_res) * 2 / len(data)
-        mag_db = 20 * np.log10(mag + 1e-12)
+        worker = AnalysisWorker(data, sr, mode, params)
+        worker.signals.result_ready.connect(self.on_analysis_result)
+        self.threadpool.start(worker)
+
+    def on_analysis_result(self, result):
+        freqs = result['freqs']
+        mag_db = result['mag_db']
+        metrics = result['metrics']
+        mode = result['mode']
 
         # Update Plot
         self.plot_curve.setData(freqs, mag_db)
 
         # Calculate Metrics
-        if self.module.mode == "MIM":
-            # Need expected tone freqs (snapped)
-            if self.module._mim_freqs is not None:
-                res = AudioCalc.calculate_multitone_tdn(mag, freqs, self.module._mim_freqs)
+        if mode == "MIM":
+            if 'mim' in metrics:
+                res = metrics['mim']
                 self.main_metric_label.setText(f"TD+N: {res['tdn_db']:.1f} dB")
                 self.sub_metric_label.setText(f"{res['tdn']:.4f} %")
 
-        elif self.module.mode == "SPDR":
-            # Assume 1kHz fundamental (snapped check?)
-            # Since we didn't store the exact snapped freq on module for SPDR,
-            # AudioCalc search will find it near 1000.
-            res = AudioCalc.calculate_spdr(mag, freqs, 1000.0)
-            self.main_metric_label.setText(f"SPDR: {res['spdr_db']:.1f} dB")
-            self.sub_metric_label.setText(
-                f"Max Spur: {res['max_spur_freq']:.0f} Hz ({20 * np.log10(res['max_spur_amp'] + 1e-12):.1f} dB)"
-            )
+        elif mode == "SPDR":
+            if 'spdr' in metrics:
+                res = metrics['spdr']
+                self.main_metric_label.setText(f"SPDR: {res['spdr_db']:.1f} dB")
+                self.sub_metric_label.setText(
+                    f"Max Spur: {res['max_spur_freq']:.0f} Hz ({20 * np.log10(res['max_spur_amp'] + 1e-12):.1f} dB)"
+                )
 
-        elif self.module.mode == "PIM":
-            f1 = self.module._pim_f1_actual if self.module._pim_f1_actual is not None else self.module.pim_f1
-            f2 = self.module._pim_f2_actual if self.module._pim_f2_actual is not None else self.module.pim_f2
-            res = AudioCalc.calculate_pim(mag, freqs, f1, f2)
-            self.main_metric_label.setText(f"PIM: {res['pim_db']:.1f} dBc")
-            products_str = ", ".join([f"{p['order']}th" for p in res["products"]])
-            self.sub_metric_label.setText(f"Orders: {products_str}")
+        elif mode == "PIM":
+            if 'pim' in metrics:
+                res = metrics['pim']
+                self.main_metric_label.setText(f"PIM: {res['pim_db']:.1f} dBc")
+                products_str = ", ".join([f"{p['order']}th" for p in res["products"]])
+                self.sub_metric_label.setText(f"Orders: {products_str}")
 
+        self.is_analyzing = False
         # Restart Measurement for next batch
         self.module.reset_measurement()

--- a/tests/benchmarks/benchmark_advanced_distortion_meter.py
+++ b/tests/benchmarks/benchmark_advanced_distortion_meter.py
@@ -1,0 +1,67 @@
+
+import time
+import numpy as np
+from src.core.analysis import AudioCalc
+from src.core.fft_manager import fft_manager
+
+def benchmark_analysis():
+    # Setup parameters matching AdvancedDistortionMeter
+    buffer_size = 65536
+    sr = 48000
+
+    # Generate synthetic data (Multitone)
+    mim_tone_count = 31
+    mim_min_freq = 20.0
+    mim_max_freq = 20000.0
+
+    bin_width = sr / buffer_size
+    raw_freqs = np.logspace(np.log10(mim_min_freq), np.log10(mim_max_freq), mim_tone_count)
+    mim_freqs = np.round(raw_freqs / bin_width) * bin_width
+
+    # Create a signal with these tones + some noise
+    t = np.arange(buffer_size) / sr
+    signal = np.random.normal(0, 0.0001, buffer_size) # Noise floor
+
+    for f in mim_freqs:
+        signal += 0.05 * np.sin(2 * np.pi * f * t) # Tones
+
+    # Benchmark Loop
+    iterations = 50
+    start_time = time.time()
+
+    for _ in range(iterations):
+        # 1. FFT
+        fft_res = fft_manager.rfft(signal)
+        freqs = fft_manager.rfftfreq(len(signal), 1 / sr)
+
+        # 2. Magnitude Calculation
+        mag = np.abs(fft_res) * 2 / len(signal)
+        # mag_db = 20 * np.log10(mag + 1e-12) # GUI does this for plotting, let's include it
+
+        # 3. Metrics (MIM mode is heaviest usually due to many tones)
+        _ = AudioCalc.calculate_multitone_tdn(mag, freqs, mim_freqs)
+
+    end_time = time.time()
+    avg_time = (end_time - start_time) / iterations
+    print(f"Average analysis time (MIM): {avg_time*1000:.2f} ms")
+
+    # Benchmark PIM
+    # PIM involves calculating products
+    pim_f1 = 1800.0
+    pim_f2 = 2100.0
+
+    start_time = time.time()
+    for _ in range(iterations):
+        # FFT (assume new data)
+        fft_res = fft_manager.rfft(signal)
+        freqs = fft_manager.rfftfreq(len(signal), 1 / sr)
+        mag = np.abs(fft_res) * 2 / len(signal)
+
+        _ = AudioCalc.calculate_pim(mag, freqs, pim_f1, pim_f2)
+
+    end_time = time.time()
+    avg_time = (end_time - start_time) / iterations
+    print(f"Average analysis time (PIM): {avg_time*1000:.2f} ms")
+
+if __name__ == "__main__":
+    benchmark_analysis()

--- a/tests/test_analysis_worker.py
+++ b/tests/test_analysis_worker.py
@@ -1,0 +1,94 @@
+
+import numpy as np
+from src.gui.widgets.advanced_distortion_meter import AnalysisWorker
+
+def test_analysis_worker_mim():
+    # Setup
+    sr = 48000
+    buffer_size = 8192 # Smaller for test speed
+    data = np.random.normal(0, 0.1, buffer_size)
+
+    # Generate 3 tones
+    freqs_mim = np.array([1000.0, 2000.0, 5000.0])
+    t = np.arange(buffer_size) / sr
+    for f in freqs_mim:
+        data += 0.5 * np.sin(2 * np.pi * f * t)
+
+    params = {'mim_freqs': freqs_mim}
+    mode = 'MIM'
+
+    worker = AnalysisWorker(data, sr, mode, params)
+
+    # Capture results
+    results = []
+    def on_result(res):
+        results.append(res)
+
+    worker.signals.result_ready.connect(on_result)
+
+    # Run
+    worker.run()
+
+    # Assert
+    assert len(results) == 1
+    res = results[0]
+    assert res['mode'] == 'MIM'
+    assert 'mim' in res['metrics']
+    assert 'tdn' in res['metrics']['mim']
+    assert 'tdn_db' in res['metrics']['mim']
+
+    # Check if correct keys are present
+    assert len(res['freqs']) == buffer_size // 2 + 1
+    assert len(res['mag_db']) == buffer_size // 2 + 1
+
+def test_analysis_worker_spdr():
+    sr = 48000
+    buffer_size = 4096
+    t = np.arange(buffer_size) / sr
+    data = 0.8 * np.sin(2 * np.pi * 1000.0 * t) # Fundamental
+    data += 0.001 * np.sin(2 * np.pi * 2500.0 * t) # Spur
+
+    params = {}
+    mode = 'SPDR'
+
+    worker = AnalysisWorker(data, sr, mode, params)
+
+    results = []
+    worker.signals.result_ready.connect(lambda r: results.append(r))
+
+    worker.run()
+
+    assert len(results) == 1
+    res = results[0]
+    assert res['mode'] == 'SPDR'
+    assert 'spdr' in res['metrics']
+    assert res['metrics']['spdr']['spdr_db'] > 0
+
+def test_analysis_worker_pim():
+    sr = 48000
+    buffer_size = 4096
+    t = np.arange(buffer_size) / sr
+    f1 = 1800.0
+    f2 = 2100.0
+
+    data = 0.4 * np.sin(2 * np.pi * f1 * t) + 0.4 * np.sin(2 * np.pi * f2 * t)
+    # Add PIM product (IM3: 2f1 - f2 = 3600 - 2100 = 1500)
+    data += 0.001 * np.sin(2 * np.pi * 1500.0 * t)
+
+    params = {'f1': f1, 'f2': f2}
+    mode = 'PIM'
+
+    worker = AnalysisWorker(data, sr, mode, params)
+
+    results = []
+    worker.signals.result_ready.connect(lambda r: results.append(r))
+
+    worker.run()
+
+    assert len(results) == 1
+    res = results[0]
+    assert res['mode'] == 'PIM'
+    assert 'pim' in res['metrics']
+    assert res['metrics']['pim']['pim_db'] > -140
+    # Should detect products
+    assert len(res['metrics']['pim']['products']) > 0


### PR DESCRIPTION
Offloaded heavy audio analysis (FFT and metric calculations) in the Advanced Distortion Meter to a background worker thread using `QThreadPool`. This ensures the GUI remains responsive during analysis updates. Added unit tests and a benchmark script to verify correctness and performance.

---
*PR created automatically by Jules for task [9553362763165441601](https://jules.google.com/task/9553362763165441601) started by @youtube-at-vach*