### PR TITLE
⚡ Optimize Spectrum Analyzer buffer unrolling

### DIFF
--- a/src/gui/widgets/spectrum_analyzer.py
+++ b/src/gui/widgets/spectrum_analyzer.py
@@ -661,7 +661,15 @@ class SpectrumAnalyzerWidget(QWidget):
         else:
             # Normal Rolling Mode
             # Unroll ring buffer for display/analysis
-            data = np.roll(self.module.input_data, -self.module.write_head, axis=0)
+            # Capture write_head locally to avoid race condition with audio thread changing it
+            idx = self.module.write_head
+            if idx == 0:
+                data = self.module.input_data.copy()
+            else:
+                data = np.concatenate(
+                    (self.module.input_data[idx:], self.module.input_data[:idx]),
+                    axis=0,
+                )
 
         # Overall RMS is calculated later from the power spectrum (see overall_weighted_db)
         # to correctly apply weighting (A/C/Z) and calibration.

--- a/tests/benchmarks/benchmark_spectrum_roll.py
+++ b/tests/benchmarks/benchmark_spectrum_roll.py
@@ -1,0 +1,39 @@
+
+import time
+import numpy as np
+
+def benchmark_roll_vs_concat():
+    # Sizes relevant to "Normal Rolling Mode" (< 500,000)
+    sizes = [1024, 4096, 8192, 16384, 32768, 65536, 131072, 262144]
+    channels = 2
+    iterations = 200
+
+    print(f"{'Buffer Size':<15} | {'np.roll (s)':<12} | {'Concat (s)':<12} | {'Speedup':<8}")
+    print("-" * 55)
+
+    for buffer_size in sizes:
+        input_data = np.random.rand(buffer_size, channels)
+        write_head = buffer_size // 2  # Worst case split
+
+        # Benchmark np.roll
+        start_time = time.time()
+        for _ in range(iterations):
+            data_roll = np.roll(input_data, -write_head, axis=0)
+        roll_duration = time.time() - start_time
+
+        # Benchmark concatenation
+        start_time = time.time()
+        for _ in range(iterations):
+            if write_head == 0:
+                data_concat = input_data.copy()
+            else:
+                data_concat = np.concatenate((input_data[write_head:], input_data[:write_head]), axis=0)
+        concat_duration = time.time() - start_time
+
+        # Verify correctness
+        np.testing.assert_array_equal(data_roll, data_concat)
+
+        print(f"{buffer_size:<15} | {roll_duration:.4f}       | {concat_duration:.4f}       | {roll_duration / concat_duration:.2f}x")
+
+if __name__ == "__main__":
+    benchmark_roll_vs_concat()

--- a/tests/logic_verification/test_spectrum_buffer.py
+++ b/tests/logic_verification/test_spectrum_buffer.py
@@ -1,0 +1,42 @@
+import numpy as np
+
+def test_spectrum_buffer_unroll_logic():
+    """
+    Verify that the manual concatenation logic produces the same result
+    as np.roll for unrolling a ring buffer.
+    """
+    buffer_sizes = [1024, 4096, 50000]
+
+    for size in buffer_sizes:
+        # Test various write positions
+        write_positions = [0, 10, size // 2, size - 1]
+
+        # Create test data (e.g. indices)
+        # Shape (size, 2)
+        input_data = np.zeros((size, 2))
+        input_data[:, 0] = np.arange(size)
+        input_data[:, 1] = np.arange(size) + 100000
+
+        for write_head in write_positions:
+            # Expected result using np.roll
+            # np.roll shift is -write_head (shift left by write_head)
+            expected = np.roll(input_data, -write_head, axis=0)
+
+            # Optimized logic
+            if write_head == 0:
+                result = input_data.copy()
+            else:
+                result = np.concatenate(
+                    (input_data[write_head:], input_data[:write_head]),
+                    axis=0
+                )
+
+            np.testing.assert_array_equal(
+                result,
+                expected,
+                err_msg=f"Failed for size={size}, write_head={write_head}"
+            )
+
+if __name__ == "__main__":
+    test_spectrum_buffer_unroll_logic()
+    print("test_spectrum_buffer_unroll_logic passed.")


### PR DESCRIPTION
Optimized the `SpectrumAnalyzerWidget` display update loop by replacing `np.roll` with `np.concatenate` for ring buffer alignment. `np.roll` is generally slower as it handles arbitrary shifts and copies data more generically. The specific use case of unrolling a ring buffer (split at `write_head`) is more efficiently handled by concatenating two slices.

**Performance Impact:**
Benchmarks (`tests/benchmarks/benchmark_spectrum_roll.py`) demonstrate:
- **Small buffers (1024):** ~5.4x speedup
- **Standard buffers (4096):** ~2.9x speedup
- **Large buffers (262k):** ~1.2x speedup

**Safety:**
- Added a local capture of `write_head` to ensure that the two slices use the same index, preventing length mismatches if the audio thread updates the head during the operation.
- Added logic verification test (`tests/logic_verification/test_spectrum_buffer.py`) to ensure the output is identical to `np.roll`.

---
*PR created automatically by Jules for task [7338379566547078311](https://jules.google.com/task/7338379566547078311) started by @youtube-at-vach*