### PR TITLE
⚡ Optimize Multitaper Loop in Spectrum Analyzer

### DIFF
--- a/src/gui/widgets/spectrum_analyzer.py
+++ b/src/gui/widgets/spectrum_analyzer.py
@@ -690,6 +690,14 @@ class SpectrumAnalyzerWidget(QWidget):
                 # Calculate PSD for each channel and each window
                 # psd = |FFT(x*w)|^2
 
+                # Pre-allocate buffers for optimization
+                # We determine complex type based on input data type
+                c_dtype = np.complex128 if data.dtype == np.float64 else np.complex64
+
+                windowed_buffer = np.empty(len(data), dtype=data.dtype)
+                fft_out = np.empty(len(freqs), dtype=c_dtype)
+                temp_psd = np.empty(len(freqs), dtype=data.dtype)
+
                 psd_accum_0 = np.zeros(len(freqs))
                 psd_accum_1 = np.zeros(len(freqs))
 
@@ -697,12 +705,24 @@ class SpectrumAnalyzerWidget(QWidget):
                     w = windows[k]
 
                     # Channel 0
-                    fft_0 = fft_manager.rfft(data[:, 0] * w)
-                    psd_accum_0 += np.abs(fft_0) ** 2
+                    np.multiply(data[:, 0], w, out=windowed_buffer)
+                    fft_manager.rfft(windowed_buffer, out=fft_out)
+
+                    # Optimized accumulation: |z|^2 = real^2 + imag^2
+                    # Avoids allocation of intermediate abs() array and squaring it
+                    np.square(fft_out.real, out=temp_psd)
+                    psd_accum_0 += temp_psd
+                    np.square(fft_out.imag, out=temp_psd)
+                    psd_accum_0 += temp_psd
 
                     # Channel 1
-                    fft_1 = fft_manager.rfft(data[:, 1] * w)
-                    psd_accum_1 += np.abs(fft_1) ** 2
+                    np.multiply(data[:, 1], w, out=windowed_buffer)
+                    fft_manager.rfft(windowed_buffer, out=fft_out)
+
+                    np.square(fft_out.real, out=temp_psd)
+                    psd_accum_1 += temp_psd
+                    np.square(fft_out.imag, out=temp_psd)
+                    psd_accum_1 += temp_psd
 
                 # Average over K windows
                 psd_0 = psd_accum_0 / K

--- a/tests/benchmarks/benchmark_multitaper_loop.py
+++ b/tests/benchmarks/benchmark_multitaper_loop.py
@@ -1,0 +1,106 @@
+
+import sys
+import os
+import time
+import numpy as np
+from scipy.signal.windows import dpss
+
+# Add src to path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../")))
+
+from src.core.fft_manager import fft_manager
+
+def benchmark_multitaper_original(data, windows, K):
+    N = len(data)
+    n_freqs = N // 2 + 1
+
+    # Simulate surrounding code
+    psd_accum_0 = np.zeros(n_freqs)
+    psd_accum_1 = np.zeros(n_freqs)
+
+    start_time = time.time()
+    for k in range(K):
+        w = windows[k]
+
+        # Channel 0
+        fft_0 = fft_manager.rfft(data[:, 0] * w)
+        psd_accum_0 += np.abs(fft_0) ** 2
+
+        # Channel 1
+        fft_1 = fft_manager.rfft(data[:, 1] * w)
+        psd_accum_1 += np.abs(fft_1) ** 2
+
+    end_time = time.time()
+    return end_time - start_time
+
+def benchmark_multitaper_optimized(data, windows, K):
+    N = len(data)
+    n_freqs = N // 2 + 1
+
+    # Pre-allocations
+    psd_accum_0 = np.zeros(n_freqs)
+    psd_accum_1 = np.zeros(n_freqs)
+
+    windowed_buffer = np.empty(N, dtype=data.dtype)
+    out_dtype = np.complex128 if data.dtype == np.float64 else np.complex64
+    fft_out = np.empty(n_freqs, dtype=out_dtype)
+    temp_psd = np.empty(n_freqs, dtype=psd_accum_0.dtype)
+
+    start_time = time.time()
+    for k in range(K):
+        w = windows[k]
+
+        # Channel 0
+        np.multiply(data[:, 0], w, out=windowed_buffer)
+        fft_manager.rfft(windowed_buffer, out=fft_out)
+
+        # Optimize abs(fft)**2 -> real**2 + imag**2
+        np.square(fft_out.real, out=temp_psd)
+        psd_accum_0 += temp_psd
+        np.square(fft_out.imag, out=temp_psd)
+        psd_accum_0 += temp_psd
+
+        # Channel 1
+        np.multiply(data[:, 1], w, out=windowed_buffer)
+        fft_manager.rfft(windowed_buffer, out=fft_out)
+
+        np.square(fft_out.real, out=temp_psd)
+        psd_accum_1 += temp_psd
+        np.square(fft_out.imag, out=temp_psd)
+        psd_accum_1 += temp_psd
+
+    end_time = time.time()
+    return end_time - start_time
+
+def run_benchmark():
+    N = 8192
+    NW = 3
+    K = 2 * NW - 1
+
+    print(f"Benchmarking Multitaper Loop (N={N}, K={K})...")
+
+    # Prepare data once
+    data = np.random.random((N, 2))
+    windows = dpss(N, NW, K)
+
+    # Warmup
+    benchmark_multitaper_original(data, windows, K)
+    benchmark_multitaper_optimized(data, windows, K)
+
+    iterations = 100
+    t_orig = 0
+    t_opt = 0
+
+    for _ in range(iterations):
+        t_orig += benchmark_multitaper_original(data, windows, K)
+        t_opt += benchmark_multitaper_optimized(data, windows, K)
+
+    avg_orig = t_orig / iterations * 1000
+    avg_opt = t_opt / iterations * 1000
+
+    print(f"Original: {avg_orig:.3f} ms")
+    print(f"Optimized: {avg_opt:.3f} ms")
+    print(f"Improvement: {(avg_orig - avg_opt)/avg_orig * 100:.1f}%")
+
+if __name__ == "__main__":
+    run_benchmark()

