### PR TITLE
🧪 Add tests for AudioCalc.bandpass_filter

### DIFF
--- a/tests/logic_verification/test_analysis_filters.py
+++ b/tests/logic_verification/test_analysis_filters.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 from src.core.analysis import AudioCalc
 
 def test_bandpass_filter_short_signal():


### PR DESCRIPTION
This PR adds unit tests for the `AudioCalc.bandpass_filter` method in `src/core/analysis.py`.
The tests cover:
- Short signal handling (`len(signal) <= 51`).
- Filter efficacy (attenuation of stopband, preservation of passband).
- Invalid parameter handling (e.g., `lowcut >= highcut`, `highcut > nyquist`).

Tests are located in `tests/logic_verification/test_analysis_filters.py`.

---
*PR created automatically by Jules for task [5160727138557850265](https://jules.google.com/task/5160727138557850265) started by @youtube-at-vach*