### PR TITLE
🧹 Refactor: Remove dead CLI run method stubs

### DIFF
--- a/src/gui/widgets/boxcar_averager.py
+++ b/src/gui/widgets/boxcar_averager.py
@@ -1,4 +1,3 @@
-import argparse
 import time
 
 import numpy as np
@@ -91,9 +90,6 @@ class BoxcarAverager(MeasurementModule):
     @property
     def description(self) -> str:
         return "High-precision signal averaging for transient analysis."
-
-    def run(self, args: argparse.Namespace):
-        print("Boxcar Averager CLI not implemented")
 
     def get_widget(self):
         return BoxcarAveragerWidget(self)

--- a/src/gui/widgets/distortion_analyzer.py
+++ b/src/gui/widgets/distortion_analyzer.py
@@ -1,4 +1,3 @@
-import argparse
 from collections import deque
 
 import numpy as np
@@ -281,9 +280,6 @@ class DistortionAnalyzer(MeasurementModule):
     @property
     def description(self) -> str:
         return "THD, THD+N, and SINAD measurements."
-
-    def run(self, args: argparse.Namespace):
-        print("Distortion Analyzer running from CLI (not implemented)")
 
     def get_widget(self):
         return DistortionAnalyzerWidget(self)

--- a/src/gui/widgets/goniometer.py
+++ b/src/gui/widgets/goniometer.py
@@ -1,4 +1,3 @@
-import argparse
 from typing import Tuple
 
 import numpy as np
@@ -62,9 +61,6 @@ class Goniometer(MeasurementModule):
     @property
     def description(self) -> str:
         return "Stereo image visualizer (Lissajous) and Phase Correlation."
-
-    def run(self, args: argparse.Namespace):
-        print("Goniometer CLI not implemented")
 
     def get_widget(self):
         return GoniometerWidget(self)

--- a/src/gui/widgets/hrtf_player.py
+++ b/src/gui/widgets/hrtf_player.py
@@ -1,4 +1,3 @@
-import argparse
 import logging
 from dataclasses import dataclass
 from typing import Optional
@@ -203,9 +202,6 @@ class HRTFPlayer(MeasurementModule):
     @property
     def description(self) -> str:
         return "Visualize and Audition HRTF (SOFA) files."
-
-    def run(self, args: argparse.Namespace):
-        pass
 
     def get_widget(self):
         return HRTFPlayerWidget(self)

--- a/src/gui/widgets/impedance_analyzer.py
+++ b/src/gui/widgets/impedance_analyzer.py
@@ -1,4 +1,3 @@
-import argparse
 import bisect
 import json
 import os
@@ -191,9 +190,6 @@ class ImpedanceAnalyzer(MeasurementModule):
     @property
     def description(self) -> str:
         return tr("Measure Impedance (Z) using Dual Lock-in Amplifier.")
-
-    def run(self, args: argparse.Namespace):
-        print("Impedance Analyzer running from CLI (not fully implemented)")
 
     def get_widget(self):
         return ImpedanceAnalyzerWidget(self)

--- a/src/gui/widgets/inverse_filter.py
+++ b/src/gui/widgets/inverse_filter.py
@@ -1,4 +1,3 @@
-import argparse
 import os
 
 import numpy as np
@@ -41,9 +40,6 @@ class InverseFilter(MeasurementModule):
     @property
     def description(self) -> str:
         return "Apply inverse calibration filter to audio files."
-
-    def run(self, args: argparse.Namespace):
-        pass
 
     def get_widget(self):
         return InverseFilterWidget(self)

--- a/src/gui/widgets/linearity_analyzer.py
+++ b/src/gui/widgets/linearity_analyzer.py
@@ -1,4 +1,3 @@
-import argparse
 import logging
 import time
 import numpy as np
@@ -242,9 +241,6 @@ class LinearityAnalyzer(MeasurementModule):
     @property
     def description(self) -> str:
         return "Measure Linearity Error (Gain Accuracy vs Level)."
-
-    def run(self, args: argparse.Namespace):
-        logger.warning("CLI not implemented")
 
     def get_latest_buffer(self) -> np.ndarray:
         """Returns the current buffer contents ordered chronologically."""

--- a/src/gui/widgets/lock_in_amplifier.py
+++ b/src/gui/widgets/lock_in_amplifier.py
@@ -1,4 +1,3 @@
-import argparse
 import threading
 import time
 from collections import deque
@@ -116,9 +115,6 @@ class LockInAmplifier(MeasurementModule):
     @property
     def description(self) -> str:
         return "Dual-phase lock-in detection."
-
-    def run(self, args: argparse.Namespace):
-        print("Lock-in Amplifier running from CLI (not fully implemented)")
 
     def get_widget(self):
         return LockInAmplifierWidget(self)

