### PR TITLE
Refactor: Replace print with logging in MainWindow

### DIFF
--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Optional
 
 from PyQt6.QtCore import QTimer
@@ -260,6 +261,7 @@ def _load_welcome_widget_class():
 class MainWindow(QMainWindow):
     def __init__(self):
         super().__init__()
+        self.logger = logging.getLogger(__name__)
         self.setWindowTitle("MeasureLab")
         self.resize(1000, 700)
 
@@ -303,7 +305,7 @@ class MainWindow(QMainWindow):
                 if found_in_id is not None:
                     in_id = found_in_id
                 else:
-                    print(f"Saved input device '{last_in}' not found, using default.")
+                    self.logger.warning(f"Saved input device '{last_in}' not found, using default.")
 
             # Find Output Device
             if last_out:
@@ -311,7 +313,7 @@ class MainWindow(QMainWindow):
                 if found_out_id is not None:
                     out_id = found_out_id
                 else:
-                    print(f"Saved output device '{last_out}' not found, using default.")
+                    self.logger.warning(f"Saved output device '{last_out}' not found, using default.")
 
         try:
             self.audio_engine.set_devices(in_id, out_id)
@@ -331,7 +333,7 @@ class MainWindow(QMainWindow):
             self.audio_engine.set_pipewire_jack_resident(self.config_manager.get_pipewire_jack_resident())
 
         except Exception as e:
-            print(f"Failed to set devices/settings: {e}")
+            self.logger.error(f"Failed to set devices/settings: {e}")
             # Try default if specific failed
             try:
                 self.audio_engine.set_devices(None, None)
@@ -659,7 +661,7 @@ class MainWindow(QMainWindow):
                     try:
                         target.set_output_destination(mode)
                     except Exception as e:
-                        print(f"Failed to sync output destination: {e}")
+                        self.logger.warning(f"Failed to sync output destination: {e}")
 
     def on_output_destination_changed(self, index):
         data = self.output_dest_combo.currentData()

--- a/tests/logic_verification/test_main_window_logging.py
+++ b/tests/logic_verification/test_main_window_logging.py
@@ -1,0 +1,127 @@
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+# -------------------------------------------------------------------------
+# MOCKING DEPENDENCIES
+# -------------------------------------------------------------------------
+
+class MockQMainWindow:
+    def __init__(self, *args, **kwargs):
+        pass
+    def setWindowTitle(self, t): pass
+    def resize(self, w, h): pass
+    def setCentralWidget(self, w): pass
+    def setStatusBar(self, b): pass
+    def layout(self): return MagicMock()
+
+qt_widgets = MagicMock()
+qt_widgets.QMainWindow = MockQMainWindow
+qt_widgets.QApplication.instance.return_value = MagicMock()
+
+class MockQWidget(MagicMock):
+    def __init__(self, *args, **kwargs):
+        super().__init__()
+
+    def _get_child_mock(self, **kwargs):
+        return MagicMock(**kwargs)
+
+class MockLayout(MagicMock):
+    def __init__(self, *args, **kwargs):
+        super().__init__()
+    def addWidget(self, *args): pass
+    def setContentsMargins(self, *args): pass
+    def count(self): return 0
+
+qt_widgets.QWidget = MockQWidget
+qt_widgets.QHBoxLayout = MockLayout
+qt_widgets.QVBoxLayout = MockLayout
+qt_widgets.QListWidget = MagicMock
+qt_widgets.QStackedWidget = MagicMock
+qt_widgets.QStatusBar = MagicMock
+
+class MockQLabel(MagicMock):
+    def __init__(self, *args, **kwargs):
+        super().__init__()
+
+qt_widgets.QLabel = MockQLabel
+qt_widgets.QComboBox = MagicMock
+
+mock_audio_engine = MagicMock()
+mock_config_manager = MagicMock()
+mock_localization = MagicMock()
+mock_localization.tr.side_effect = lambda x: str(x)
+mock_localization.get_manager.return_value = MagicMock()
+
+mock_theme_manager = MagicMock()
+mock_detachable = MagicMock()
+
+class TestMainWindowLogging(unittest.TestCase):
+    def test_logging_on_missing_device(self):
+        """
+        Verify that logger.warning is called when a saved device is not found.
+        """
+        # Reset mocks
+        mock_audio_engine.reset_mock()
+        mock_config_manager.reset_mock()
+
+        # Setup mock behavior
+        # Config has saved devices
+        # mock_config_manager is the module, so we target the class ConfigManager inside it
+        mock_config_manager.ConfigManager.return_value.get_audio_config.return_value = {
+            "input_device": "Saved Mic",
+            "input_hostapi": "Core Audio",
+            "output_device": "Saved Speaker",
+            "output_hostapi": "Core Audio"
+        }
+
+        # Audio Engine lists devices, but NOT the saved ones
+        # mock_audio_engine is the module, target AudioEngine class
+        mock_audio_engine.AudioEngine.return_value.list_devices.return_value = [
+            {"name": "Other Mic", "hostapi_name": "Core Audio", "max_input_channels": 2, "max_output_channels": 0},
+            {"name": "Other Speaker", "hostapi_name": "Core Audio", "max_input_channels": 0, "max_output_channels": 2},
+        ]
+
+        # Patch modules
+        modules_to_patch = {
+            "PyQt6": MagicMock(),
+            "PyQt6.QtCore": MagicMock(),
+            "PyQt6.QtWidgets": qt_widgets,
+            "PyQt6.QtGui": MagicMock(),
+            "src.core.audio_engine": mock_audio_engine,
+            "src.core.config_manager": mock_config_manager,
+            "src.core.localization": mock_localization,
+            "src.core.theme_manager": mock_theme_manager,
+            "src.gui.widgets.detachable_wrapper": mock_detachable,
+        }
+
+        with patch.dict(sys.modules, modules_to_patch):
+            # Ensure fresh import
+            if "src.gui.main_window" in sys.modules:
+                del sys.modules["src.gui.main_window"]
+
+            # Patch logging.getLogger to return our spy logger
+            # Note: logging is imported in MainWindow, so we should patch it where it is used or imported.
+            # But since we are reloading MainWindow, patching 'logging.getLogger' globally should work
+            # because 'import logging' in MainWindow will use the already loaded logging module,
+            # and we are patching getLogger on it.
+            with patch("logging.getLogger") as mock_get_logger:
+                spy_logger = MagicMock()
+                mock_get_logger.return_value = spy_logger
+
+                from src.gui.main_window import MainWindow
+
+                # Instantiate MainWindow
+                MainWindow()
+
+                # Verify logger.warning was called for input and output
+                # We expect 2 calls: one for input, one for output
+
+                # Check for input warning
+                spy_logger.warning.assert_any_call("Saved input device 'Saved Mic' not found, using default.")
+
+                # Check for output warning
+                spy_logger.warning.assert_any_call("Saved output device 'Saved Speaker' not found, using default.")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR addresses a code health issue where `print` statements were used for error logging in `src/gui/main_window.py`. 
These have been replaced with proper `logging.warning` and `logging.error` calls.
A new test file `tests/logic_verification/test_main_window_logging.py` has been added to verify that logging is correctly invoked when saved devices are missing.
Existing tests pass.

---
*PR created automatically by Jules for task [16868861920386890913](https://jules.google.com/task/16868861920386890913) started by @youtube-at-vach*