### PR TITLE
docs: Add SECURITY.md and link from CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,6 +141,12 @@ Open a PR on GitHub. In the description, briefly explain:
 
 ---
 
+## 🛡️ Security
+
+For information on how to report security vulnerabilities, please see our [Security Policy](<SECURITY.md>).
+
+---
+
 ## 📜 Coding Standards
 
 - **Style:** We follow PEP 8 and use `ruff` for linting.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| :-----: | :----------------: |
+| 0.4.x   | :white_check_mark: |
+| < 0.4   |        :x:         |
+
+## Reporting a Vulnerability
+
+We take the security of this project seriously. If you find any security vulnerability, please report it as an issue on GitHub.
+
+1. Open an issue in the [MeasureLab repository](<https://github.com/youtube-at-vach/MeasureLab>).
+2. **Do not include sensitive details or reproduction steps in the public issue.**
+3. Instead, simply state that you found a potential security vulnerability and request a private communication channel.
+4. We will acknowledge your request and provide a way to share the details securely.
+
+We will work to address the issue as soon as possible.


### PR DESCRIPTION
This PR addresses the missing security policy issue by adding a `SECURITY.md` file and linking to it from `CONTRIBUTING.md`.

## Changes
- **SECURITY.md**: created with supported versions (0.4.x) and reporting instructions.
  - Explicitly warns users **not** to include sensitive details in public issues.
  - Instructs users to open an issue to request a private communication channel.
- **CONTRIBUTING.md**: Added a "Security" section linking to the new policy.

## Verification
- Ran `npx markdownlint-cli2 SECURITY.md CONTRIBUTING.md` to ensure style compliance.
- Verified correct placement of the new section in `CONTRIBUTING.md`.

---
*PR created automatically by Jules for task [15405720350625255843](https://jules.google.com/task/15405720350625255843) started by @youtube-at-vach*