### PR TITLE
🧹 Remove deprecated AudioEngine.start_stream method

### DIFF
--- a/src/core/audio_engine.py
+++ b/src/core/audio_engine.py
@@ -401,17 +401,3 @@ class AudioEngine:
             "last_error": last_error,
         }
 
-    # Legacy method support (deprecated but kept for compatibility during transition if needed)
-    def start_stream(self, callback, channels=2):
-        """
-        Deprecated: Use register_callback instead.
-        This acts as a wrapper for single-client usage.
-        """
-        self.logger.warning("start_stream is deprecated. Use register_callback.")
-        # Stop any existing stream/callbacks to mimic exclusive behavior
-        self.stop_stream()
-        with self.lock:
-            self.callbacks.clear()
-            self._cached_callbacks = []
-
-        self.register_callback(callback)

--- a/tests/functional/test_audio_engine.py
+++ b/tests/functional/test_audio_engine.py
@@ -67,7 +67,7 @@ class TestAudioEngine(unittest.TestCase):
                 print(f"Callback: Out Max={np.max(np.abs(outdata))}, In Max={np.max(np.abs(indata))}")
 
         # Start stream with 2 channels
-        self.engine.start_stream(callback, channels=2)
+        self.engine.register_callback(callback)
         time.sleep(1.0) # Run for 1 second
         self.engine.stop_stream()
 


### PR DESCRIPTION
Removed the deprecated `start_stream` method from `src/core/audio_engine.py`.
Updated the functional test `tests/functional/test_audio_engine.py` to use the replacement method `register_callback`.
Verified that core logic remains intact and tests pass.
This improves code health by removing unused legacy code.

---
*PR created automatically by Jules for task [10635383508995990274](https://jules.google.com/task/10635383508995990274) started by @youtube-at-vach*