### PR TITLE
🧹 Refactor SignalGenerator to use logging for MLS fallback notification

### DIFF
--- a/src/gui/widgets/signal_generator.py
+++ b/src/gui/widgets/signal_generator.py
@@ -1,4 +1,5 @@
 import argparse
+import logging
 from dataclasses import dataclass
 from typing import Optional
 
@@ -25,6 +26,9 @@ from PyQt6.QtWidgets import (
 from src.core.audio_engine import AudioEngine
 from src.core.localization import tr
 from src.measurement_modules.base import MeasurementModule
+
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -255,7 +259,7 @@ class SignalGenerator(MeasurementModule):
             signal = seq.astype(float) * 2 - 1
             return signal
         except Exception:
-            print("scipy.signal.max_len_seq not found/failed, using optimized fallback")
+            logger.warning("scipy.signal.max_len_seq not found/failed, using optimized fallback")
             tap_indices = [x - 1 for x in taps[order]]
             N = 2**order - 1
 

--- a/tests/logic_verification/test_signal_generator_mls_fallback.py
+++ b/tests/logic_verification/test_signal_generator_mls_fallback.py
@@ -40,9 +40,13 @@ def test_mls_fallback_correctness():
         # However, the code does `import scipy.signal` inside the function.
         # If we patch `scipy.signal.max_len_seq`, it should work because the module object is the same.
 
-        with patch('scipy.signal.max_len_seq', side_effect=RuntimeError("Forced failure for testing fallback")):
+        with patch('scipy.signal.max_len_seq', side_effect=RuntimeError("Forced failure for testing fallback")), \
+             patch('src.gui.widgets.signal_generator.logger') as mock_logger:
             # Note: We pass sample_rate but _generate_mls doesn't strictly use it for MLS length (it uses order)
             fallback_signal = sg._generate_mls(params, 48000)
+
+            # Verify logger was called
+            mock_logger.warning.assert_called_with("scipy.signal.max_len_seq not found/failed, using optimized fallback")
 
         # 3. Verify
         # Check length


### PR DESCRIPTION
This PR addresses a code health issue where a `print` statement was used for error reporting in `SignalGenerator`.

**Changes:**
- Replaced `print` with `logger.warning` in `src/gui/widgets/signal_generator.py` for the MLS fallback mechanism.
- Added `import logging` and initialized `logger`.
- Updated `tests/logic_verification/test_signal_generator_mls_fallback.py` to mock the logger and assert that `warning` is called when the fallback is triggered.

**Verification:**
- Ran `tests/logic_verification/test_signal_generator_mls_fallback.py` and confirmed it passes.
- Ran other `signal_generator` related tests to ensure no regressions.

---
*PR created automatically by Jules for task [15367287580731611425](https://jules.google.com/task/15367287580731611425) started by @youtube-at-vach*