### PR TITLE
🔒 Fix path traversal vulnerability in ConfigManager

### DIFF
--- a/src/core/config_manager.py
+++ b/src/core/config_manager.py
@@ -170,9 +170,10 @@ class ConfigManager:
 
     def _resolve_path(self, path_value: str) -> str:
         if os.path.isabs(path_value):
-            return path_value
+            full_path = os.path.abspath(path_value)
+        else:
+            full_path = os.path.abspath(os.path.join(self.config_dir, path_value))
 
-        full_path = os.path.abspath(os.path.join(self.config_dir, path_value))
         base_dir = os.path.abspath(self.config_dir)
 
         try:

--- a/tests/security/test_config_traversal.py
+++ b/tests/security/test_config_traversal.py
@@ -57,14 +57,14 @@ def test_screenshot_path_traversal():
             if os.path.exists(target_path):
                 shutil.rmtree(target_path)
 
-def test_absolute_path_allowed():
+def test_absolute_path_rejected():
     """
-    Verifies that absolute paths are still allowed (as per design decision).
+    Verifies that absolute paths pointing outside the config directory are rejected.
     """
     with tempfile.TemporaryDirectory() as temp_dir:
         config_file = os.path.join(temp_dir, "config.json")
 
-        # Create a safe target directory inside another temp dir
+        # Create a target directory in a separate location
         with tempfile.TemporaryDirectory() as abs_target_dir:
             config_data = {
                 "screenshot": {
@@ -77,6 +77,11 @@ def test_absolute_path_allowed():
 
             cm = ConfigManager(config_path=config_file)
 
-            # Should be allowed
+            # Should default to "screenshots" in config dir because abs_target_dir is outside temp_dir
             actual_dir = cm.get_screenshot_output_dir()
-            assert os.path.abspath(actual_dir) == os.path.abspath(abs_target_dir)
+
+            # The fallback path
+            expected_fallback = os.path.join(temp_dir, "screenshots")
+
+            assert os.path.abspath(actual_dir) == os.path.abspath(expected_fallback)
+            assert os.path.abspath(actual_dir) != os.path.abspath(abs_target_dir)


### PR DESCRIPTION
🎯 **What:** Fixed a path traversal vulnerability in `src/core/config_manager.py`.
⚠️ **Risk:** Previously, providing an absolute path in the configuration allowed bypassing the directory confinement check, potentially allowing read/write access to arbitrary files outside the intended sandbox.
🛡️ **Solution:** Updated `_resolve_path` to normalize all paths and validate them against `self.config_dir` using `os.path.commonpath`. Absolute paths are no longer automatically accepted; they are checked to ensuring they reside within the allowed directory. Updated tests to confirm this behavior.

---
*PR created automatically by Jules for task [12445819990347143755](https://jules.google.com/task/12445819990347143755) started by @youtube-at-vach*