### PR TITLE
Fix missing error signal in NoiseAnalysisWorker

### DIFF
--- a/src/gui/widgets/noise_profiler.py
+++ b/src/gui/widgets/noise_profiler.py
@@ -208,6 +208,7 @@ class NoiseProfiler(MeasurementModule):
 class NoiseAnalysisSignals(QObject):
     # freqs, avg_mag_cal, results, raw_avg, unit_mode
     result = pyqtSignal(object, object, object, object, str)
+    error = pyqtSignal(str)
     finished = pyqtSignal()
 
 
@@ -230,6 +231,7 @@ class NoiseAnalysisWorker(QRunnable):
             # We should probably log this or handle it, but for now we just don't emit
             print(f"Error in NoiseAnalysisWorker: {e}")
             traceback.print_exc()
+            self.signals.error.emit(str(e))
         finally:
             self.signals.finished.emit()
 


### PR DESCRIPTION
Found a bug where `NoiseAnalysisWorker` in `src/gui/widgets/noise_profiler.py` caught exceptions but only printed them to stdout without emitting an error signal to the UI.

Fixed by:
1.  Adding `error = pyqtSignal(str)` to `NoiseAnalysisSignals`.
2.  Emitting `self.signals.error.emit(str(e))` in the `except` block of `NoiseAnalysisWorker.run`.

---
*PR created automatically by Jules for task [3162278459153021078](https://jules.google.com/task/3162278459153021078) started by @youtube-at-vach*