### PR TITLE
🧹 Refactor hardcoded widget styles to src/gui/styles.py

### DIFF
--- a/src/gui/styles.py
+++ b/src/gui/styles.py
@@ -1,0 +1,29 @@
+"""
+Common stylesheet definitions for GUI widgets.
+"""
+
+# Toggle Button Styles (Start/Stop)
+STYLE_TOGGLE_BTN_DARK = (
+    "QPushButton { background-color: #2e7d32; color: white; border: 1px solid #555; border-radius: 4px; padding: 5px; }"
+    "QPushButton:checked { background-color: #c62828; color: white; border: 1px solid #555; border-radius: 4px; padding: 5px; }"
+    "QPushButton:hover { background-color: #388e3c; }"
+    "QPushButton:checked:hover { background-color: #d32f2f; }"
+)
+
+STYLE_TOGGLE_BTN_LIGHT = (
+    "QPushButton { background-color: #ccffcc; color: black; border: 1px solid #ccc; border-radius: 4px; padding: 5px; }"
+    "QPushButton:checked { background-color: #ffcccc; color: black; border: 1px solid #ccc; border-radius: 4px; padding: 5px; }"
+    "QPushButton:hover { background-color: #bbfebb; }"
+    "QPushButton:checked:hover { background-color: #ffbbbb; }"
+)
+
+# Label Styles (Oscilloscope measurements, etc.)
+# Dark Theme
+STYLE_LABEL_LEFT_CH_DARK = "font-family: monospace; font-weight: bold; color: #00ff00;"
+STYLE_LABEL_RIGHT_CH_DARK = "font-family: monospace; font-weight: bold; color: #ff0000;"
+STYLE_LABEL_CURSOR_DARK = "font-family: monospace; font-weight: bold; color: yellow;"
+
+# Light Theme
+STYLE_LABEL_LEFT_CH_LIGHT = "font-family: monospace; font-weight: bold; color: #008800;"
+STYLE_LABEL_RIGHT_CH_LIGHT = "font-family: monospace; font-weight: bold; color: #cc0000;"
+STYLE_LABEL_CURSOR_LIGHT = "font-family: monospace; font-weight: bold; color: #888800;"

--- a/src/gui/widgets/oscilloscope.py
+++ b/src/gui/widgets/oscilloscope.py
@@ -26,6 +26,16 @@ from src.core.analysis import AudioCalc
 from src.core.audio_engine import AudioEngine
 from src.core.localization import tr
 from src.measurement_modules.base import MeasurementModule
+from src.gui.styles import (
+    STYLE_TOGGLE_BTN_DARK,
+    STYLE_TOGGLE_BTN_LIGHT,
+    STYLE_LABEL_LEFT_CH_DARK,
+    STYLE_LABEL_RIGHT_CH_DARK,
+    STYLE_LABEL_CURSOR_DARK,
+    STYLE_LABEL_LEFT_CH_LIGHT,
+    STYLE_LABEL_RIGHT_CH_LIGHT,
+    STYLE_LABEL_CURSOR_LIGHT,
+)
 
 
 class Oscilloscope(MeasurementModule):
@@ -582,22 +592,22 @@ class OscilloscopeWidget(QWidget):
 
         meas_row_1 = QHBoxLayout()
         self.meas_l_label = QLabel(tr("L: Vrms: 0.000 V  Vpp: 0.000 V"))
-        self.meas_l_label.setStyleSheet("font-family: monospace; font-weight: bold; color: #00ff00;")
+        self.meas_l_label.setStyleSheet(STYLE_LABEL_LEFT_CH_DARK)
         meas_row_1.addWidget(self.meas_l_label)
 
         self.meas_r_label = QLabel(tr("R: Vrms: 0.000 V  Vpp: 0.000 V"))
-        self.meas_r_label.setStyleSheet("font-family: monospace; font-weight: bold; color: #ff0000;")
+        self.meas_r_label.setStyleSheet(STYLE_LABEL_RIGHT_CH_DARK)
         meas_row_1.addWidget(self.meas_r_label)
         meas_row_1.addStretch()
         meas_layout.addLayout(meas_row_1)
 
         self.meas_l_auto_label = QLabel(tr("Freq") + ": --  " + tr("Rise") + ": --  " + tr("Fall") + ": --")
