### PR TITLE
Refactor VirtualStream error handling to use logging

### DIFF
--- a/src/core/audio_engine.py
+++ b/src/core/audio_engine.py
@@ -27,6 +27,7 @@ class VirtualStream:
         self.cpu_load = 0.0
         self._stop_event = threading.Event()
         self._thread = None
+        self.logger = logging.getLogger(__name__)
 
     def start(self):
         if self.active:
@@ -104,7 +105,7 @@ class VirtualStream:
                 # So we are good.
 
             except Exception as e:
-                print(f"VirtualStream Error: {e}")
+                self.logger.error(f"VirtualStream Error: {e}")
                 # Don't crash thread, just log
                 pass
 


### PR DESCRIPTION
Replaced `print` with `logging.error` in `VirtualStream._run_loop` to improve error handling and maintainability. Initialized `self.logger` in `VirtualStream` constructor. Verified with a reproduction script and existing tests.

---
*PR created automatically by Jules for task [8851147284351761734](https://jules.google.com/task/8851147284351761734) started by @youtube-at-vach*