### PR TITLE
⚡ Optimize memory allocation in AudioEngine 'right' channel fallback

### DIFF
--- a/src/core/audio_engine.py
+++ b/src/core/audio_engine.py
@@ -241,7 +241,12 @@ class AudioEngine:
                     if indata.shape[1] >= 2:
                         logical_in = indata[:, 1:2]
                     else:
-                        logical_in = np.zeros((frames, 1))
+                        buf = self._logical_in_buffer
+                        if buf is None or buf.shape != (frames, 1):
+                            buf = np.zeros((frames, 1), dtype="float32")
+                            self._logical_in_buffer = buf
+                        logical_in = buf
+                        logical_in.fill(0)
                 else:  # stereo
                     logical_in = indata[:, 0:2]
 

--- a/tests/benchmarks/benchmark_audio_allocation.py
+++ b/tests/benchmarks/benchmark_audio_allocation.py
@@ -1,0 +1,94 @@
+import time
+import numpy as np
+import unittest.mock as mock
+import sys
+
+# Mock sounddevice
+mock_sd = mock.MagicMock()
+mock_sd.CallbackFlags = lambda: 0
+sys.modules["sounddevice"] = mock_sd
+
+from src.core.audio_engine import AudioEngine  # noqa: E402
+
+def benchmark_audio_allocation():
+    engine = AudioEngine()
+    engine.input_channel_mode = "right"
+    # Ensure loopback is false to hit the else block
+    engine.loopback = False
+
+    # We need to trigger _start_master_stream to get the internal master_callback
+    # Since we mocked sd.Stream, this is safe
+    engine._start_master_stream()
+
+    # Retrieve the callback passed to sd.Stream
+    # engine.stream should be the mock return value
+    # But wait, sd.Stream is a class.
+    # mock_sd.Stream(...) returns the stream instance.
+
+    # The call arguments to sd.Stream constructor:
+    call_args = mock_sd.Stream.call_args
+    if not call_args:
+        print("Error: sd.Stream was not called.")
+        return
+
+    kwargs = call_args[1]
+    master_callback = kwargs.get("callback")
+
+    if not master_callback:
+        print("Error: Could not find master_callback in sd.Stream arguments.")
+        return
+
+    # Prepare data for benchmark
+    frames = 1024
+    # indata with 1 channel to trigger the allocation path
+    indata_1ch = np.zeros((frames, 1), dtype="float32")
+    outdata = np.zeros((frames, 2), dtype="float32")
+    status = 0
+
+    iterations = 100000
+
+    print("Benchmarking 'right' channel mode with 1-channel input (allocating path)...")
+
+    start_time = time.perf_counter()
+    for _ in range(iterations):
+        master_callback(indata_1ch, outdata, frames, 0.0, status)
+    end_time = time.perf_counter()
+
+    duration = end_time - start_time
+    print(f"Duration for {iterations} iterations: {duration:.4f} s")
+    print(f"Average time per callback: {duration/iterations*1e6:.2f} us")
+
+    # Verify that the allocation path is actually being hit?
+    # We can inspect if _logical_in_buffer is being used or not (it shouldn't be in the current code)
+    # The current code doesn't use _logical_in_buffer for this path, so it allocates.
+
+    # Let's also benchmark the "good" path (e.g. stereo input) for comparison
+    engine.input_channel_mode = "stereo"
+    # Need to get a new callback or restart stream?
+    # Changing input_channel_mode in engine changes `in_mode` used in `master_callback`?
+    # NO. `in_mode` is a local variable captured at definition time in `_start_master_stream`.
+    #   in_mode = self.input_channel_mode
+    # So we need to restart the stream to test another mode.
+
+    engine.stop_stream()
+    engine.input_channel_mode = "stereo"
+    engine._start_master_stream()
+
+    call_args = mock_sd.Stream.call_args
+    master_callback_stereo = call_args[1].get("callback")
+
+    indata_2ch = np.zeros((frames, 2), dtype="float32")
+
+    print("Benchmarking 'stereo' channel mode (no allocation path)...")
+    start_time = time.perf_counter()
+    for _ in range(iterations):
+        master_callback_stereo(indata_2ch, outdata, frames, 0.0, status)
+    end_time = time.perf_counter()
+
+    duration_stereo = end_time - start_time
+    print(f"Duration for {iterations} iterations: {duration_stereo:.4f} s")
+    print(f"Average time per callback: {duration_stereo/iterations*1e6:.2f} us")
+
+
+if __name__ == "__main__":
+    benchmark_audio_allocation()


### PR DESCRIPTION
💡 **What:**
The `master_callback` in `AudioEngine` was allocating a new NumPy array (`np.zeros`) every callback cycle when the input mode was set to "right" and the hardware input had fewer than 2 channels (e.g., mono input). This change reuses the existing `self._logical_in_buffer` (initialized in `__init__`) for this purpose.

🎯 **Why:**
Memory allocation in real-time audio callbacks is a performance anti-pattern. While the raw CPU time for `np.zeros` is small, the allocation creates garbage which eventually triggers the Python Garbage Collector. GC pauses can cause non-deterministic audio dropouts. By reusing a pre-allocated buffer, we eliminate this source of GC pressure.

📊 **Measured Improvement:**
A benchmark was added (`tests/benchmarks/benchmark_audio_allocation.py`).
- **Baseline (Allocation):** ~2.20 us per callback
- **Optimized (Reuse):** ~2.34 us per callback

*Note:* The raw CPU time increased slightly (~0.14 us) due to Python attribute lookup overhead being slightly higher than the highly optimized C-implementation of `np.zeros`. However, the primary goal of this optimization is **latency stability** (zero allocation) rather than raw throughput. The elimination of GC pressure is the critical improvement for real-time reliability.

*Verification:*
- Verified that `self._logical_in_buffer` is initialized to `None` in `AudioEngine.__init__`.
- Verified that the logic correctly reuses the buffer and zeroes it out.
- Ran existing tests (`test_audio_engine_logic.py`, `test_audio_error_handling.py`) which passed.


---
*PR created automatically by Jules for task [5253068185070612710](https://jules.google.com/task/5253068185070612710) started by @youtube-at-vach*