-        self.meas_l_auto_label.setStyleSheet("font-family: monospace; font-weight: bold; color: #00ff00;")
+        self.meas_l_auto_label.setStyleSheet(STYLE_LABEL_LEFT_CH_DARK)
         self.meas_l_auto_label.setVisible(False)
         meas_layout.addWidget(self.meas_l_auto_label)
 
         self.meas_r_auto_label = QLabel(tr("Freq") + ": --  " + tr("Rise") + ": --  " + tr("Fall") + ": --")
-        self.meas_r_auto_label.setStyleSheet("font-family: monospace; font-weight: bold; color: #ff0000;")
+        self.meas_r_auto_label.setStyleSheet(STYLE_LABEL_RIGHT_CH_DARK)
         self.meas_r_auto_label.setVisible(False)
         meas_layout.addWidget(self.meas_r_auto_label)
 
@@ -606,7 +616,7 @@ class OscilloscopeWidget(QWidget):
 
         # Cursor Info
         self.cursor_info_label = QLabel(tr("Cursors: Off"))
-        self.cursor_info_label.setStyleSheet("font-family: monospace; font-weight: bold; color: yellow;")
+        self.cursor_info_label.setStyleSheet(STYLE_LABEL_CURSOR_DARK)
         left_layout.addWidget(self.cursor_info_label)
 
         # Plot
@@ -718,9 +728,7 @@ class OscilloscopeWidget(QWidget):
             self.app.theme_manager.theme_changed.connect(self.apply_theme)
             self.apply_theme(self.app.theme_manager.get_current_theme())
         else:
-            self.toggle_btn.setStyleSheet(
-                "QPushButton { background-color: #ccffcc; } QPushButton:checked { background-color: #ffcccc; }"
-            )
+            self.toggle_btn.setStyleSheet(STYLE_TOGGLE_BTN_LIGHT)
 
         gen_layout.addWidget(self.toggle_btn)
 
@@ -1464,31 +1472,21 @@ class OscilloscopeWidget(QWidget):
 
         if theme_name == "dark":
             # Dark Theme
-            self.toggle_btn.setStyleSheet(
-                "QPushButton { background-color: #2e7d32; color: white; border: 1px solid #555; border-radius: 4px; padding: 5px; }"
-                "QPushButton:checked { background-color: #c62828; color: white; border: 1px solid #555; border-radius: 4px; padding: 5px; }"
-                "QPushButton:hover { background-color: #388e3c; }"
-                "QPushButton:checked:hover { background-color: #d32f2f; }"
-            )
-            self.meas_l_label.setStyleSheet("font-family: monospace; font-weight: bold; color: #00ff00;")
-            self.meas_r_label.setStyleSheet("font-family: monospace; font-weight: bold; color: #ff0000;")
+            self.toggle_btn.setStyleSheet(STYLE_TOGGLE_BTN_DARK)
+            self.meas_l_label.setStyleSheet(STYLE_LABEL_LEFT_CH_DARK)
+            self.meas_r_label.setStyleSheet(STYLE_LABEL_RIGHT_CH_DARK)
             if hasattr(self, "meas_l_auto_label"):
-                self.meas_l_auto_label.setStyleSheet("font-family: monospace; font-weight: bold; color: #00ff00;")
+                self.meas_l_auto_label.setStyleSheet(STYLE_LABEL_LEFT_CH_DARK)
             if hasattr(self, "meas_r_auto_label"):
-                self.meas_r_auto_label.setStyleSheet("font-family: monospace; font-weight: bold; color: #ff0000;")
-            self.cursor_info_label.setStyleSheet("font-family: monospace; font-weight: bold; color: yellow;")
+                self.meas_r_auto_label.setStyleSheet(STYLE_LABEL_RIGHT_CH_DARK)
+            self.cursor_info_label.setStyleSheet(STYLE_LABEL_CURSOR_DARK)
         else:
             # Light Theme
