### PR TITLE
Refactor device selection logic in MainWindow to reduce duplication

### DIFF
--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from PyQt6.QtCore import QTimer
 from PyQt6.QtWidgets import (
     QApplication,
@@ -362,7 +364,7 @@ class MainWindow(QMainWindow):
         # Sync output destination control with engine state on startup
         self._sync_output_destination_ui(self._get_engine_output_destination(), propagate=True)
 
-    def _find_device_id(self, devices: list, name: str, hostapi: str, is_input: bool) -> int | None:
+    def _find_device_id(self, devices: list, name: str, hostapi: str, is_input: bool) -> Optional[int]:
         """Find device ID by name and hostapi, with fallback to name only."""
         if not name:
             return None

--- a/tests/logic_verification/test_main_window_device_selection.py
+++ b/tests/logic_verification/test_main_window_device_selection.py
@@ -1,12 +1,12 @@
 import sys
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 # -------------------------------------------------------------------------
 # MOCKING DEPENDENCIES
 # -------------------------------------------------------------------------
-# We need to mock PyQt6 and other heavy dependencies to load MainWindow
-# without a GUI environment.
+# We mock PyQt6 and other heavy dependencies to load MainWindow
+# without a GUI environment. But we do this inside a patch to avoid global pollution.
 
 class MockQMainWindow:
     def __init__(self, *args, **kwargs):
@@ -29,96 +29,99 @@ qt_widgets.QStatusBar = MagicMock
 qt_widgets.QLabel = MagicMock
 qt_widgets.QComboBox = MagicMock
 
-sys.modules["PyQt6"] = MagicMock()
-sys.modules["PyQt6.QtCore"] = MagicMock()
-sys.modules["PyQt6.QtWidgets"] = qt_widgets
-sys.modules["numpy"] = MagicMock()
-sys.modules["scipy"] = MagicMock()
-sys.modules["sounddevice"] = MagicMock()
-
-# Mock internal modules
-sys.modules["src.core.audio_engine"] = MagicMock()
-sys.modules["src.core.config_manager"] = MagicMock()
-sys.modules["src.core.localization"] = MagicMock()
-sys.modules["src.core.theme_manager"] = MagicMock()
-sys.modules["src.gui.widgets.detachable_wrapper"] = MagicMock()
-
-# -------------------------------------------------------------------------
-# IMPORT
-# -------------------------------------------------------------------------
-try:
-    from src.gui.main_window import MainWindow
-except ImportError as e:
-    print(f"Failed to import MainWindow: {e}")
-    MainWindow = None
+mock_audio_engine = MagicMock()
+mock_config_manager = MagicMock()
+mock_localization = MagicMock()
+mock_theme_manager = MagicMock()
+mock_detachable = MagicMock()
 
 class TestMainWindowDeviceSelection(unittest.TestCase):
-    def setUp(self):
-        if MainWindow is None:
-            self.skipTest("MainWindow could not be imported")
-
-        # We don't instantiate MainWindow because __init__ does a lot.
-        # We just want to test the helper method which should be pure logic.
-        # But we need an instance or class to call the method if it's an instance method.
-        # Since we are refactoring, we can just test the method by attaching it to a dummy
-        # or calling it as unbound method if possible, or instantiating a mocked MainWindow.
-
-        # Let's instantiate a minimal MainWindow if possible, or just mock __init__
-        pass
-
     def test_find_device_id_logic(self):
         """
-        Since we haven't implemented the method in MainWindow yet,
-        we define the expected logic here to verify our test expectations,
-        and then we will verify it calls the method on MainWindow once implemented.
+        Verify the device selection logic in _find_device_id.
         """
 
-        devices = [
-            {"name": "Built-in Mic", "hostapi_name": "Core Audio", "max_input_channels": 2, "max_output_channels": 0},
-            {"name": "Built-in Output", "hostapi_name": "Core Audio", "max_input_channels": 0, "max_output_channels": 2},
-            {"name": "USB Audio", "hostapi_name": "Core Audio", "max_input_channels": 2, "max_output_channels": 2},
-            {"name": "USB Audio", "hostapi_name": "ASIO", "max_input_channels": 2, "max_output_channels": 2},
-        ]
+        # Patch modules needed by MainWindow.
+        # We do NOT patch numpy or scipy here, letting them be real if available.
+        modules_to_patch = {
+            "PyQt6": MagicMock(),
+            "PyQt6.QtCore": MagicMock(),
+            "PyQt6.QtWidgets": qt_widgets,
+            "src.core.audio_engine": mock_audio_engine,
+            "src.core.config_manager": mock_config_manager,
+            "src.core.localization": mock_localization,
+            "src.core.theme_manager": mock_theme_manager,
+            "src.gui.widgets.detachable_wrapper": mock_detachable,
+        }
 
-        # Create an instance with the new method (simulating it) or access it if it exists
-        # For now, I'll use a local helper to verify my logic, then I'll use this test
-        # to verify the ACTUAL method after I apply the edit.
+        with patch.dict(sys.modules, modules_to_patch):
+            # Now we import MainWindow inside the patched context
+            try:
+                # We might need to reload if it was already imported?
+                # But typically in pytest, test files are imported sequentially.
+                # If MainWindow was already imported by another test, this import will return
+                # the existing module object which might have real dependencies if not cleared.
+                # However, since we are patching sys.modules, the import system sees our mocks
+                # for dependencies.
+                # The issue is if src.gui.main_window is already in sys.modules.
+                # To be safe, we can remove it first if it exists, or rely on patch.dict
+                # to shadow it if we were patching IT.
+                # But here we are patching its DEPENDENCIES.
+                # If src.gui.main_window is already imported, it holds references to the OLD
+                # (possibly real) dependencies.
+                # But here, we want to import it for the first time or force reload.
 
-        mw = MainWindow.__new__(MainWindow) # Skip __init__
+                if "src.gui.main_window" in sys.modules:
+                    del sys.modules["src.gui.main_window"]
 
-        # Check if method exists
-        if not hasattr(mw, "_find_device_id"):
-            self.fail("Method _find_device_id not found on MainWindow")
+                from src.gui.main_window import MainWindow
+            except ImportError as e:
+                self.fail(f"Failed to import MainWindow: {e}")
 
-        # Test Case 1: Strict Match Input
-        # Find "USB Audio" with "ASIO" (Input)
-        idx = mw._find_device_id(devices, "USB Audio", "ASIO", is_input=True)
-        self.assertEqual(idx, 3)
+            devices = [
+                {"name": "Built-in Mic", "hostapi_name": "Core Audio", "max_input_channels": 2, "max_output_channels": 0},
+                {"name": "Built-in Output", "hostapi_name": "Core Audio", "max_input_channels": 0, "max_output_channels": 2},
+                {"name": "USB Audio", "hostapi_name": "Core Audio", "max_input_channels": 2, "max_output_channels": 2},
+                {"name": "USB Audio", "hostapi_name": "ASIO", "max_input_channels": 2, "max_output_channels": 2},
+            ]
 
-        # Test Case 2: Strict Match Output
-        # Find "Built-in Output" with "Core Audio" (Output)
-        idx = mw._find_device_id(devices, "Built-in Output", "Core Audio", is_input=False)
-        self.assertEqual(idx, 1)
+            # Create an instance (mocked __init__ effectively due to mocked dependencies)
+            # Or use __new__ to bypass __init__ completely which is safer for logic testing.
+            mw = MainWindow.__new__(MainWindow)
 
-        # Test Case 3: Loose Match Input (HostAPI mismatch)
-        # Find "USB Audio" with "Unknown HostAPI". Should fall back to name match.
-        # It should find the first "USB Audio" that has input channels.
-        idx = mw._find_device_id(devices, "USB Audio", "Unknown HostAPI", is_input=True)
-        self.assertEqual(idx, 2) # Index 2 is Core Audio USB Audio (first match)
+            # Check if method exists
+            if not hasattr(mw, "_find_device_id"):
+                self.fail("Method _find_device_id not found on MainWindow")
 
-        # Test Case 4: Wrong Capability
-        # Find "Built-in Mic" as Output. Should be None.
-        idx = mw._find_device_id(devices, "Built-in Mic", "Core Audio", is_input=False)
-        self.assertIsNone(idx)
+            # Test Case 1: Strict Match Input
+            # Find "USB Audio" with "ASIO" (Input)
+            idx = mw._find_device_id(devices, "USB Audio", "ASIO", is_input=True)
+            self.assertEqual(idx, 3)
 
-        # Test Case 5: Name mismatch
-        idx = mw._find_device_id(devices, "Nonexistent", None, is_input=True)
-        self.assertIsNone(idx)
+            # Test Case 2: Strict Match Output
+            # Find "Built-in Output" with "Core Audio" (Output)
+            idx = mw._find_device_id(devices, "Built-in Output", "Core Audio", is_input=False)
+            self.assertEqual(idx, 1)
 
-        # Test Case 6: No HostAPI provided (Strict match on name only)
-        # Find "USB Audio", any host api.
-        idx = mw._find_device_id(devices, "USB Audio", None, is_input=True)
-        self.assertEqual(idx, 2)
+            # Test Case 3: Loose Match Input (HostAPI mismatch)
+            # Find "USB Audio" with "Unknown HostAPI". Should fall back to name match.
+            # It should find the first "USB Audio" that has input channels.
+            idx = mw._find_device_id(devices, "USB Audio", "Unknown HostAPI", is_input=True)
+            self.assertEqual(idx, 2) # Index 2 is Core Audio USB Audio (first match)
+
+            # Test Case 4: Wrong Capability
+            # Find "Built-in Mic" as Output. Should be None.
+            idx = mw._find_device_id(devices, "Built-in Mic", "Core Audio", is_input=False)
+            self.assertIsNone(idx)
+
+            # Test Case 5: Name mismatch
+            idx = mw._find_device_id(devices, "Nonexistent", None, is_input=True)
+            self.assertIsNone(idx)
+
+            # Test Case 6: No HostAPI provided (Strict match on name only)
+            # Find "USB Audio", any host api.
+            idx = mw._find_device_id(devices, "USB Audio", None, is_input=True)
+            self.assertEqual(idx, 2)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR refactors the device selection logic in `src/gui/main_window.py` to reduce code duplication and improve maintainability.

### Changes
- Introduced a private helper method `_find_device_id(devices, name, hostapi, is_input)` to encapsulate the logic for finding a device ID by name and HostAPI.
- Updated `MainWindow.__init__` to use this helper method instead of repeating the loop logic for input and output devices.
- The new method preserves the original prioritization:
    1.  **Strict Match:** Checks for both Device Name and HostAPI (if provided).
    2.  **Loose Match:** Falls back to matching only the Device Name if the strict match fails (only if HostAPI was provided).
- Added `tests/logic_verification/test_main_window_device_selection.py` to verify the logic with mocks, ensuring no regression in device selection behavior.

### Verification
- Ran the new test `pytest tests/logic_verification/test_main_window_device_selection.py`, which passed.
- The refactor maintains the existing behavior while cleaning up the code structure.

---
*PR created automatically by Jules for task [18356750289692435711](https://jules.google.com/task/18356750289692435711) started by @youtube-at-vach*