### PR TITLE
Potential fix for code scanning alert no. 181: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,5 +1,7 @@
 name: Lint GitHub Actions workflows
 on: [push, pull_request]
+permissions:
+  contents: read
 
 jobs:
   actionlint:


### PR DESCRIPTION
Potential fix for [https://github.com/youtube-at-vach/MeasureLab/security/code-scanning/181](https://github.com/youtube-at-vach/MeasureLab/security/code-scanning/181)

In general, fix this by adding an explicit `permissions` block that grants only the minimal scopes needed, either at the workflow root (applies to all jobs) or at the specific job level. For this workflow, the job merely checks out code and runs `actionlint` locally; it does not need write access. The minimal and appropriate fix is to add `permissions: contents: read` at the workflow root so all jobs, including `actionlint`, run with a read-only token for repository contents.

Concretely, edit `.github/workflows/actionlint.yml` to insert a `permissions:` section after the `on:` line, e.g. on a new line 3. This block should set `contents: read`, which matches GitHub’s recommended minimal starting point and aligns with the CodeQL suggestion. No additional imports or methods are required because this is a YAML configuration change only and does not alter the existing workflow functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