-            self.toggle_btn.setStyleSheet(
-                "QPushButton { background-color: #ccffcc; color: black; border: 1px solid #ccc; border-radius: 4px; padding: 5px; }"
-                "QPushButton:checked { background-color: #ffcccc; color: black; border: 1px solid #ccc; border-radius: 4px; padding: 5px; }"
-                "QPushButton:hover { background-color: #bbfebb; }"
-                "QPushButton:checked:hover { background-color: #ffbbbb; }"
-            )
-            self.meas_l_label.setStyleSheet("font-family: monospace; font-weight: bold; color: #008800;")
-            self.meas_r_label.setStyleSheet("font-family: monospace; font-weight: bold; color: #cc0000;")
+            self.toggle_btn.setStyleSheet(STYLE_TOGGLE_BTN_LIGHT)
+            self.meas_l_label.setStyleSheet(STYLE_LABEL_LEFT_CH_LIGHT)
+            self.meas_r_label.setStyleSheet(STYLE_LABEL_RIGHT_CH_LIGHT)
             if hasattr(self, "meas_l_auto_label"):
-                self.meas_l_auto_label.setStyleSheet("font-family: monospace; font-weight: bold; color: #008800;")
+                self.meas_l_auto_label.setStyleSheet(STYLE_LABEL_LEFT_CH_LIGHT)
             if hasattr(self, "meas_r_auto_label"):
-                self.meas_r_auto_label.setStyleSheet("font-family: monospace; font-weight: bold; color: #cc0000;")
-            self.cursor_info_label.setStyleSheet("font-family: monospace; font-weight: bold; color: #888800;")
+                self.meas_r_auto_label.setStyleSheet(STYLE_LABEL_RIGHT_CH_LIGHT)
+            self.cursor_info_label.setStyleSheet(STYLE_LABEL_CURSOR_LIGHT)

--- a/src/gui/widgets/spectrogram.py
+++ b/src/gui/widgets/spectrogram.py
@@ -22,6 +22,7 @@ from src.core.analysis import get_cached_window
 from src.core.localization import tr
 from src.measurement_modules.base import MeasurementModule
 from src.core.fft_manager import fft_manager
+from src.gui.styles import STYLE_TOGGLE_BTN_DARK, STYLE_TOGGLE_BTN_LIGHT
 
 
 class Spectrogram(MeasurementModule):
@@ -208,9 +209,7 @@ class SpectrogramWidget(QWidget):
             self.app.theme_manager.theme_changed.connect(self.apply_theme)
             self.apply_theme(self.app.theme_manager.get_current_theme())
         else:
-            self.toggle_btn.setStyleSheet(
-                "QPushButton { background-color: #ccffcc; } QPushButton:checked { background-color: #ffcccc; }"
-            )
+            self.toggle_btn.setStyleSheet(STYLE_TOGGLE_BTN_LIGHT)
 
         controls_layout.addWidget(self.toggle_btn)
 
@@ -465,17 +464,7 @@ class SpectrogramWidget(QWidget):
 
         if theme_name == "dark":
             # Dark Theme
-            self.toggle_btn.setStyleSheet(
-                "QPushButton { background-color: #2e7d32; color: white; border: 1px solid #555; border-radius: 4px; padding: 5px; }"
-                "QPushButton:checked { background-color: #c62828; color: white; border: 1px solid #555; border-radius: 4px; padding: 5px; }"
-                "QPushButton:hover { background-color: #388e3c; }"
-                "QPushButton:checked:hover { background-color: #d32f2f; }"
-            )
+            self.toggle_btn.setStyleSheet(STYLE_TOGGLE_BTN_DARK)
         else:
             # Light Theme
-            self.toggle_btn.setStyleSheet(
-                "QPushButton { background-color: #ccffcc; color: black; border: 1px solid #ccc; border-radius: 4px; padding: 5px; }"
-                "QPushButton:checked { background-color: #ffcccc; color: black; border: 1px solid #ccc; border-radius: 4px; padding: 5px; }"
-                "QPushButton:hover { background-color: #bbfebb; }"
-                "QPushButton:checked:hover { background-color: #ffbbbb; }"
-            )
+            self.toggle_btn.setStyleSheet(STYLE_TOGGLE_BTN_LIGHT)

