### PR TITLE
🧹 Remove unused calculation in Noise Profiler

### DIFF
--- a/src/gui/widgets/noise_profiler.py
+++ b/src/gui/widgets/noise_profiler.py
@@ -863,7 +863,6 @@ class NoiseProfilerWidget(QWidget):
                 white_volts = results["white_density"] * 10 ** (cal_offset / 20)
 
             white_density_in = white_volts / gain_linear
-        20 * np.log10(white_density_in + 1e-15)
 
         # Report Values (Display Units)
         hum_rms = results["hum_rms"]


### PR DESCRIPTION
Removed a dead code line in `NoiseProfilerWidget.update_report` that performed a logarithmic calculation on `white_density_in` without using the result. This improves code clarity and removes potential confusion.

---
*PR created automatically by Jules for task [2571790563513412435](https://jules.google.com/task/2571790563513412435) started by @youtube-at-vach*