### PR TITLE
🧹 Remove unused CLI run method from LufsMeter and refactor MeasurementModule

### DIFF
--- a/src/gui/widgets/lufs_meter.py
+++ b/src/gui/widgets/lufs_meter.py
@@ -1,4 +1,3 @@
-import argparse
 import threading
 import time
 
@@ -106,9 +105,6 @@ class LufsMeter(MeasurementModule):
     @property
     def description(self) -> str:
         return "Real-time Loudness (LUFS) and Stereo Level Meter"
-
-    def run(self, args: argparse.Namespace):
-        print("LUFS Meter running from CLI (not fully implemented)")
 
     def get_widget(self):
         return LufsMeterWidget(self)

--- a/src/measurement_modules/base.py
+++ b/src/measurement_modules/base.py
@@ -22,13 +22,12 @@ class MeasurementModule(ABC):
         """Brief description of the module's purpose."""
         pass
 
-    @abstractmethod
     def run(self, args: argparse.Namespace):
         """
         Execute the measurement from CLI.
         Currently frozen/not implemented for most modules.
         """
-        pass
+        return None
 
     def get_widget(self):
         """


### PR DESCRIPTION
🎯 **What:**
- Removed the unused `run` method and `argparse` import from `src/gui/widgets/lufs_meter.py`.
- Refactored `src/measurement_modules/base.py` to make `MeasurementModule.run` a concrete method (returning `None` instead of being abstract), allowing subclasses to omit it if they don't support CLI.

💡 **Why:**
- `LufsMeter.run` was a dead code stub ("not fully implemented") and the CLI functionality is currently frozen/removed from the project.
- Making `MeasurementModule.run` optional reduces boilerplate in subclasses that are GUI-only.
- Improves code health by removing unused imports and methods.

✅ **Verification:**
- Verified that `MeasurementModule` changes do not break subclasses that *do* implement `run` (like `LoopbackFinder`) or those that don't (like `LufsMeter`) using a custom test script `tests/functional/test_measurement_module_run.py`.
- Confirmed that `ruff` rule `B027` is satisfied by using `return None` in the base class.

✨ **Result:**
- Cleaner `LufsMeter` code and a more flexible `MeasurementModule` base class.

---
*PR created automatically by Jules for task [13730495513410037043](https://jules.google.com/task/13730495513410037043) started by @youtube-at-vach*