### PR TITLE
⚡ Optimize Spectrogram Loop Allocations

### DIFF
--- a/src/gui/widgets/spectrogram.py
+++ b/src/gui/widgets/spectrogram.py
@@ -39,19 +39,8 @@ class Spectrogram(MeasurementModule):
         self.max_freq = 20000  # Default, will be updated by UI or sample rate
 
         # State
-        self.input_buffer = np.zeros(self.fft_size)  # For overlap processing
-        self.spectrogram_buffer = np.full((self.history_length, self.fft_size // 2 + 1), -120.0)
-        self.spectrogram_ptr = 0
         self.callback_id = None
-
-        # Accumulator for Sweep Speed
-        self.accumulator = None
-        self.acc_count = 0
-
-        # Ring buffer for incoming audio
-        self.audio_buffer = np.zeros((self.fft_size * 2, 2))  # Keep enough for overlap
-        self.audio_buffer_pos = 0
-        self.output_buffer = None
+        self.reset_buffers()
 
     @property
     def name(self) -> str:
@@ -79,6 +68,11 @@ class Spectrogram(MeasurementModule):
         self.accumulator = None
         self.acc_count = 0
         self.output_buffer = None
+
+        # Performance buffers
+        self.work_buffer = np.zeros(self.fft_size, dtype=np.float64)
+        self.fft_out_buffer = np.zeros(self.fft_size // 2 + 1, dtype=np.complex128)
+        self.mag_buffer = np.zeros(self.fft_size // 2 + 1, dtype=np.float64)
 
     def start_analysis(self):
         if self.is_running:
@@ -338,36 +332,52 @@ class SpectrogramWidget(QWidget):
         # We take the last fft_size samples
         raw_data = self.module.get_latest_samples(self.module.fft_size)
 
-        # Select Channel
+        # Use pre-allocated buffers
+        work_buffer = self.module.work_buffer
+        fft_out_buffer = self.module.fft_out_buffer
+        mag_buffer = self.module.mag_buffer
+
+        # Ensure work buffer size matches (it should if reset_buffers called correctly)
+        if len(work_buffer) != len(raw_data):
+            work_buffer = np.zeros(len(raw_data), dtype=np.float64)
+            fft_out_buffer = np.zeros(len(raw_data) // 2 + 1, dtype=np.complex128)
+            mag_buffer = np.zeros(len(raw_data) // 2 + 1, dtype=np.float64)
+
+        # Populate Work Buffer
         if self.module.channel_mode == "Left":
-            sig = raw_data[:, 0]
+            work_buffer[:] = raw_data[:, 0]
         elif self.module.channel_mode == "Right":
-            sig = raw_data[:, 1]
+            work_buffer[:] = raw_data[:, 1]
         else:
-            sig = np.mean(raw_data, axis=1)
+            # Average: optimize to avoid 'np.mean' allocation
+            np.add(raw_data[:, 0], raw_data[:, 1], out=work_buffer)
+            work_buffer *= 0.5
 
         # Windowing
-        window = get_cached_window(self.module.window_type, len(sig))
-        sig_win = sig * window
+        window = get_cached_window(self.module.window_type, len(work_buffer))
+        work_buffer *= window
 
         # Window Correction Factor (Coherent Gain)
         win_correction = 1.0 / np.mean(window)
 
         # FFT
-        fft_res = fft_manager.rfft(sig_win)
-        mag = np.abs(fft_res)
+        fft_manager.rfft(work_buffer, out=fft_out_buffer)
+
+        # Magnitude (Abs)
+        np.abs(fft_out_buffer, out=mag_buffer)
 
         # Normalize
         # Optimized in-place normalization
-        mag *= (2.0 * win_correction) / len(sig)
+        mag_buffer *= (2.0 * win_correction) / len(work_buffer)
 
         # Convert to dB
         # In-place optimization to save memory bandwidth
         with np.errstate(divide="ignore"):
-            np.add(mag, 1e-12, out=mag)
-            np.log10(mag, out=mag)
-            np.multiply(mag, 20, out=mag)
-            mag_db = mag
+            np.add(mag_buffer, 1e-12, out=mag_buffer)
+            np.log10(mag_buffer, out=mag_buffer)
+            np.multiply(mag_buffer, 20, out=mag_buffer)
+
+        mag_db = mag_buffer
 
         # --- Accumulation Logic ---
         if self.module.accumulator is None or self.module.accumulator.shape != mag_db.shape:

--- a/tests/benchmarks/benchmark_spectrogram_windowing.py
+++ b/tests/benchmarks/benchmark_spectrogram_windowing.py
@@ -1,0 +1,115 @@
+
+import time
+import numpy as np
+from src.core.analysis import get_cached_window
+from src.core.fft_manager import fft_manager
+
+# Configuration
+FFT_SIZE = 4096
+ITERATIONS = 1000
+
+def setup_data():
+    raw_data = np.random.random((FFT_SIZE, 2)).astype(np.float64)
+    window = get_cached_window("hann", FFT_SIZE)
+    return raw_data, window
+
+def run_current_implementation(raw_data, window, channel_mode):
+    # Old logic
+    if channel_mode == "Left":
+        sig = raw_data[:, 0]
+    elif channel_mode == "Right":
+        sig = raw_data[:, 1]
+    else:
+        sig = np.mean(raw_data, axis=1)
+
+    # Windowing
+    sig_win = sig * window
+
+    # Correction
+    win_correction = 1.0 / np.mean(window)
+
+    # FFT
+    fft_res = fft_manager.rfft(sig_win)
+    mag = np.abs(fft_res)
+
+    # Normalize
+    mag *= (2.0 * win_correction) / len(sig)
+
+    # dB
+    with np.errstate(divide="ignore"):
+        np.add(mag, 1e-12, out=mag)
+        np.log10(mag, out=mag)
+        np.multiply(mag, 20, out=mag)
+        mag_db = mag
+
+    return mag_db
+
+def run_optimized_implementation(raw_data, window, channel_mode, work_buffer, fft_out_buffer, mag_buffer):
+    # Logic in SpectrogramWidget.update_spectrogram
+
+    # Ensure work buffer size matches
+    if len(work_buffer) != len(raw_data):
+        work_buffer = np.zeros(len(raw_data), dtype=np.float64)
+        fft_out_buffer = np.zeros(len(raw_data) // 2 + 1, dtype=np.complex128)
+        mag_buffer = np.zeros(len(raw_data) // 2 + 1, dtype=np.float64)
+
+    if channel_mode == "Left":
+        work_buffer[:] = raw_data[:, 0]
+    elif channel_mode == "Right":
+        work_buffer[:] = raw_data[:, 1]
+    else:
+        np.add(raw_data[:, 0], raw_data[:, 1], out=work_buffer)
+        work_buffer *= 0.5
+
+    # Windowing
+    # Note: Benchmark reuses window, safe as it's read-only
+    work_buffer *= window
+
+    win_correction = 1.0 / np.mean(window)
+
+    # FFT
+    fft_manager.rfft(work_buffer, out=fft_out_buffer)
+
+    # Magnitude
+    np.abs(fft_out_buffer, out=mag_buffer)
+
+    # Normalize
+    mag_buffer *= (2.0 * win_correction) / len(work_buffer)
+
+    # dB
+    with np.errstate(divide="ignore"):
+        np.add(mag_buffer, 1e-12, out=mag_buffer)
+        np.log10(mag_buffer, out=mag_buffer)
+        np.multiply(mag_buffer, 20, out=mag_buffer)
+
+    return mag_buffer
+
+def benchmark_scenario(mode, name):
+    raw_data, window = setup_data()
+
+    # Warmup
+    work_buffer = np.zeros(FFT_SIZE, dtype=np.float64)
+    fft_out_buffer = np.zeros(FFT_SIZE // 2 + 1, dtype=np.complex128)
+    mag_buffer = np.zeros(FFT_SIZE // 2 + 1, dtype=np.float64)
+
+    # Measure Current
+    start_time = time.perf_counter()
+    for _ in range(ITERATIONS):
+        run_current_implementation(raw_data, window, mode)
+    current_time = time.perf_counter() - start_time
+
+    # Measure Optimized
+    start_time = time.perf_counter()
+    for _ in range(ITERATIONS):
+        run_optimized_implementation(raw_data, window, mode, work_buffer, fft_out_buffer, mag_buffer)
+    optimized_time = time.perf_counter() - start_time
+
+    print(f"\nScenario: {name}")
+    print(f"Current Time:   {current_time:.6f}s")
+    print(f"Optimized Time: {optimized_time:.6f}s")
+    print(f"Improvement:    {(current_time - optimized_time) / current_time * 100:.2f}%")
+
+if __name__ == "__main__":
+    print(f"Benchmarking Spectrogram Full Pipeline (Size={FFT_SIZE}, Iterations={ITERATIONS})")
+    benchmark_scenario("Left", "Left Channel (View)")
+    benchmark_scenario("Average", "Average Channel (Calc)")


### PR DESCRIPTION
This PR optimizes the critical path in `SpectrogramWidget.update_spectrogram` by eliminating redundant NumPy array allocations.

**Changes:**
1.  **Pre-allocated Buffers:** Added `work_buffer`, `fft_out_buffer`, and `mag_buffer` to `Spectrogram` class, initialized in `reset_buffers()`.
2.  **In-place Operations:** Refactored `update_spectrogram` to use these buffers with `out` parameters and in-place operators (`*=`) for:
    *   Channel averaging
    *   Window application
    *   FFT calculation (via `fft_manager.rfft`'s `out` parameter)
    *   Magnitude calculation (`np.abs`)
    *   Normalization and dB conversion
3.  **Buffer Management:** Updated `Spectrogram.__init__` to call `reset_buffers()` for consistent initialization.

**Performance:**
A benchmark (`tests/benchmarks/benchmark_spectrogram_windowing.py`) demonstrates:
*   **Average Channel:** ~46% improvement (0.21s -> 0.11s for 1000 iter).
*   **Left Channel:** ~5% improvement.

Verified with existing `tests/logic_verification/test_spectrogram_buffer.py` to ensure ring buffer logic remains intact.

---
*PR created automatically by Jules for task [11368025847002867459](https://jules.google.com/task/11368025847002867459) started by @youtube-at-vach*