--- a/tests/logic_verification/test_spectrum_multitaper.py
+++ b/tests/logic_verification/test_spectrum_multitaper.py
@@ -1,0 +1,81 @@
+import sys
+import os
+import numpy as np
+from unittest.mock import MagicMock
+import pytest
+import re
+
+# Ensure sounddevice is mocked
+if 'sounddevice' not in sys.modules:
+    sys.modules['sounddevice'] = MagicMock()
+
+# Add src to path
+sys.path.append(os.path.join(os.path.dirname(__file__), '../../'))
+
+from src.gui.widgets.spectrum_analyzer import SpectrumAnalyzer, SpectrumAnalyzerWidget
+from PyQt6.QtWidgets import QApplication
+
+# Initialize QApplication if not exists
+app = QApplication.instance()
+if app is None:
+    app = QApplication([])
+
+def test_spectrum_multitaper_sine_accuracy(qtbot):
+    """
+    Verify that Overall Weighted RMS is accurate for a Sine Wave (0dBFS)
+    when Multitaper is enabled.
+    Expected RMS for Full Scale Sine is -3.01 dB.
+    """
+    # Mock AudioEngine
+    mock_engine = MagicMock()
+    mock_engine.sample_rate = 48000
+    mock_engine.calibration = MagicMock()
+    mock_engine.calibration.input_sensitivity = 1.0
+    mock_engine.calibration.get_input_offset_db.return_value = 0.0
+    mock_engine.calibration.get_spl_offset_db.return_value = 0.0
+
+    # Init SpectrumAnalyzer
+    sa = SpectrumAnalyzer(mock_engine)
+    sa.set_buffer_size(4096)
+    sa.start_analysis()
+
+    # Init Widget
+    widget = SpectrumAnalyzerWidget(sa)
+    qtbot.addWidget(widget)
+
+    # Generate Sine Wave 1kHz, Amplitude 1.0 (Peak 0dBFS)
+    fs = 48000
+    N = 4096
+    t = np.arange(N) / fs
+    sig = 1.0 * np.sin(2 * np.pi * 1000 * t)
+
+    # Fill buffer
+    sa.input_data[:, 0] = sig
+    sa.input_data[:, 1] = sig
+    sa.write_head = 0
+
+    # Set Weighting to Z (Flat)
+    sa.weighting = "Z"
+
+    # Enable Multitaper
+    sa.multitaper_enabled = True
+    sa.analysis_mode = "Spectrum"
+
+    # Call update_plot
+    widget.update_plot()
+
+    # Check Overall Label
+    # Expected: 20*log10(1/sqrt(2)) = -3.01 dB
+    text = widget.overall_label.text()
+    print(f"Label Text: {text}")
+
+    # Format: "Overall: -3.0 dBFS(Z)"
+    match = re.search(r"Overall:\s*([\d\.-]+)\s*dBFS", text)
+    assert match is not None
+    val = float(match.group(1))
+
+    print(f"Measured RMS dB: {val}")
+
+    # Check accuracy
+    # Multitaper should also yield correct RMS for sine
+    assert val == pytest.approx(-3.01, abs=0.5)


### PR DESCRIPTION
Optimized the multitaper spectrum estimation loop in `SpectrumAnalyzer` to reduce memory allocations and improve CPU efficiency.

Key changes:
- Pre-allocated `windowed_buffer`, `fft_out`, and `temp_psd` buffers outside the loop.
- Used in-place operations (`out` parameter) for windowing and FFTs.
- Replaced `np.abs(fft)**2` with `fft.real**2 + fft.imag**2` to avoid intermediate allocations and unnecessary square root calculations.

Verification:
- Added `tests/logic_verification/test_spectrum_multitaper.py` to verify RMS accuracy for sine waves (passed).
- Verified performance improvement of ~8-10% using `tests/benchmarks/benchmark_multitaper_loop.py`.
- Verified existing tests pass.

---
*PR created automatically by Jules for task [8666412260729591098](https://jules.google.com/task/8666412260729591098) started by @youtube-at-vach*