### PR TITLE
Refactor: remove dead CLI code from BoxcarAverager

### DIFF
--- a/src/gui/widgets/boxcar_averager.py
+++ b/src/gui/widgets/boxcar_averager.py
@@ -1,4 +1,3 @@
-import argparse
 import time
 
 import numpy as np
@@ -91,9 +90,6 @@ class BoxcarAverager(MeasurementModule):
     @property
     def description(self) -> str:
         return "High-precision signal averaging for transient analysis."
-
-    def run(self, args: argparse.Namespace):
-        print("Boxcar Averager CLI not implemented")
 
     def get_widget(self):
         return BoxcarAveragerWidget(self)

--- a/src/measurement_modules/base.py
+++ b/src/measurement_modules/base.py
@@ -22,13 +22,12 @@ class MeasurementModule(ABC):
         """Brief description of the module's purpose."""
         pass
 
-    @abstractmethod
     def run(self, args: argparse.Namespace):
         """
         Execute the measurement from CLI.
         Currently frozen/not implemented for most modules.
         """
-        pass
+        print(f"CLI run not implemented for {self.name}")
 
     def get_widget(self):
         """


### PR DESCRIPTION
**What:** Removed the `run` method and `argparse` import from `src/gui/widgets/boxcar_averager.py`. Modified `src/measurement_modules/base.py` to make `run` a concrete method with a default "not implemented" message instead of an abstract method.

**Why:** The CLI functionality is frozen/suspended, so the `run` method in `BoxcarAverager` was dead code. Removing it improves code health and readability. Making the base class method concrete allows other modules to also omit this unused method in the future without violating the ABC contract.

**Verification:** 
- Created a reproduction script `reproduce_issue.py` to confirm that `MeasurementModule` subclasses can now be instantiated without `run`.
- Ran existing tests `tests/logic_verification/test_boxcar_*.py` which passed, confirming no regression in `BoxcarAverager` logic.

**Result:** Cleaner code in `BoxcarAverager` and a more flexible base class for future cleanups.

---
*PR created automatically by Jules for task [9293220785460788633](https://jules.google.com/task/9293220785460788633) started by @youtube-at-vach*