### PR TITLE
🧹 Refactor MeasurementModule to remove dead CLI code from widgets

### DIFF
--- a/src/gui/widgets/linearity_analyzer.py
+++ b/src/gui/widgets/linearity_analyzer.py
@@ -1,4 +1,3 @@
-import argparse
 import logging
 import time
 import numpy as np
@@ -242,9 +241,6 @@ class LinearityAnalyzer(MeasurementModule):
     @property
     def description(self) -> str:
         return "Measure Linearity Error (Gain Accuracy vs Level)."
-
-    def run(self, args: argparse.Namespace):
-        logger.warning("CLI not implemented")
 
     def get_latest_buffer(self) -> np.ndarray:
         """Returns the current buffer contents ordered chronologically."""

--- a/src/gui/widgets/oscilloscope.py
+++ b/src/gui/widgets/oscilloscope.py
@@ -1,4 +1,3 @@
-import argparse
 import threading
 
 import numpy as np
@@ -137,9 +136,6 @@ class Oscilloscope(MeasurementModule):
 
         # Accumulate
         np.add.at(heatmap, (x_idx, y_idx), intensity * 100)
-
-    def run(self, args: argparse.Namespace):
-        print("Oscilloscope running from CLI (not fully implemented)")
 
     def get_widget(self):
         return OscilloscopeWidget(self)

--- a/src/gui/widgets/recorder_player.py
+++ b/src/gui/widgets/recorder_player.py
@@ -113,9 +113,6 @@ class RecorderPlayer(MeasurementModule):
     def description(self) -> str:
         return "Record and play audio files (WAV, MP3, FLAC, etc.)"
 
-    def run(self, args):
-        pass
-
     def get_widget(self):
         if self.widget is None:
             self.widget = RecorderPlayerWidget(self)

--- a/src/gui/widgets/signal_generator.py
+++ b/src/gui/widgets/signal_generator.py
@@ -1,4 +1,3 @@
-import argparse
 import logging
 from dataclasses import dataclass
 from typing import Optional
@@ -118,9 +117,6 @@ class SignalGenerator(MeasurementModule):
     @property
     def description(self) -> str:
         return "Generates advanced test signals (Sine, Square, Noise, Sweeps) with independent channel control"
-
-    def run(self, args: argparse.Namespace):
-        print("Signal Generator running from CLI (not fully implemented)")
 
     def get_widget(self):
         return SignalGeneratorWidget(self)

--- a/src/measurement_modules/base.py
+++ b/src/measurement_modules/base.py
@@ -22,13 +22,12 @@ class MeasurementModule(ABC):
         """Brief description of the module's purpose."""
         pass
 
-    @abstractmethod
     def run(self, args: argparse.Namespace):
         """
         Execute the measurement from CLI.
         Currently frozen/not implemented for most modules.
         """
-        pass
+        return None
 
     def get_widget(self):
         """


### PR DESCRIPTION
This PR addresses the code health issue of dead CLI `run` methods in GUI widgets.

**Changes:**
1.  Refactored `MeasurementModule` (base class) to make `run` a concrete method with a default implementation (`return None`). This removes the need for subclasses to implement a stub if they don't support CLI.
2.  Removed the `run` method and associated unused `argparse` imports from:
    *   `LinearityAnalyzer`
    *   `Oscilloscope`
    *   `RecorderPlayer`
    *   `SignalGenerator`

**Verification:**
*   Ran `ruff check .` to ensure linting passes (especially regarding unused imports).
*   Ran logic verification tests for the modified widgets (`tests/logic_verification/test_linearity_analyzer_logic.py`, `tests/logic_verification/test_oscilloscope_trigger_logic.py`, etc.) to ensure that class instantiation and basic logic remain functional.
*   Verified that `MeasurementModule` changes do not break the API contract for other modules (they simply inherit the default implementation).

**Why:**
The CLI functionality is currently frozen/suspended. Forcing every GUI widget to implement a `run` stub that just prints "not implemented" adds unnecessary noise and imports to the codebase. This refactor cleans up this technical debt.

---
*PR created automatically by Jules for task [1884503121210658093](https://jules.google.com/task/1884503121210658093) started by @youtube-at-vach*