### PR TITLE
🧹 Remove dead CLI code from LockInAmplifier and update base class

### DIFF
--- a/src/gui/widgets/lock_in_amplifier.py
+++ b/src/gui/widgets/lock_in_amplifier.py
@@ -1,4 +1,3 @@
-import argparse
 import threading
 import time
 from collections import deque
@@ -116,9 +115,6 @@ class LockInAmplifier(MeasurementModule):
     @property
     def description(self) -> str:
         return "Dual-phase lock-in detection."
-
-    def run(self, args: argparse.Namespace):
-        print("Lock-in Amplifier running from CLI (not fully implemented)")
 
     def get_widget(self):
         return LockInAmplifierWidget(self)

--- a/src/measurement_modules/base.py
+++ b/src/measurement_modules/base.py
@@ -22,13 +22,12 @@ class MeasurementModule(ABC):
         """Brief description of the module's purpose."""
         pass
 
-    @abstractmethod
     def run(self, args: argparse.Namespace):
         """
         Execute the measurement from CLI.
         Currently frozen/not implemented for most modules.
         """
-        pass
+        return None
 
     def get_widget(self):
         """


### PR DESCRIPTION
This PR addresses a code health issue by removing the dead `run` method stub in `LockInAmplifier`. To do this safely, `MeasurementModule.run` was converted from an abstract method to a concrete method with a default implementation (`return None`), as CLI functionality is currently frozen. This allows `LockInAmplifier` (and other future modules) to inherit the default behavior without implementing a stub.

**Changes:**
- `src/measurement_modules/base.py`: Removed `@abstractmethod` from `run`, changed `pass` to `return None`.
- `src/gui/widgets/lock_in_amplifier.py`: Removed `run` method and `import argparse`.

**Verification:**
- Verified that `LockInAmplifier` can be instantiated without `TypeError` using a custom test script mocking dependencies.
- Confirmed that inheritance remains valid and `run` returns `None`.

---
*PR created automatically by Jules for task [11965070182559032416](https://jules.google.com/task/11965070182559032416) started by @youtube-at-vach*