### PR TITLE
🔒 Document and Verify Secure Wisdom Persistence

### DIFF
--- a/src/core/fft_manager.py
+++ b/src/core/fft_manager.py
@@ -41,6 +41,7 @@ class FFTManager:
 
         # Store wisdom in XDG compliant user data directory
         # This fixes the issue where wisdom cannot be saved in read-only AppImage environments
+        # We also use JSON with Base64 encoding instead of pickle for security (prevents arbitrary code execution)
         xdg_data_home = os.environ.get("XDG_DATA_HOME")
         if not xdg_data_home:
             xdg_data_home = os.path.join(os.path.expanduser("~"), ".local", "share")
@@ -62,6 +63,7 @@ class FFTManager:
 
         if self.wisdom_path.exists():
             try:
+                # Use JSON + Base64 to safely load wisdom (avoids pickle deserialization vulnerabilities)
                 with open(self.wisdom_path, "r") as f:
                     data = json.load(f)
 

--- a/tests/test_wisdom_security.py
+++ b/tests/test_wisdom_security.py
@@ -98,5 +98,26 @@ class TestWisdomSecurity(unittest.TestCase):
         # And verify import_wisdom was NOT called (since it was legacy data)
         self.mock_pyfftw.import_wisdom.assert_not_called()
 
+    def test_malicious_pickle_ignored(self):
+        """Test that a malicious pickle payload is rejected and not executed."""
+        # Create a mock malicious class
+        class Malicious:
+            def __reduce__(self):
+                # This would execute if unpickled
+                return (os.system, ('echo malicious code executed',))
+
+        # Create a malicious pickle file
+        with open(self.manager.wisdom_path, "wb") as f:
+            pickle.dump(Malicious(), f)
+
+        # Ensure load_wisdom doesn't crash on this file
+        try:
+            self.manager.load_wisdom()
+        except Exception as e:
+            self.fail(f"load_wisdom crashed on malicious pickle file: {e}")
+
+        # And verify import_wisdom was NOT called
+        self.mock_pyfftw.import_wisdom.assert_not_called()
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
🎯 **What:** Verified that `src/core/fft_manager.py` uses JSON/Base64 for wisdom persistence instead of insecure `pickle`.
⚠️ **Risk:** `pickle` deserialization can lead to arbitrary code execution.
🛡️ **Solution:**
- Added explicit documentation in `src/core/fft_manager.py` confirming the use of JSON/Base64 for security.
- Enhanced `tests/test_wisdom_security.py` with a new test case `test_malicious_pickle_ignored` that attempts to load a malicious pickle payload, verifying that the JSON loader safely rejects it without execution.
- Confirmed that the existing code ignores legacy pickle files safely.

---
*PR created automatically by Jules for task [10864513793719832822](https://jules.google.com/task/10864513793719832822) started by @youtube-at-vach*