### PR TITLE
Refactor SpectrogramWidget.init_ui to improve code organization

### DIFF
--- a/src/gui/widgets/spectrogram.py
+++ b/src/gui/widgets/spectrogram.py
@@ -193,8 +193,11 @@ class SpectrogramWidget(QWidget):
 
     def init_ui(self):
         layout = QVBoxLayout()
+        layout.addWidget(self._init_controls())
+        layout.addWidget(self._init_plot())
+        self.setLayout(layout)
 
-        # --- Controls ---
+    def _init_controls(self) -> QGroupBox:
         controls_group = QGroupBox(tr("Settings"))
         controls_layout = QHBoxLayout()
 
@@ -240,7 +243,6 @@ class SpectrogramWidget(QWidget):
         self.cmap_combo = QComboBox()
         self.cmap_combo.addItems(["viridis", "plasma", "inferno", "magma", "cividis", "turbo"])
         self.cmap_combo.currentTextChanged.connect(self.on_cmap_changed)
-        self.cmap_combo.currentTextChanged.connect(self.on_cmap_changed)
         controls_layout.addWidget(self.cmap_combo)
 
         # Sweep Speed
@@ -269,12 +271,11 @@ class SpectrogramWidget(QWidget):
         controls_layout.addWidget(self.max_freq_spin)
 
         controls_group.setLayout(controls_layout)
-        layout.addWidget(controls_group)
+        return controls_group
 
-        # --- Plot ---
+    def _init_plot(self) -> pg.GraphicsLayoutWidget:
         # We use a GraphicsLayoutWidget to hold the Plot and Histogram
         self.win = pg.GraphicsLayoutWidget()
-        layout.addWidget(self.win)
 
         # Plot Item
         self.plot = self.win.addPlot(title=tr("Spectrogram"))
@@ -301,7 +302,7 @@ class SpectrogramWidget(QWidget):
         self.hist.gradient.loadPreset("viridis")
         self.hist.setLevels(-120, 0)  # Default dB range
 
-        self.setLayout(layout)
+        return self.win
 
     def on_toggle(self, checked):
         if checked:


### PR DESCRIPTION
🎯 **What:**
Refactored `SpectrogramWidget.init_ui` in `src/gui/widgets/spectrogram.py` by splitting it into two helper methods:
- `_init_controls(self) -> QGroupBox`
- `_init_plot(self) -> pg.GraphicsLayoutWidget`

💡 **Why:**
The original `init_ui` method was long and mixed control creation logic with plot setup logic. Extracting these into separate methods improves code organization, readability, and maintainability. It makes it easier to understand the widget structure and modify specific parts (controls vs plot) in the future.

✅ **Verification:**
- Ran existing tests: `tests/functional/test_spectrogram.py`, `tests/functional/test_spectrogram_widget_integration.py`, and `tests/logic_verification/test_spectrogram_style.py`. All tests passed.
- Removed a duplicate signal connection for `self.cmap_combo` that was identified during refactoring.
- Linted the file with `ruff`.

✨ **Result:**
The `SpectrogramWidget` code is now cleaner and better organized without any change in functionality.

---
*PR created automatically by Jules for task [5240843828981018105](https://jules.google.com/task/5240843828981018105) started by @youtube-at-vach*