### PR TITLE
🧹 Refactor: Remove dead CLI code from Oscilloscope and update MeasurementModule

### DIFF
--- a/src/gui/widgets/oscilloscope.py
+++ b/src/gui/widgets/oscilloscope.py
@@ -1,4 +1,3 @@
-import argparse
 import threading
 
 import numpy as np
@@ -137,9 +136,6 @@ class Oscilloscope(MeasurementModule):
 
         # Accumulate
         np.add.at(heatmap, (x_idx, y_idx), intensity * 100)
-
-    def run(self, args: argparse.Namespace):
-        print("Oscilloscope running from CLI (not fully implemented)")
 
     def get_widget(self):
         return OscilloscopeWidget(self)

--- a/src/measurement_modules/base.py
+++ b/src/measurement_modules/base.py
@@ -22,13 +22,12 @@ class MeasurementModule(ABC):
         """Brief description of the module's purpose."""
         pass
 
-    @abstractmethod
     def run(self, args: argparse.Namespace):
         """
         Execute the measurement from CLI.
         Currently frozen/not implemented for most modules.
         """
-        pass
+        return None
 
     def get_widget(self):
         """


### PR DESCRIPTION
This PR removes the dead `run` method from the `Oscilloscope` widget, which was a leftover stub for CLI functionality. It also refactors the base `MeasurementModule` class to make the `run` method concrete with a default no-op implementation. This change simplifies the `Oscilloscope` class and improves the maintainability of the `MeasurementModule` hierarchy by allowing subclasses to opt-out of CLI implementation without violating abstract class requirements.

Changes:
- `src/gui/widgets/oscilloscope.py`: Removed `run` method and `argparse` import.
- `src/measurement_modules/base.py`: Removed `@abstractmethod` from `run` and added default `return None` implementation.

Verification:
- Ran `ruff` to ensure no linting errors.
- Ran `pytest` on `tests/functional/test_oscilloscope_*.py` and `tests/logic_verification/test_oscilloscope_*.py` to ensure no regressions. All tests passed.

---
*PR created automatically by Jules for task [12930575720103977226](https://jules.google.com/task/12930575720103977226) started by @youtube-at-vach*