### PR TITLE
🧪 Improve LockInFrequencyCounter testing

### DIFF
--- a/tests/logic_verification/test_lockin_counter.py
+++ b/tests/logic_verification/test_lockin_counter.py
@@ -1,57 +1,138 @@
-
+import sys
+import unittest
 import numpy as np
+from unittest.mock import MagicMock, patch
 
-from src.gui.widgets.lock_in_frequency_counter import LockInFrequencyCounter
+# Mock PyQt6 and pyqtgraph before importing the widget
+# This is necessary because the module imports PyQt6 widgets at the top level
+mock_qt_widgets = MagicMock()
+mock_qt_core = MagicMock()
+mock_pyqtgraph = MagicMock()
 
-
-# Mock AudioEngine
-class MockAudioEngine:
-    def __init__(self):
-        self.sample_rate = 48000
-
-    def register_callback(self, cb):
-        return 1
-
-    def unregister_callback(self, id):
+# Create a dummy QWidget class for inheritance
+class DummyQWidget:
+    def __init__(self, *args, **kwargs):
         pass
 
-def test_frequency_calculation():
-    engine = MockAudioEngine()
-    counter = LockInFrequencyCounter(engine)
-    counter.gen_frequency = 1000.0 # NCO
+mock_qt_widgets.QWidget = DummyQWidget
+mock_qt_core.Qt = MagicMock()
 
-    # Create a signal at 1001.0 Hz (Delta = +1.0 Hz)
-    sr = 48000
-    4096 / sr
-    t = np.arange(4096) / sr
-    sig = np.cos(2 * np.pi * 1001.0 * t) # 1001 Hz
+# Patch sys.modules
+with patch.dict(sys.modules, {
+    "PyQt6.QtWidgets": mock_qt_widgets,
+    "PyQt6.QtCore": mock_qt_core,
+    "pyqtgraph": mock_pyqtgraph,
+}):
+    from src.gui.widgets.lock_in_frequency_counter import LockInFrequencyCounter
 
-    # Fill input data
-    counter.input_data[:, 0] = sig
-    counter.is_running = True
+class TestLockInFrequencyCounter(unittest.TestCase):
+    def setUp(self):
+        self.mock_audio_engine = MagicMock()
+        self.mock_audio_engine.sample_rate = 48000
+        self.counter = LockInFrequencyCounter(self.mock_audio_engine)
+        self.counter.gen_frequency = 1000.0
+        self.counter.buffer_size = 4096
 
-    # Process
-    counter.process_data()
+        # Helper for creating signals
+        self.fs = 48000
+        self.t = np.arange(self.counter.buffer_size) / self.fs
 
-    print(f"Measured Delta F: {counter.current_freq_dev}")
+    def create_signal(self, freq, amplitude=1.0, phase=0.0):
+        return amplitude * np.cos(2 * np.pi * freq * self.t + phase)
 
-    # Allow small error due to windowing/segmentation approximate method
-    assert abs(counter.current_freq_dev - 1.0) < 0.05
+    def test_frequency_calculation_steady_state(self):
+        """Test accurate frequency deviation measurement."""
+        # 1001 Hz signal (1 Hz deviation from 1000 Hz NCO)
+        sig = self.create_signal(1001.0)
 
-def test_negative_frequency_deviation():
-    engine = MockAudioEngine()
-    counter = LockInFrequencyCounter(engine)
-    counter.gen_frequency = 1000.0
+        self.counter.input_data[:, 0] = sig
+        self.counter.signal_channel = 0
+        self.counter.is_running = True
 
-    # Create a signal at 999.0 Hz (Delta = -1.0 Hz)
-    sr = 48000
-    t = np.arange(4096) / sr
-    sig = np.cos(2 * np.pi * 999.0 * t)
+        # Bypass transient suppression manually for this test
+        self.counter._samples_received = 0
+        self.counter._discard_initial_estimates = 0
 
-    counter.input_data[:, 0] = sig
-    counter.is_running = True
+        self.counter.process_data()
 
-    counter.process_data()
+        self.assertTrue(self.counter.signal_present)
+        # Allow small error (0.05 Hz) due to windowing/segmentation
+        self.assertAlmostEqual(self.counter.current_freq_dev, 1.0, delta=0.05)
 
