### PR TITLE
Remove dead security check in CalibrationManager

### DIFF
--- a/src/core/calibration.py
+++ b/src/core/calibration.py
@@ -238,20 +238,11 @@ class CalibrationManager:
 
     # --- Frequency Correction Map ---
 
-    def _is_path_allowed(self, path):
-        # Allow loading calibration files from any location.
-        # Previously restricted to config directory, but this was too limiting.
-        return True
-
     def load_frequency_map(self, path):
         """
         Loads a frequency correction map from a JSON file.
         Format: [[freq, mag_db, phase_deg], ...]
         """
-        if not self._is_path_allowed(path):
-            self.logger.warning("Security Warning: Attempted to load calibration map from outside allowed directory: %s", path)
-            return False
-
         if not os.path.exists(path):
             self.logger.warning("Calibration map not found: %s", path)
             return False


### PR DESCRIPTION
Removed `_is_path_allowed` method and its usage in `src/core/calibration.py` to eliminate dead code and misleading security checks. Verified with existing tests.

---
*PR created automatically by Jules for task [10647648332415581403](https://jules.google.com/task/10647648332415581403) started by @youtube-at-vach*