### PR TITLE
🧹 Remove commented-out debug code in localization.py

### DIFF
--- a/src/core/localization.py
+++ b/src/core/localization.py
@@ -37,7 +37,6 @@ class LocalizationManager:
 
     def load_language(self, lang_code):
         if lang_code not in self.available_languages:
-            # print(f"Language {lang_code} not found, falling back to en")
             lang_code = "en"
 
         self.language = lang_code


### PR DESCRIPTION
Removed a commented-out debug print statement in `src/core/localization.py` to improve code health. Verified that the removal does not affect the localization logic by running existing tests.

---
*PR created automatically by Jules for task [5655122462695664956](https://jules.google.com/task/5655122462695664956) started by @youtube-at-vach*