--- a/src/gui/widgets/lock_in_frequency_counter.py
+++ b/src/gui/widgets/lock_in_frequency_counter.py
@@ -1,4 +1,3 @@
-import argparse
 from collections import deque
 import time
 
@@ -185,9 +184,6 @@ class LockInFrequencyCounter(MeasurementModule):
     @property
     def description(self) -> str:
         return tr("Precision Frequency & Phase Drift Measurement using Lock-in Principle.")
-
-    def run(self, args: argparse.Namespace):
-        print("CLI not implemented")
 
     def get_widget(self):
         return LockInFrequencyCounterWidget(self)

--- a/src/gui/widgets/lufs_meter.py
+++ b/src/gui/widgets/lufs_meter.py
@@ -1,4 +1,3 @@
-import argparse
 import threading
 import time
 
@@ -106,9 +105,6 @@ class LufsMeter(MeasurementModule):
     @property
     def description(self) -> str:
         return "Real-time Loudness (LUFS) and Stereo Level Meter"
-
-    def run(self, args: argparse.Namespace):
-        print("LUFS Meter running from CLI (not fully implemented)")
 
     def get_widget(self):
         return LufsMeterWidget(self)

--- a/src/gui/widgets/network_analyzer.py
+++ b/src/gui/widgets/network_analyzer.py
@@ -1,4 +1,3 @@
-import argparse
 import threading
 
 import numpy as np
@@ -170,9 +169,6 @@ class NetworkAnalyzer(MeasurementModule):
     @property
     def description(self) -> str:
         return "Bode Plot (Gain & Phase) with XFER support"
-
-    def run(self, args: argparse.Namespace):
-        print("CLI not implemented")
 
     def get_widget(self):
         return NetworkAnalyzerWidget(self)

--- a/src/gui/widgets/noise_profiler.py
+++ b/src/gui/widgets/noise_profiler.py
@@ -1,4 +1,3 @@
-import argparse
 import logging
 
 import numpy as np
@@ -160,9 +159,6 @@ class NoiseProfiler(MeasurementModule):
     @property
     def description(self) -> str:
         return tr("Noise characterization and analysis tool.")
-
-    def run(self, args: argparse.Namespace):
-        logger.info("Noise Profiler running from CLI (not fully implemented)")
 
     def get_widget(self):
         return NoiseProfilerWidget(self)

--- a/src/gui/widgets/one_pps_monitor.py
+++ b/src/gui/widgets/one_pps_monitor.py
@@ -1,4 +1,3 @@
-import argparse
 import threading
 import time
 import queue
@@ -92,10 +91,6 @@ class OnePPSMonitor(MeasurementModule):
 
     def get_widget(self):
         return OnePPSMonitorWidget(self)
-
-    def run(self, args: argparse.Namespace):
-        """CLI entry point (not used in GUI mode)."""
-        print("1PPS Monitor CLI mode not implemented.")
 
     def start_analysis(self):
         if self.is_running:

--- a/src/gui/widgets/oscilloscope.py
+++ b/src/gui/widgets/oscilloscope.py
@@ -1,4 +1,3 @@
-import argparse
 import threading
 
 import numpy as np
@@ -137,9 +136,6 @@ class Oscilloscope(MeasurementModule):
 
         # Accumulate
         np.add.at(heatmap, (x_idx, y_idx), intensity * 100)
-
-    def run(self, args: argparse.Namespace):
-        print("Oscilloscope running from CLI (not fully implemented)")
 
     def get_widget(self):
         return OscilloscopeWidget(self)

--- a/src/gui/widgets/raw_time_series.py
+++ b/src/gui/widgets/raw_time_series.py
@@ -1,4 +1,3 @@
-import argparse
 import threading
 
 import numpy as np
@@ -58,9 +57,6 @@ class RawTimeSeries(MeasurementModule):
     @property
     def description(self) -> str:
         return "Long-span scrolling time series monitor."
-
-    def run(self, args: argparse.Namespace):
-        print("Raw Time Series running from CLI (not implemented)")
 
     def get_widget(self):
         return RawTimeSeriesWidget(self)

--- a/src/gui/widgets/signal_generator.py
+++ b/src/gui/widgets/signal_generator.py
@@ -1,4 +1,3 @@
-import argparse
 import logging
 from dataclasses import dataclass
 from typing import Optional
@@ -118,9 +117,6 @@ class SignalGenerator(MeasurementModule):
     @property
     def description(self) -> str:
         return "Generates advanced test signals (Sine, Square, Noise, Sweeps) with independent channel control"
-
-    def run(self, args: argparse.Namespace):
-        print("Signal Generator running from CLI (not fully implemented)")
 
     def get_widget(self):
         return SignalGeneratorWidget(self)

