### PR TITLE
refactor: Remove duplicate variable initialization in NetworkAnalyzer

### DIFF
--- a/src/gui/widgets/network_analyzer.py
+++ b/src/gui/widgets/network_analyzer.py
@@ -202,8 +202,6 @@ class NetworkAnalyzer(MeasurementModule):
 
         t = np.linspace(0, duration, int(sample_rate * duration), endpoint=False)
         chirp = scipy.signal.chirp(t, f0=20, t1=duration, f1=10000, method="logarithmic")
-        t = np.linspace(0, duration, int(sample_rate * duration), endpoint=False)
-        chirp = scipy.signal.chirp(t, f0=20, t1=duration, f1=10000, method="logarithmic")
         chirp *= self.get_output_amplitude()
 
         try:


### PR DESCRIPTION
Removed duplicate variable initialization in `src/gui/widgets/network_analyzer.py`. The variables `t` and `chirp` were being assigned twice with the same values, which was redundant. This cleanup improves code maintainability and removes a small amount of unnecessary computation. Verified that the `calibrate_latency` method still functions correctly without errors.

---
*PR created automatically by Jules for task [1953492202632345775](https://jules.google.com/task/1953492202632345775) started by @youtube-at-vach*