### PR TITLE
Refactor LocalizationManager to remove custom singleton pattern

### DIFF
--- a/src/core/localization.py
+++ b/src/core/localization.py
@@ -8,20 +8,10 @@ from src.core.utils import resource_path
 class LocalizationManager:
     """Manages application localization and translation loading."""
 
-    _instance = None
-
-    def __new__(cls, *args, **kwargs):
-        if not cls._instance:
-            cls._instance = super(LocalizationManager, cls).__new__(cls)
-        return cls._instance
-
     def __init__(self):
-        if hasattr(self, "initialized"):
-            return
         self.language = "en"
         self.translations = {}
         self.available_languages = {}
-        self.initialized = True
         self.logger = logging.getLogger(self.__class__.__name__)
         self.load_available_languages()
 

--- a/tests/logic_verification/test_localization_logic.py
+++ b/tests/logic_verification/test_localization_logic.py
@@ -3,29 +3,6 @@ from unittest.mock import patch, mock_open
 from src.core.localization import LocalizationManager, tr, get_manager
 
 class TestLocalizationManager(unittest.TestCase):
-    def setUp(self):
-        # Reset the singleton instance before each test
-        LocalizationManager._instance = None
-        # Reset the global manager if it was created
-        # Note: The module level _loc_manager is created on import.
-        # We can't easily reset that without reloading the module,
-        # but we can reset the class instance to verify new creations.
-
-    def test_singleton(self):
-        """Test that LocalizationManager is a singleton."""
-        with patch("src.core.localization.resource_path") as mock_path, \
-             patch("os.path.exists") as mock_exists, \
-             patch("os.listdir") as mock_listdir:
-
-            mock_path.return_value = "/fake/path"
-            mock_exists.return_value = True
-            mock_listdir.return_value = []
-
-            m1 = LocalizationManager()
-            m2 = LocalizationManager()
-            self.assertIs(m1, m2)
-            self.assertTrue(m1.initialized)
-
     def test_init_scans_directory(self):
         """Test that available languages are scanned correctly."""
         with patch("src.core.localization.resource_path") as mock_path, \


### PR DESCRIPTION
Removed non-standard singleton implementation from `LocalizationManager`.
- Removed `__new__` and `_instance` from `src/core/localization.py`.
- Removed `test_singleton` from `tests/logic_verification/test_localization_logic.py`.
- Verified that `get_manager()` and `tr()` still function correctly via the module-level instance.


---
*PR created automatically by Jules for task [18262038881843794043](https://jules.google.com/task/18262038881843794043) started by @youtube-at-vach*