--- a/src/gui/widgets/sound_quality_analyzer.py
+++ b/src/gui/widgets/sound_quality_analyzer.py
@@ -1,4 +1,3 @@
-import argparse
 
 import numpy as np
 import pyqtgraph as pg
@@ -490,9 +489,6 @@ class SoundQualityAnalyzer(MeasurementModule):
     @property
     def description(self) -> str:
         return "Offline analysis of sound quality metrics (Loudness, Sharpness, Roughness)."
-
-    def run(self, args: argparse.Namespace):
-        print("Sound Quality Analyzer is a GUI-only widget.")
 
     def get_widget(self):
         return SoundQualityAnalyzerWidget(self)

--- a/src/gui/widgets/spectrogram.py
+++ b/src/gui/widgets/spectrogram.py
@@ -1,4 +1,3 @@
-import argparse
 import threading
 
 import numpy as np
@@ -64,9 +63,6 @@ class Spectrogram(MeasurementModule):
     @property
     def description(self) -> str:
         return "Time-frequency analysis (Spectrogram)."
-
-    def run(self, args: argparse.Namespace):
-        print("Spectrogram CLI not implemented")
 
     def get_widget(self):
         return SpectrogramWidget(self)

--- a/src/gui/widgets/spectrum_analyzer.py
+++ b/src/gui/widgets/spectrum_analyzer.py
@@ -1,4 +1,3 @@
-import argparse
 import queue
 
 import numpy as np
@@ -66,9 +65,6 @@ class SpectrumAnalyzer(MeasurementModule):
     @property
     def description(self) -> str:
         return "Real-time frequency spectrum analysis."
-
-    def run(self, args: argparse.Namespace):
-        print("Spectrum Analyzer running from CLI (not fully implemented)")
 
     def get_widget(self):
         return SpectrumAnalyzerWidget(self)

--- a/src/gui/widgets/ultrasound_modulator.py
+++ b/src/gui/widgets/ultrasound_modulator.py
@@ -1,4 +1,3 @@
-import argparse
 import numpy as np
 import scipy.signal
 from PyQt6.QtCore import Qt, QTimer
@@ -82,9 +81,6 @@ class UltrasoundModulator(MeasurementModule):
     @property
     def description(self) -> str:
         return "Real-time AM modulator for ultrasonic speakers (40kHz)"
-
-    def run(self, args: argparse.Namespace):
-        print("Ultrasound Modulator running from CLI (not fully implemented)")
 
     def get_widget(self):
         return UltrasoundModulatorWidget(self)

--- a/src/measurement_modules/base.py
+++ b/src/measurement_modules/base.py
@@ -22,8 +22,7 @@ class MeasurementModule(ABC):
         """Brief description of the module's purpose."""
         pass
 
-    @abstractmethod
-    def run(self, args: argparse.Namespace):
+    def run(self, args: argparse.Namespace):  # noqa: B027
         """
         Execute the measurement from CLI.
         Currently frozen/not implemented for most modules.

--- a/tests/logic_verification/test_noise_profiler_logging.py
+++ b/tests/logic_verification/test_noise_profiler_logging.py
@@ -50,17 +50,3 @@ def test_worker_exception_logging():
         # exc_info should be True to log traceback
         assert kwargs.get('exc_info') is True, "exc_info=True is required for full traceback"
 
-def test_cli_run_logging():
-    """
-    Verify that NoiseProfiler.run logs an info message instead of printing.
-    """
-    mock_engine = MagicMock()
-    module = NoiseProfiler(mock_engine)
-
-    with patch('src.gui.widgets.noise_profiler.logger', create=True) as mock_logger:
-        module.run(None)
-
-        # Check if logger.info was called
-        mock_logger.info.assert_called()
-        args, _ = mock_logger.info.call_args
-        assert "Noise Profiler running from CLI" in args[0]


### PR DESCRIPTION
This PR removes the deprecated/dead CLI `run` method stubs from all measurement modules. 

The `MeasurementModule` base class now provides a default no-op implementation for `run`, so subclasses no longer need to implement it if they don't support CLI mode (which is currently frozen/unused).

This change improves code health by reducing bloat and removing misleading stub methods. It also updates a test file that was specifically testing the stub behavior.

**Changes:**
- `src/measurement_modules/base.py`: Removed `@abstractmethod` from `run`, added `pass`.
- `src/gui/widgets/*.py`: Removed `run` methods and `import argparse`.
- `tests/logic_verification/test_noise_profiler_logging.py`: Removed dead test case.

---
*PR created automatically by Jules for task [5742069148725190113](https://jules.google.com/task/5742069148725190113) started by @youtube-at-vach*