### PR TITLE
Refactor ConfigManager to remove deprecated legacy API methods

### DIFF
--- a/src/core/config_manager.py
+++ b/src/core/config_manager.py
@@ -216,24 +216,6 @@ class ConfigManager:
         """Returns a dictionary of audio configuration."""
         return self.config.get("audio", self._default_config()["audio"])
 
-    # --- Legacy API (kept for backward compatibility with older tests/tools) ---
-    def get_last_devices(self):
-        audio = self.get_audio_config()
-        return audio.get("input_device"), audio.get("output_device")
-
-    def set_last_devices(self, input_name, output_name, input_hostapi=None, output_hostapi=None):
-        audio = self.get_audio_config()
-        self.set_audio_config(
-            input_name=input_name,
-            output_name=output_name,
-            sample_rate=audio.get("sample_rate", 48000),
-            block_size=audio.get("block_size", 1024),
-            in_ch=audio.get("input_channels", "stereo"),
-            out_ch=audio.get("output_channels", "stereo"),
-            input_hostapi=input_hostapi,
-            output_hostapi=output_hostapi,
-        )
-
     def set_audio_config(
         self,
         input_name,

--- a/tests/functional/test_config.py
+++ b/tests/functional/test_config.py
@@ -18,16 +18,28 @@ def test_config_persistence():
     cm = ConfigManager(config_path)
 
     print("Checking default values...")
-    in_dev, out_dev = cm.get_last_devices()
+    audio = cm.get_audio_config()
+    in_dev = audio.get("input_device")
+    out_dev = audio.get("output_device")
     if in_dev is not None or out_dev is not None:
         print("FAILED: Default devices should be None")
         return
 
     print("Setting devices...")
-    cm.set_last_devices("My Mic", "My Speaker")
+    audio = cm.get_audio_config()
+    cm.set_audio_config(
+        input_name="My Mic",
+        output_name="My Speaker",
+        sample_rate=audio.get("sample_rate", 48000),
+        block_size=audio.get("block_size", 1024),
+        in_ch=audio.get("input_channels", "stereo"),
+        out_ch=audio.get("output_channels", "stereo"),
+    )
 
     print("Verifying in-memory update...")
-    in_dev, out_dev = cm.get_last_devices()
+    audio = cm.get_audio_config()
+    in_dev = audio.get("input_device")
+    out_dev = audio.get("output_device")
     if in_dev != "My Mic" or out_dev != "My Speaker":
         print(f"FAILED: In-memory update failed. Got {in_dev}, {out_dev}")
         return
@@ -39,7 +51,9 @@ def test_config_persistence():
     print("Verifying file persistence...")
     # Create new instance to load from file
     cm2 = ConfigManager(config_path)
-    in_dev, out_dev = cm2.get_last_devices()
+    audio2 = cm2.get_audio_config()
+    in_dev = audio2.get("input_device")
+    out_dev = audio2.get("output_device")
     if in_dev != "My Mic" or out_dev != "My Speaker":
         print(f"FAILED: File persistence failed. Got {in_dev}, {out_dev}")
         return


### PR DESCRIPTION
Removed deprecated `get_last_devices` and `set_last_devices` methods from `src/core/config_manager.py`.
Updated `tests/functional/test_config.py` to use the modern `get_audio_config` and `set_audio_config` API.
Verified that `tests/functional/test_config.py` and `tests/logic_verification/test_config_manager_lifecycle.py` pass.

---
*PR created automatically by Jules for task [348948974430863503](https://jules.google.com/task/348948974430863503) started by @youtube-at-vach*