### PR TITLE
Refactor NoiseProfiler for Testability

### DIFF
--- a/src/gui/widgets/noise_profiler.py
+++ b/src/gui/widgets/noise_profiler.py
@@ -57,6 +57,99 @@ class NoiseProfiler(MeasurementModule):
         self.accumulated_magnitude = None
         self._avg_magnitude = None
 
+    def update_average(self, mag_v_rthz):
+        """Updates the running average of the magnitude spectrum."""
+        if self.average_mode:
+            # Cumulative Average Logic
+            if self.current_avg_count < self.target_averages:
+                if self.current_avg_count == 0:
+                    self.accumulated_magnitude = mag_v_rthz.copy()
+                    self.current_avg_count = 1
+                else:
+                    self.accumulated_magnitude += mag_v_rthz
+                    self.current_avg_count += 1
+
+                self._avg_magnitude = self.accumulated_magnitude / self.current_avg_count
+            else:
+                # Target reached, hold result
+                if self._avg_magnitude is None:
+                    self._avg_magnitude = mag_v_rthz
+        else:
+            # Exponential Moving Average
+            if self._avg_magnitude is None:
+                self._avg_magnitude = mag_v_rthz
+            else:
+                alpha = 0.8  # Fixed smoothing
+                self._avg_magnitude = alpha * self._avg_magnitude + (1 - alpha) * mag_v_rthz
+
+        return self._avg_magnitude
+
+    def process_data(self, channel_idx, unit_mode, apply_gain_correction):
+        """
+        Process the current input data buffer to produce noise profile results.
+        Returns (freqs, calibrated_magnitude, results_dict) or None if insufficient data.
+        """
+        data = self.input_data
+        if len(data) < self.buffer_size:
+            return None
+
+        # 1. Compute PSD (V/rtHz)
+        # Use Hanning window
+        window = get_cached_window("hann", len(data))
+
+        fs = self.audio_engine.sample_rate
+        sum_w2 = np.sum(window**2)
+        psd_factor = np.sqrt(2 / (fs * sum_w2))
+
+        # FFT
+        # Select Channel
+        if data.shape[1] > channel_idx:
+            fft_input = data[:, channel_idx]
+        else:
+            fft_input = data[:, 0]
+
+        fft_data = fft_manager.rfft(fft_input * window)
+        mag_v_rthz = np.abs(fft_data) * psd_factor
+
+        freqs = fft_manager.rfftfreq(len(data), 1 / fs)
+
+        # Averaging
+        avg_mag = self.update_average(mag_v_rthz)
+        if avg_mag is None:
+            return None
+
+        # Apply Unit / Calibration Offset
+        # avg_mag is in V_fs/rtHz (Linear, relative to Full Scale 1.0)
+
+        offset_db = 0.0
+
+        if "dBV" in unit_mode or "dBu" in unit_mode:
+            # Apply Calibration Offset
+            offset_db += self.audio_engine.calibration.get_input_offset_db()
+
+        if "dBu" in unit_mode:
+            # 0 dBu = 0.775V = -2.218 dBV
+            # dBu = dBV + 2.218
+            offset_db += 2.2184
+
+        # Apply LNA Gain Offset if requested
+        if apply_gain_correction:
+            # Subtract Gain (Input Referred)
+            # Gain is in dB
+            offset_db -= self.lna_gain_db
+
+        # Apply offset to linear magnitude
+        # magnitude_new = magnitude_old * 10^(offset_db/20)
+        cal_factor = 10 ** (offset_db / 20)
+        avg_mag_cal = avg_mag * cal_factor
+
+        # 2. Analyze Noise (using calibrated magnitude)
+        results = AudioCalc.calculate_noise_profile(avg_mag_cal, freqs, fs)
+
+        self.last_results = results
+
+        return freqs, avg_mag_cal, results
+
     @property
     def name(self) -> str:
         return "Noise Profiler"
@@ -381,89 +474,20 @@ class NoiseProfilerWidget(QWidget):
             return
 
         try:
-            data = self.module.input_data
-            if len(data) < self.module.buffer_size:
+            # Gather parameters
+            channel_idx = self.channel_combo.currentIndex()
+            unit_mode = self.unit_combo.currentText()
+            apply_gain = self.apply_gain_chk.isChecked()
+
+            # Process Data
+            output = self.module.process_data(channel_idx, unit_mode, apply_gain)
+            if output is None:
                 return
 
-            # 1. Compute PSD (V/rtHz)
-            # Use Hanning window
-            window = get_cached_window("hann", len(data))
-
-            fs = self.module.audio_engine.sample_rate
-            sum_w2 = np.sum(window**2)
-            psd_factor = np.sqrt(2 / (fs * sum_w2))
-
-            # FFT
-            # Select Channel
-            ch_idx = self.channel_combo.currentIndex()  # 0=Left, 1=Right
-            if data.shape[1] > ch_idx:
-                fft_input = data[:, ch_idx]
-            else:
-                fft_input = data[:, 0]
-
-            fft_data = fft_manager.rfft(fft_input * window)
-            mag_v_rthz = np.abs(fft_data) * psd_factor
-
-            freqs = fft_manager.rfftfreq(len(data), 1 / fs)
-
-            # Averaging
-            if self.module.average_mode:
-                # Cumulative Average Logic
-                if self.module.current_avg_count < self.module.target_averages:
-                    if self.module.current_avg_count == 0:
-                        self.module.accumulated_magnitude = mag_v_rthz.copy()
-                        self.module.current_avg_count = 1
-                    else:
-                        self.module.accumulated_magnitude += mag_v_rthz
-                        self.module.current_avg_count += 1
-
-                    self.module._avg_magnitude = self.module.accumulated_magnitude / self.module.current_avg_count
-                    self.update_avg_ui()
-                else:
-                    # Target reached, hold result
-                    if self.module._avg_magnitude is None:
-                        self.module._avg_magnitude = mag_v_rthz  # Should not happen if count > 0
-            else:
-                # Exponential Moving Average
-                if self.module._avg_magnitude is None:
-                    self.module._avg_magnitude = mag_v_rthz
-                else:
-                    alpha = 0.8  # Fixed smoothing
-                    self.module._avg_magnitude = alpha * self.module._avg_magnitude + (1 - alpha) * mag_v_rthz
-
+            freqs, avg_mag_cal, results = output
             avg_mag = self.module._avg_magnitude
 
-            # Apply Unit / Calibration Offset
-            # avg_mag is in V_fs/rtHz (Linear, relative to Full Scale 1.0)
-            # We want to convert to the selected unit's linear voltage reference
-
-            unit_mode = self.unit_combo.currentText()
-            offset_db = 0.0
-
-            if "dBV" in unit_mode or "dBu" in unit_mode:
-                # Apply Calibration Offset
-                offset_db += self.module.audio_engine.calibration.get_input_offset_db()
-
-            if "dBu" in unit_mode:
-                # 0 dBu = 0.775V = -2.218 dBV
-                # dBu = dBV + 2.218
-                offset_db += 2.2184
-
-            # Apply LNA Gain Offset if requested
-            if self.apply_gain_chk.isChecked():
-                # Subtract Gain (Input Referred)
-                # Gain is in dB
-                offset_db -= self.module.lna_gain_db
-
-            # Apply offset to linear magnitude
-            # magnitude_new = magnitude_old * 10^(offset_db/20)
-            cal_factor = 10 ** (offset_db / 20)
-            avg_mag_cal = avg_mag * cal_factor
-
-            # 2. Analyze Noise (using calibrated magnitude)
-            results = AudioCalc.calculate_noise_profile(avg_mag_cal, freqs, fs)
-
-            self.module.last_results = results
+            self.update_avg_ui()
 
             # 3. Update Plots
 

--- a/tests/logic_verification/test_noise_profiler_avg.py
+++ b/tests/logic_verification/test_noise_profiler_avg.py
@@ -39,46 +39,24 @@ class TestNoiseProfilerAverage(unittest.TestCase):
     def test_averaging_logic(self):
         # Simulate 3 updates
 
