### PR TITLE
Potential fix for code scanning alert no. 181: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,5 +1,7 @@
 name: Lint GitHub Actions workflows
 on: [pull_request]
+permissions:
+  contents: read
 
 jobs:
   actionlint:


### PR DESCRIPTION
Potential fix for [https://github.com/youtube-at-vach/MeasureLab/security/code-scanning/181](https://github.com/youtube-at-vach/MeasureLab/security/code-scanning/181)

To fix the problem, add an explicit `permissions` block that grants only the minimal access required by this workflow. Since this job only checks out the repository and runs a linter, it only needs read access to repository contents.

The best approach without changing behavior is to add `permissions: contents: read` at the workflow (root) level, just under the `on:` key. This will apply to all jobs in the workflow (currently just `actionlint`) and restrict the `GITHUB_TOKEN` for this workflow to read-only repository contents, which is sufficient for `actions/checkout` and does not change what the current steps can do.

Concretely, in `.github/workflows/actionlint.yml`, insert:

```yml
permissions:
  contents: read
```

between lines 2 and 4 (after `on: [pull_request]` and before `jobs:`). No additional imports, methods, or other definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
