### PR TITLE
Remove unused audio_queue from Oscilloscope

### DIFF
--- a/src/gui/widgets/oscilloscope.py
+++ b/src/gui/widgets/oscilloscope.py
@@ -1,5 +1,4 @@
 import argparse
-import queue
 import threading
 
 import numpy as np
@@ -82,7 +81,6 @@ class Oscilloscope(MeasurementModule):
         self.transfer_read_count = 0
         self.transfer_lock = threading.Lock()
 
-        self.audio_queue = queue.Queue()  # Kept for compatibility if external access exists (unlikely), but unused internally
         self.callback_id = None
 
     @property


### PR DESCRIPTION
Removed `self.audio_queue = queue.Queue()` and `import queue` from `src/gui/widgets/oscilloscope.py`. These were legacy artifacts and not used by the current implementation which uses a transfer buffer.

Tests passed:
- `tests/functional/test_oscilloscope_queue.py`
- `tests/functional/test_oscilloscope_allocation.py`

---
*PR created automatically by Jules for task [3581060949812517316](https://jules.google.com/task/3581060949812517316) started by @youtube-at-vach*