### PR TITLE
🧹 Refactor dbfs_to_dbv in CalibrationManager

### DIFF
--- a/src/core/calibration.py
+++ b/src/core/calibration.py
@@ -199,7 +199,7 @@ class CalibrationManager:
         # Voltage = 10^(dBFS/20) * input_sensitivity
         # dBV = 20 * log10(10^(dBFS/20) * input_sensitivity)
         #     = dBFS + 20 * log10(input_sensitivity)
-        return dbfs + 20 * np.log10(self.input_sensitivity)
+        return dbfs + self.get_input_offset_db()
 
     def dbfs_to_volts(self, dbfs):
         """Converts dBFS to Volts (Peak)."""


### PR DESCRIPTION
🎯 **What:** Refactored `dbfs_to_dbv` in `src/core/calibration.py` to use `get_input_offset_db`.
💡 **Why:** To eliminate duplicated calculation of `20 * np.log10(self.input_sensitivity)` and ensure consistency in calibration logic.
✅ **Verification:**
- Ran `python -m pytest tests/test_calibration_manager.py` (Passed)
- Ran `python tests/logic_verification/test_calibration_manager_logic.py` (Passed)
- Ran `ruff check src/core/calibration.py` (Passed)
✨ **Result:** Cleaner code with centralized offset calculation logic.

---
*PR created automatically by Jules for task [2254859281644758352](https://jules.google.com/task/2254859281644758352) started by @youtube-at-vach*