### PR TITLE
🧹 Remove dead CLI run method from SignalGenerator

### DIFF
--- a/src/gui/widgets/signal_generator.py
+++ b/src/gui/widgets/signal_generator.py
@@ -1,4 +1,3 @@
-import argparse
 import logging
 from dataclasses import dataclass
 from typing import Optional
@@ -118,9 +117,6 @@ class SignalGenerator(MeasurementModule):
     @property
     def description(self) -> str:
         return "Generates advanced test signals (Sine, Square, Noise, Sweeps) with independent channel control"
-
-    def run(self, args: argparse.Namespace):
-        print("Signal Generator running from CLI (not fully implemented)")
 
     def get_widget(self):
         return SignalGeneratorWidget(self)

--- a/src/measurement_modules/base.py
+++ b/src/measurement_modules/base.py
@@ -22,13 +22,12 @@ class MeasurementModule(ABC):
         """Brief description of the module's purpose."""
         pass
 
-    @abstractmethod
     def run(self, args: argparse.Namespace):
         """
         Execute the measurement from CLI.
         Currently frozen/not implemented for most modules.
         """
-        pass
+        return None
 
     def get_widget(self):
         """


### PR DESCRIPTION
Removed the dead `run` method from `SignalGenerator` and refactored `MeasurementModule.base` to allow optional implementation of `run`. This cleans up unused CLI code while preserving application stability. Verified with reproduction script and lint checks.

---
*PR created automatically by Jules for task [3573755063045520965](https://jules.google.com/task/3573755063045520965) started by @youtube-at-vach*