### PR TITLE
Fix logical bug in bandpass filter and crash in notch filter

### DIFF
--- a/src/core/analysis.py
+++ b/src/core/analysis.py
@@ -124,7 +124,7 @@ class AudioCalc:
         lowcut = max(0.1, lowcut)
         highcut = min(nyquist - 1, highcut)
         if lowcut >= highcut:
-            return signal
+            return np.zeros_like(signal)
 
         # Wn must be a tuple to be hashable for lru_cache
         Wn = (lowcut / nyquist, highcut / nyquist)
@@ -160,11 +160,23 @@ class AudioCalc:
             return signal
 
         nyquist = 0.5 * sampling_rate
+        if target_frequency <= 0 or target_frequency >= nyquist:
+            return signal
+
         w0 = target_frequency / nyquist
         bandwidth = w0 / quality_factor
 
+        # Validate resulting filter poles
+        # bandwidth is normalized (0-1 range approx, relative to nyquist)
+        # The critical frequencies for bandstop are w0 - bw/2 and w0 + bw/2
+        w_low = w0 - bandwidth / 2
+        w_high = w0 + bandwidth / 2
+
+        if w_low <= 0 or w_high >= 1:
+            return signal
+
         # Wn must be a tuple to be hashable for lru_cache
-        Wn = (w0 - bandwidth / 2, w0 + bandwidth / 2)
+        Wn = (w_low, w_high)
         sos = _get_butter_sos(2, Wn, "bandstop")
         return sosfiltfilt(sos, signal)
 

--- a/tests/logic_verification/test_analysis_filters.py
+++ b/tests/logic_verification/test_analysis_filters.py
@@ -69,12 +69,36 @@ def test_bandpass_filter_invalid_bounds():
     signal = np.random.randn(1000)
 
     # Case 1: lowcut >= highcut
-    # Should return original signal
+    # Should return silence (zeros) as passband is empty
     filtered = AudioCalc.bandpass_filter(signal, sampling_rate, lowcut=5000.0, highcut=100.0)
-    assert np.array_equal(filtered, signal)
+    assert np.allclose(filtered, 0)
 
     # Case 2: lowcut = highcut
     filtered = AudioCalc.bandpass_filter(signal, sampling_rate, lowcut=1000.0, highcut=1000.0)
+    assert np.allclose(filtered, 0)
+
+def test_notch_filter_safety():
+    """Verify safety with invalid notch parameters."""
+    sampling_rate = 48000
+    signal = np.random.randn(1000)
+
+    # Case 1: Target > Nyquist
+    # Should return original signal (bypass)
+    filtered = AudioCalc.notch_filter(signal, sampling_rate, target_frequency=30000.0)
+    assert np.array_equal(filtered, signal)
+
+    # Case 2: Target <= 0
+    filtered = AudioCalc.notch_filter(signal, sampling_rate, target_frequency=-100.0)
+    assert np.array_equal(filtered, signal)
+
+    # Case 3: Bandwidth causes Nyquist violation
+    # Target 23900, Q=0.1 -> Bandwidth very large, upper > 24000
+    filtered = AudioCalc.notch_filter(signal, sampling_rate, target_frequency=23900.0, quality_factor=0.1)
+    assert np.array_equal(filtered, signal)
+
+    # Case 4: Bandwidth causes DC violation
+    # Target 100, Q=0.1 -> Bandwidth very large, lower < 0
+    filtered = AudioCalc.notch_filter(signal, sampling_rate, target_frequency=100.0, quality_factor=0.1)
     assert np.array_equal(filtered, signal)
 
 def test_bandpass_filter_nyquist_handling():


### PR DESCRIPTION
- Fixed `AudioCalc.bandpass_filter` to return silence (`np.zeros_like(signal)`) instead of the original signal when `lowcut >= highcut` (invalid/empty passband).
- Fixed `AudioCalc.notch_filter` to prevent `ValueError` crashes by validating `target_frequency` and bandwidth bounds against Nyquist/DC limits. Returns original signal (bypass) if invalid.
- Updated `tests/logic_verification/test_analysis_filters.py` to assert correct behavior (silence for invalid bandpass) and added safety tests for notch filter edge cases.

---
*PR created automatically by Jules for task [8875614402425142386](https://jules.google.com/task/8875614402425142386) started by @youtube-at-vach*