### PR TITLE
Fix: Restart audio stream when channel mode changes

### DIFF
--- a/src/core/audio_engine.py
+++ b/src/core/audio_engine.py
@@ -149,6 +149,8 @@ class AudioEngine:
         self.logger.info(f"Set channel modes: Input={input_mode}, Output={output_mode}")
         # Note: Changing channel mode might affect active callbacks if they expect specific mapping.
         # For now, we assume global mode applies to the master stream.
+        if self.is_active():
+            self._restart_stream()
 
     def register_callback(self, callback):
         """

--- a/tests/logic_verification/test_audio_engine_logic.py
+++ b/tests/logic_verification/test_audio_engine_logic.py
@@ -68,5 +68,30 @@ class TestAudioEngineLogic(unittest.TestCase):
 
         self.assertFalse(found_log, "Should not log unregister for non-existent callback")
 
+    def test_set_channel_mode_restarts_stream(self):
+        # Setup: stream is active
+        self.engine.stream.active = True
+
+        # Mock _restart_stream to verify it's called
+        self.engine._restart_stream = MagicMock()
+
+        self.engine.set_channel_mode("left", "right")
+
+        self.engine._restart_stream.assert_called_once()
+        self.assertEqual(self.engine.input_channel_mode, "left")
+        self.assertEqual(self.engine.output_channel_mode, "right")
+
+    def test_set_channel_mode_no_restart_if_inactive(self):
+        # Setup: stream is NOT active
+        self.engine.stream = None
+
+        self.engine._restart_stream = MagicMock()
+
+        self.engine.set_channel_mode("left", "right")
+
+        self.engine._restart_stream.assert_not_called()
+        self.assertEqual(self.engine.input_channel_mode, "left")
+        self.assertEqual(self.engine.output_channel_mode, "right")
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes a bug where changing the input/output channel mode in `AudioEngine` did not take effect if the stream was already running. The fix involves checking if the stream is active in `set_channel_mode` and restarting it if necessary. Added regression tests to verify the fix.

---
*PR created automatically by Jules for task [13118240090504954943](https://jules.google.com/task/13118240090504954943) started by @youtube-at-vach*