-    print(f"Measured Delta F: {counter.current_freq_dev}")
-    assert abs(counter.current_freq_dev - (-1.0)) < 0.05
+    def test_startup_transient_suppression(self):
+        """Test that initial estimates are discarded on startup."""
+        self.counter.start_analysis() # Sets _discard_initial_estimates = 3
+
+        # 1001 Hz signal
+        sig = self.create_signal(1001.0)
+        self.counter.input_data[:, 0] = sig
+
+        # 1st call - should be discarded
+        self.counter.process_data()
+        self.assertEqual(self.counter.current_freq_dev, 0.0)
+        self.assertEqual(self.counter._estimates_discarded, 1)
+
+        # 2nd call - should be discarded
+        self.counter.process_data()
+        self.assertEqual(self.counter.current_freq_dev, 0.0)
+        self.assertEqual(self.counter._estimates_discarded, 2)
+
+        # 3rd call - should be discarded
+        self.counter.process_data()
+        self.assertEqual(self.counter.current_freq_dev, 0.0)
+        self.assertEqual(self.counter._estimates_discarded, 3)
+
+        # 4th call - should process
+        self.counter.process_data()
+        self.assertNotEqual(self.counter.current_freq_dev, 0.0)
+        self.assertAlmostEqual(self.counter.current_freq_dev, 1.0, delta=0.05)
+
+    def test_signal_gate(self):
+        """Test that low amplitude signals are ignored."""
+        self.counter.is_running = True
+        self.counter._discard_initial_estimates = 0
+
+        # Very weak signal (-80 dB)
+        amp_db = -80.0
+        amp_lin = 10**(amp_db/20.0)
+        sig = self.create_signal(1000.0, amplitude=amp_lin)
+
+        self.counter.input_data[:, 0] = sig
+        self.counter.gate_threshold_db = -60.0
+
+        self.counter.process_data()
+
+        self.assertFalse(self.counter.signal_present)
+
+        # Strong signal (-40 dB)
+        amp_db = -40.0
+        amp_lin = 10**(amp_db/20.0)
+        sig = self.create_signal(1000.0, amplitude=amp_lin)
+
+        self.counter.input_data[:, 0] = sig
+        self.counter.process_data()
+
+        self.assertTrue(self.counter.signal_present)
+
+    def test_pid_lock_behavior(self):
+        """Test that PID controller updates NCO frequency when locked."""
+        self.counter.locked = True
+        self.counter.is_running = True
+        self.counter._discard_initial_estimates = 0
+        self.counter.gen_frequency = 1000.0
+
+        # Input signal at 1005 Hz (Error = +5 Hz)
+        sig = self.create_signal(1005.0)
+        self.counter.input_data[:, 0] = sig
+
+        # First iteration
+        self.counter.process_data()
+
+        # PID should have adjusted gen_frequency towards 1005 Hz
+        # With Kp=0.5, error=5.0, P-term = 2.5
+        # New freq should be around 1002.5 + I/D terms
+        self.assertNotEqual(self.counter.gen_frequency, 1000.0)
+        self.assertTrue(self.counter.gen_frequency > 1000.0)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Improved testing for `LockInFrequencyCounter` by replacing basic functional tests with a comprehensive `unittest.TestCase` suite.
The new tests mock `PyQt6` and `pyqtgraph` to allow running logic verification without a GUI environment.
Added specific test cases for:
- `test_frequency_calculation_steady_state`: Verifies accurate frequency deviation measurement for a known signal.
- `test_startup_transient_suppression`: Verifies that `_discard_initial_estimates` logic correctly ignores the first few buffers to prevent startup glitches.
- `test_signal_gate`: Verifies that signals below `gate_threshold_db` are ignored.
- `test_pid_lock_behavior`: Verifies that the PID controller updates the NCO frequency when the FLL is locked.
Verified that all tests pass, including the new suite and existing tests.

---
*PR created automatically by Jules for task [17540924756383072295](https://jules.google.com/task/17540924756383072295) started by @youtube-at-vach*