### PR TITLE
🧹 Remove dead CLI code from OnePPSMonitor

### DIFF
--- a/src/gui/widgets/one_pps_monitor.py
+++ b/src/gui/widgets/one_pps_monitor.py
@@ -1,4 +1,3 @@
-import argparse
 import threading
 import time
 import queue
@@ -92,10 +91,6 @@ class OnePPSMonitor(MeasurementModule):
 
     def get_widget(self):
         return OnePPSMonitorWidget(self)
-
-    def run(self, args: argparse.Namespace):
-        """CLI entry point (not used in GUI mode)."""
-        print("1PPS Monitor CLI mode not implemented.")
 
     def start_analysis(self):
         if self.is_running:

--- a/src/measurement_modules/base.py
+++ b/src/measurement_modules/base.py
@@ -1,4 +1,5 @@
 import argparse
+import logging
 from abc import ABC, abstractmethod
 
 
@@ -22,13 +23,12 @@ class MeasurementModule(ABC):
         """Brief description of the module's purpose."""
         pass
 
-    @abstractmethod
     def run(self, args: argparse.Namespace):
         """
         Execute the measurement from CLI.
         Currently frozen/not implemented for most modules.
         """
-        pass
+        logging.debug(f"CLI run not implemented for {self.name}")
 
     def get_widget(self):
         """


### PR DESCRIPTION
🎯 **What:** Removed the unused `run` method and `argparse` import from `src/gui/widgets/one_pps_monitor.py`. Updated `src/measurement_modules/base.py` to make `run` a concrete method with a default logging implementation.

💡 **Why:** The `run` method in `OnePPSMonitor` was a dead code stub containing only a print statement. CLI functionality is currently frozen. Removing this stub improves readability and maintainability. Making `MeasurementModule.run` concrete allows other widgets to also omit this stub in the future without violating the abstract base class contract.

✅ **Verification:**
- Ran `tests/functional/test_one_pps_logic.py` and `tests/functional/test_one_pps_improvements.py` to ensure `OnePPSMonitor` can still be instantiated and functions correctly.
- Confirmed that `OnePPSMonitor` inherits from `MeasurementModule` and that the instantiation succeeds with the updated base class.

✨ **Result:** Cleaner code in `OnePPSMonitor` and a more flexible base class structure.

---
*PR created automatically by Jules for task [13626283415999960208](https://jules.google.com/task/13626283415999960208) started by @youtube-at-vach*