### PR TITLE
⚡ Optimize allocations in frequency analysis loop

### DIFF
--- a/src/core/analysis.py
+++ b/src/core/analysis.py
@@ -145,6 +145,11 @@ class AudioCalc:
         M = np.empty((N, 3), dtype=t.dtype)
         M[:, 2] = 1.0  # The 'ones' column is constant
 
+        # Pre-allocate working buffers for fitting to avoid loop allocations
+        # These are reused in every iteration of get_residual_rms
+        fitted_buffer = np.empty(N, dtype=t.dtype)
+        residual_buffer = np.empty(N, dtype=t.dtype)
+
         def get_residual_rms(f):
             w = 2 * np.pi * f
 
@@ -162,9 +167,15 @@ class AudioCalc:
                 # Fallback to lstsq if matrix is singular (unlikely unless w=0)
                 coeffs, _, _, _ = np.linalg.lstsq(M, signal, rcond=None)
 
-            fitted = M @ coeffs
-            residual = signal - fitted
-            return np.sqrt(np.mean(residual**2))
+            # Use out parameter to avoid allocation: fitted = M @ coeffs
+            np.matmul(M, coeffs, out=fitted_buffer)
+
+            # Use out parameter to avoid allocation: residual = signal - fitted
+            np.subtract(signal, fitted_buffer, out=residual_buffer)
+
+            # Square in-place (safe because residual_buffer is our disposable buffer)
+            np.square(residual_buffer, out=residual_buffer)
+            return np.sqrt(np.mean(residual_buffer))
 
         # Search around guess
         # The objective function has local minima spaced by approx sampling_rate/N.


### PR DESCRIPTION
Optimized `AudioCalc.optimize_frequency` to reduce memory allocations during the iterative sine fitting process.

**Changes:**
- Pre-allocated `fitted_buffer` and `residual_buffer` arrays outside the `get_residual_rms` function.
- Replaced infix operators with `np.matmul`, `np.subtract`, and `np.square` utilizing `out=` parameters to target the pre-allocated buffers.
- Verified correctness with existing tests (`test_analysis_correctness.py`, `test_thd_calculation.py`, etc.).
- Micro-benchmark indicates approximately 10% performance improvement in the core calculation logic by avoiding repeated array creations.

---
*PR created automatically by Jules for task [11386073026592606842](https://jules.google.com/task/11386073026592606842) started by @youtube-at-vach*