### PR TITLE
Fix crash in filter methods when signal is too short

### DIFF
--- a/src/core/analysis.py
+++ b/src/core/analysis.py
@@ -91,6 +91,10 @@ class AudioCalc:
 
     @staticmethod
     def bandpass_filter(signal, sampling_rate, lowcut=20.0, highcut=20000.0):
+        # Check signal length to ensure padding works (3 * (2 * 8 + 1) = 51)
+        if len(signal) <= 51:
+            return signal
+
         nyquist = 0.5 * sampling_rate
         # Ensure valid bounds
         lowcut = max(0.1, lowcut)
@@ -105,6 +109,10 @@ class AudioCalc:
 
     @staticmethod
     def lowpass_filter(signal, sampling_rate, cutoff=20000.0):
+        # Check signal length to ensure padding works (3 * (2 * 4 + 1) = 27)
+        if len(signal) <= 27:
+            return signal
+
         nyquist = 0.5 * sampling_rate
         cutoff = min(nyquist - 1, max(0.1, cutoff))
         sos = _get_butter_sos(8, cutoff, "lowpass", fs=sampling_rate)
@@ -112,6 +120,10 @@ class AudioCalc:
 
     @staticmethod
     def highpass_filter(signal, sampling_rate, cutoff=20.0):
+        # Check signal length to ensure padding works (3 * (2 * 4 + 1) = 27)
+        if len(signal) <= 27:
+            return signal
+
         nyquist = 0.5 * sampling_rate
         cutoff = min(nyquist - 1, max(0.1, cutoff))
         sos = _get_butter_sos(8, cutoff / nyquist, "highpass")
@@ -119,6 +131,10 @@ class AudioCalc:
 
     @staticmethod
     def notch_filter(signal, sampling_rate, target_frequency, quality_factor=30):
+        # Check signal length to ensure padding works (3 * (2 * 2 + 1) = 15)
+        if len(signal) <= 15:
+            return signal
+
         nyquist = 0.5 * sampling_rate
         w0 = target_frequency / nyquist
         bandwidth = w0 / quality_factor


### PR DESCRIPTION
The `lowpass_filter`, `highpass_filter`, `bandpass_filter`, and `notch_filter` methods in `AudioCalc` used `scipy.signal.sosfiltfilt` which requires a minimum signal length for padding (typically 3 * (2 * sections + 1)). For short signals, this would cause a ValueError.

This commit adds checks to these methods to return the original signal if it is shorter than the required padding length.

- `lowpass_filter`/`highpass_filter` (order 8 -> 4 sections): Check `len(signal) <= 27`
- `bandpass_filter` (order 8 -> 8 sections): Check `len(signal) <= 51`
- `notch_filter` (order 2 bandstop -> 2 sections): Check `len(signal) <= 15`

---
*PR created automatically by Jules for task [4646325559470185171](https://jules.google.com/task/4646325559470185171) started by @youtube-at-vach*