-        # 1. First update
-        # Create fake magnitude data (simulating what happens inside update_analysis)
-        # Since we can't easily call update_analysis without GUI dependencies (QTimer, etc) or refactoring,
-        # we will test the logic we INTEND to put into update_analysis here,
-        # OR we can refactor NoiseProfiler to have a separate 'process_data' method.
-        # For now, let's assume we are testing the logic that will be added.
-
-        # Let's define the logic function here as it would appear in the class
-        def process_average(profiler, new_mag):
-            if profiler.current_avg_count == 0:
-                profiler.accumulated_magnitude = new_mag.copy()
-                profiler.current_avg_count = 1
-            else:
-                # Cumulative Average: new_avg = (old_avg * count + current) / (count + 1)
-                # But to avoid precision issues, better to accumulate sum?
-                # "accumulated_magnitude" suggests sum.
-                # If we store SUM:
-                profiler.accumulated_magnitude += new_mag
-                profiler.current_avg_count += 1
-
-            profiler._avg_magnitude = profiler.accumulated_magnitude / profiler.current_avg_count
-
         # Test Data
         mag1 = np.ones(513) * 1.0
         mag2 = np.ones(513) * 2.0
         mag3 = np.ones(513) * 3.0
 
         # Step 1
-        process_average(self.profiler, mag1)
+        self.profiler.update_average(mag1)
         self.assertEqual(self.profiler.current_avg_count, 1)
         np.testing.assert_array_almost_equal(self.profiler._avg_magnitude, mag1)
 
         # Step 2
-        process_average(self.profiler, mag2)
+        self.profiler.update_average(mag2)
         self.assertEqual(self.profiler.current_avg_count, 2)
         # Avg of 1 and 2 is 1.5
         np.testing.assert_array_almost_equal(self.profiler._avg_magnitude, np.ones(513) * 1.5)
 
         # Step 3
-        process_average(self.profiler, mag3)
+        self.profiler.update_average(mag3)
         self.assertEqual(self.profiler.current_avg_count, 3)
         # Avg of 1, 2, 3 is 2.0
         np.testing.assert_array_almost_equal(self.profiler._avg_magnitude, np.ones(513) * 2.0)

--- a/tests/logic_verification/test_noise_profiler_process.py
+++ b/tests/logic_verification/test_noise_profiler_process.py
@@ -1,0 +1,43 @@
+import unittest
+from unittest.mock import MagicMock
+import numpy as np
+import sys
+import os
+
+# Add src to path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
+
+from src.gui.widgets.noise_profiler import NoiseProfiler
+
+class TestNoiseProfilerProcess(unittest.TestCase):
+    def setUp(self):
+        self.engine = MagicMock()
+        self.engine.sample_rate = 48000
+        self.engine.calibration.get_input_offset_db.return_value = 0.0
+
+        self.profiler = NoiseProfiler(self.engine)
+        self.profiler.buffer_size = 1024
+        # Fill input data
+        self.profiler.input_data = np.random.rand(1024, 2)
+
+    def test_process_data_smoke(self):
+        # Basic smoke test
+        output = self.profiler.process_data(channel_idx=0, unit_mode="dBV", apply_gain_correction=False)
+
+        self.assertIsNotNone(output)
+        freqs, mag, results = output
+
+        self.assertIsNotNone(freqs)
+        self.assertIsNotNone(mag)
+        self.assertIsNotNone(results)
+        self.assertEqual(len(freqs), 513) # 1024/2 + 1
+        self.assertEqual(len(mag), 513)
+        self.assertIn("white_density", results)
+
+    def test_process_data_insufficient_data(self):
+        self.profiler.input_data = np.zeros((100, 2)) # Less than buffer_size
+        output = self.profiler.process_data(0, "dBV", False)
+        self.assertIsNone(output)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Refactored NoiseProfiler to separate data processing logic into `process_data` and `update_average` methods to decouple it from GUI dependencies and improve testability. Updated existing tests and added a new smoke test for the processing pipeline.

---
*PR created automatically by Jules for task [8722428493442930029](https://jules.google.com/task/8722428493442930029) started by @youtube-at-vach*