### PR TITLE
🧹 Remove redundant assignment in NetworkAnalyzer

### DIFF
--- a/src/gui/widgets/network_analyzer.py
+++ b/src/gui/widgets/network_analyzer.py
@@ -142,7 +142,6 @@ class NetworkAnalyzer(MeasurementModule):
         self.start_freq = 20.0
         self.end_freq = 20000.0
         self.steps_per_octave = 12
-        self.steps_per_octave = 12
         self.amplitude = 0.5
         self.gen_unit = "Amplitude"  # 'Amplitude', 'dBFS', 'dBV', 'dBu', 'Vrms', 'Vpeak'
         self.duration_per_step = 0.5


### PR DESCRIPTION
🎯 **What:** Removed a redundant assignment of `self.steps_per_octave` in `src/gui/widgets/network_analyzer.py`.
💡 **Why:** The variable was assigned the value `12` twice in consecutive lines. Removing the duplicate improves code readability and maintainability.
✅ **Verification:**
- Ran `pytest tests/functional/test_network_analyzer_xfer.py` to ensure `NetworkAnalyzer` instantiation and transfer mode logic remain functional.
- Ran `pytest tests/logic_verification/test_network_analyzer.py` to verify calculation logic.
- Both tests passed.
✨ **Result:** Cleaner code with no functional changes.

---
*PR created automatically by Jules for task [8687942151949991911](https://jules.google.com/task/8687942151949991911) started by @youtube-at-vach*