### PR TITLE
Potential fix for code scanning alert no. 179: Code injection

### DIFF
--- a/.github/workflows/virustotal.yml
+++ b/.github/workflows/virustotal.yml
@@ -30,10 +30,11 @@ jobs:
         id: target
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
           # If triggered by release workflow completion, use that tag/branch
           if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
-            TAG_NAME="${{ github.event.workflow_run.head_branch }}"
+            TAG_NAME="$HEAD_BRANCH"
             echo "Targeting workflow_run head_branch: $TAG_NAME"
           # If triggered by release event (legacy, kept for completeness or manual trigger simulation)
           elif [[ "${{ github.event_name }}" == "release" ]]; then


### PR DESCRIPTION
Potential fix for [https://github.com/youtube-at-vach/MeasureLab/security/code-scanning/179](https://github.com/youtube-at-vach/MeasureLab/security/code-scanning/179)

In general, to fix this kind of issue in GitHub Actions, you should avoid using `${{ ... }}` expressions that contain untrusted input directly inside script bodies. Instead, assign the expression value to an environment variable via `env:` and then access it using the shell’s native variable expansion (`$VAR`) inside the `run:` block. This prevents expression-level interpolation from being parsed as part of the script and avoids command injection.

For this specific workflow, the problematic use is `TAG_NAME="${{ github.event.workflow_run.head_branch }}"` in the `Determine Release Target` step. The best fix that preserves behavior is:

1. Add an environment variable (e.g., `HEAD_BRANCH`) in the step’s `env:` block and set it to `${{ github.event.workflow_run.head_branch }}`.
2. In the shell script, replace `TAG_NAME="${{ github.event.workflow_run.head_branch }}"` with `TAG_NAME="$HEAD_BRANCH"`.

This change should be made in `.github/workflows/virustotal.yml` in the `Determine Release Target` step, around line 31–37. No additional methods or external libraries are required; we only extend the existing `env:` mapping and adjust the script to read from the new environment variable.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