--- a/tests/logic_verification/test_spectrogram_style.py
+++ b/tests/logic_verification/test_spectrogram_style.py
@@ -1,0 +1,86 @@
+import sys
+from unittest.mock import MagicMock, patch
+
+# Helper to create mock QWidget-like class
+class MockQWidget(MagicMock):
+    def _get_child_mock(self, **kw):
+        return MagicMock(**kw)
+
+def test_spectrogram_style():
+    # Import actual styles for verification
+    try:
+        from src.gui.styles import STYLE_TOGGLE_BTN_DARK, STYLE_TOGGLE_BTN_LIGHT
+    except ImportError:
+        # If running from a place where src is not in path (though python -m pytest adds it)
+        sys.path.append(".")
+        from src.gui.styles import STYLE_TOGGLE_BTN_DARK, STYLE_TOGGLE_BTN_LIGHT
+
+    # Define mocks
+    mock_np = MagicMock()
+    mock_pg = MagicMock()
+
+    # Configure Qt
+    mock_qt_core = MagicMock()
+    mock_qt_core.QTimer = MagicMock()
+
+    mock_qt_widgets = MagicMock()
+    mock_qt_widgets.QWidget = MockQWidget
+    mock_qt_widgets.QPushButton = MagicMock()
+    mock_qt_widgets.QApplication = MagicMock()
+    mock_qt_widgets.QComboBox = MagicMock()
+    mock_qt_widgets.QGroupBox = MagicMock()
+    mock_qt_widgets.QHBoxLayout = MagicMock()
+    mock_qt_widgets.QVBoxLayout = MagicMock()
+    mock_qt_widgets.QLabel = MagicMock()
+    mock_qt_widgets.QSpinBox = MagicMock()
+
+    # Mock dependencies
+    mock_modules = {
+        "numpy": mock_np,
+        "pyqtgraph": mock_pg,
+        "PyQt6": MagicMock(),
+        "PyQt6.QtCore": mock_qt_core,
+        "PyQt6.QtGui": MagicMock(),
+        "PyQt6.QtWidgets": mock_qt_widgets,
+        "src.core.audio_engine": MagicMock(),
+        "src.core.analysis": MagicMock(),
+        "src.core.localization": MagicMock(),
+        "src.core.fft_manager": MagicMock(),
+    }
+
+    # Patch modules
+    with patch.dict(sys.modules, mock_modules):
+        # Clean import
+        if "src.gui.widgets.spectrogram" in sys.modules:
+            del sys.modules["src.gui.widgets.spectrogram"]
+
+        from src.gui.widgets.spectrogram import SpectrogramWidget, Spectrogram # noqa: E402
+
+        # Setup
+        mock_audio_engine = MagicMock()
+        spectrogram = Spectrogram(mock_audio_engine)
+
+        # Mock QApplication instance to have theme_manager
+        mock_app = MagicMock()
+        mock_theme_manager = MagicMock()
+        mock_app.theme_manager = mock_theme_manager
+        mock_qt_widgets.QApplication.instance.return_value = mock_app
+
+        # Instantiate Widget
+        # init_ui calls apply_theme, which will use the mock_theme_manager
+        mock_theme_manager.get_current_theme.return_value = "light"
+
+        widget = SpectrogramWidget(spectrogram)
+
+        # Test Dark Theme
+        widget.apply_theme("dark")
+        widget.toggle_btn.setStyleSheet.assert_called_with(STYLE_TOGGLE_BTN_DARK)
+
+        # Test Light Theme
+        widget.apply_theme("light")
+        widget.toggle_btn.setStyleSheet.assert_called_with(STYLE_TOGGLE_BTN_LIGHT)
+
+        print("Spectrogram style verification passed.")
+
+if __name__ == "__main__":
+    test_spectrogram_style()


### PR DESCRIPTION
This PR addresses a code health issue by extracting hardcoded CSS stylesheets from `SpectrogramWidget` and `OscilloscopeWidget` into a new `src/gui/styles.py` file. This improves maintainability and ensures consistency across widgets.

**Changes:**
- **New File:** `src/gui/styles.py` containing constants for button and label styles.
- **Refactor:** `SpectrogramWidget` now imports and uses these constants instead of inline strings.
- **Refactor:** `OscilloscopeWidget` also updated to use the same constants, ensuring consistent Start/Stop button appearance and label styling.
- **Test:** Added `tests/logic_verification/test_spectrogram_style.py` to verify that `apply_theme` correctly sets the expected stylesheet constants.

**Verification:**
- Ran `pytest tests/logic_verification/test_spectrogram_style.py` (Passed).
- Ran `pytest tests/logic_verification/test_oscilloscope_widget_logic.py` (Passed).
- Ran `ruff check` on modified files (Passed).


---
*PR created automatically by Jules for task [1470443812732815895](https://jules.google.com/task/1470443812732815895) started by @youtube-at-vach*