### PR TITLE
🧹 Remove dead code EXTENDED_SIZES from fft_manager

### DIFF
--- a/src/core/fft_manager.py
+++ b/src/core/fft_manager.py
@@ -25,8 +25,6 @@ WARMUP_SIZES = [256, 512, 1024, 2048, 4096, 8192, 16384, 24000, 32768, 48000, 65
 MEDIUM_SIZES = [131072, 262144]
 # Huge sizes that take very long to optimize (optional)
 HUGE_SIZES = [1048576, 2097152, 4194304]
-# Backwards compatibility or default full set if needed, but logic currently uses WARMUP + MEDIUM
-EXTENDED_SIZES = MEDIUM_SIZES + HUGE_SIZES
 
 
 class FFTManager:


### PR DESCRIPTION
🎯 **What:** Removed the `EXTENDED_SIZES` constant and its comment from `src/core/fft_manager.py`.
💡 **Why:** The constant was unused (dead code), and removing it improves code clarity and maintainability.
✅ **Verification:**
- Confirmed no usage via `grep`.
- Ran `tests/logic_verification/test_fft_manager_optimization.py` and the full `tests/logic_verification` suite, all passed.
✨ **Result:** Cleaner code in `fft_manager.py`.

---
*PR created automatically by Jules for task [992020645983414626](https://jules.google.com/task/992020645983414626) started by @youtube-at-vach*