### PR TITLE
Refactor main_gui.py to fix module-level execution

### DIFF
--- a/main_gui.py
+++ b/main_gui.py
@@ -3,117 +3,30 @@ import os
 import signal
 import sys
 
-# Suppress benign GNOME portal Settings warnings like:
-#   qt.qpa.theme.gnome: dbus reply error: ... org.freedesktop.portal.Settings
-# This must be set before importing Qt/PyQt.
-_qt_rule = "qt.qpa.theme.gnome=false"
-_existing_rules = os.environ.get("QT_LOGGING_RULES")
-if not _existing_rules:
-    os.environ["QT_LOGGING_RULES"] = _qt_rule
+from src.core.config_manager import ConfigManager
+from src.core.localization import get_manager, tr
+from src.core.utils import resource_path
+from src.core.fft_manager import fft_manager
 
-from PyQt6.QtCore import QEvent, QObject, Qt, QTimer  # noqa: E402
-from PyQt6.QtGui import QPixmap, QPainter  # noqa: E402
-from PyQt6.QtWidgets import QApplication, QSplashScreen, QWidget  # noqa: E402
-
-from src.core.config_manager import ConfigManager  # noqa: E402
-from src.core.localization import get_manager, tr  # noqa: E402
-from src.core.utils import resource_path  # noqa: E402
-from src.core.fft_manager import fft_manager  # noqa: E402
-from src.gui.main_window import MainWindow  # noqa: E402
-
-
-class _TopLevelWindowLogger(QObject):
-    """Optional startup logger to identify transient top-level windows.
-
-    Enable by setting environment variable MEASURELAB_DEBUG_WINDOWS=1.
-    """
-
-    def __init__(self, parent=None):
-        super().__init__(parent)
-        self._trace_enabled = os.environ.get("MEASURELAB_DEBUG_WINDOWS_TRACE", "").strip() not in (
-            "",
-            "0",
-            "false",
-            "False",
-        )
-        self._traced_ids = set()
-
-    def _maybe_trace(self, obj: QWidget) -> None:
-        if not self._trace_enabled:
-            return
-
-        try:
-            oid = int(obj.winId()) if obj.winId() else id(obj)
-        except Exception:
-            oid = id(obj)
-
-        if oid in self._traced_ids:
-            return
-
-        self._traced_ids.add(oid)
-
-        try:
-            import traceback
-
-            print("[window-trace] begin")
-            for line in traceback.format_stack(limit=40):
-                print(line.rstrip("\n"))
-            print("[window-trace] end")
-        except Exception:
-            pass
-
-    def eventFilter(self, obj, event):
-        try:
-            if isinstance(obj, QWidget) and obj.isWindow():
-                et = event.type()
-                if et in (QEvent.Type.Show, QEvent.Type.Resize, QEvent.Type.WindowTitleChange):
-                    g = obj.geometry()
-                    title = obj.windowTitle()
-                    name = obj.__class__.__name__
-                    print(
-                        f"[window] {name} title='{title}' event={int(et)} "
-                        f"geom=({g.x()},{g.y()},{g.width()}x{g.height()}) visible={obj.isVisible()}"
-                    )
-
-                    # Trace suspicious tiny, untitled top-level windows (often the 'flash').
-                    if et == QEvent.Type.Show and not title:
-                        if 0 < g.width() <= 650 and 0 < g.height() <= 120:
-                            self._maybe_trace(obj)
-        except Exception:
-            pass
-
-        return super().eventFilter(obj, event)
-
-
-class WrappingSplashScreen(QSplashScreen):
-    """
-    Custom QSplashScreen that supports text wrapping and padding.
-    """
-    def __init__(self, pixmap):
-        super().__init__(pixmap)
-        self._message = ""
-        self._alignment = Qt.AlignmentFlag.AlignBottom | Qt.AlignmentFlag.AlignHCenter
-        self._color = Qt.GlobalColor.black
-
-    def showMessage(self, message, alignment=Qt.AlignmentFlag.AlignBottom | Qt.AlignmentFlag.AlignHCenter, color=Qt.GlobalColor.black):
-        self._message = message
-        self._alignment = alignment
-        self._color = color
-        # Call super to trigger repaint, but we'll override drawContents
-        super().showMessage(message, alignment, color)
-
-    def drawContents(self, painter: QPainter | None):
-        if painter is None:
-            return
-        painter.setPen(self._color)
-        # Add padding around the edges
-        margin = 20
-        rect = self.rect().adjusted(margin, margin, -margin, -margin)
-        # Draw text with word wrap
-        painter.drawText(rect, self._alignment | Qt.TextFlag.TextWordWrap, self._message)
 
 def main():
     """GUI Application Entry Point"""
+    # Suppress benign GNOME portal Settings warnings like:
+    #   qt.qpa.theme.gnome: dbus reply error: ... org.freedesktop.portal.Settings
+    # This must be set before importing Qt/PyQt.
+    _qt_rule = "qt.qpa.theme.gnome=false"
+    _existing_rules = os.environ.get("QT_LOGGING_RULES")
+    if not _existing_rules:
+        os.environ["QT_LOGGING_RULES"] = _qt_rule
+
+    # Import PyQt and GUI components only after setting the environment variable
+    from PyQt6.QtCore import Qt, QTimer
+    from PyQt6.QtGui import QPixmap
+    from PyQt6.QtWidgets import QApplication
+
+    from src.gui.main_window import MainWindow
+    from src.gui.startup import TopLevelWindowLogger, WrappingSplashScreen
+
     # Allow Ctrl+C to exit
     signal.signal(signal.SIGINT, signal.SIG_DFL)
 
@@ -130,7 +43,7 @@ def main():
 
     # Optional: log transient windows during startup to diagnose flashes.
     if os.environ.get("MEASURELAB_DEBUG_WINDOWS", "").strip() not in ("", "0", "false", "False"):
-        app._measurelab_window_logger = _TopLevelWindowLogger(app)  # keep a strong ref
+        app._measurelab_window_logger = TopLevelWindowLogger(app)  # keep a strong ref
         app.installEventFilter(app._measurelab_window_logger)
 
     # Startup splash (loading screen): show immediately while MainWindow initializes.
@@ -210,6 +123,7 @@ def main():
         QTimer.singleShot(5000, app.quit)
 
     sys.exit(app.exec())
+
 
 if __name__ == "__main__":
     main()

--- a/src/gui/startup.py
+++ b/src/gui/startup.py
@@ -1,0 +1,94 @@
+import os
+import traceback
+from PyQt6.QtCore import QEvent, QObject, Qt
+from PyQt6.QtGui import QPainter
+from PyQt6.QtWidgets import QSplashScreen, QWidget
+
+
+class TopLevelWindowLogger(QObject):
+    """Optional startup logger to identify transient top-level windows.
+
+    Enable by setting environment variable MEASURELAB_DEBUG_WINDOWS=1.
+    """
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._trace_enabled = os.environ.get("MEASURELAB_DEBUG_WINDOWS_TRACE", "").strip() not in (
+            "",
+            "0",
+            "false",
+            "False",
+        )
+        self._traced_ids = set()
+
+    def _maybe_trace(self, obj: QWidget) -> None:
+        if not self._trace_enabled:
+            return
+
+        try:
+            oid = int(obj.winId()) if obj.winId() else id(obj)
+        except Exception:
+            oid = id(obj)
+
+        if oid in self._traced_ids:
+            return
+
+        self._traced_ids.add(oid)
+
+        try:
+            print("[window-trace] begin")
+            for line in traceback.format_stack(limit=40):
+                print(line.rstrip("\n"))
+            print("[window-trace] end")
+        except Exception:
+            pass
+
+    def eventFilter(self, obj, event):
+        try:
+            if isinstance(obj, QWidget) and obj.isWindow():
+                et = event.type()
+                if et in (QEvent.Type.Show, QEvent.Type.Resize, QEvent.Type.WindowTitleChange):
+                    g = obj.geometry()
+                    title = obj.windowTitle()
+                    name = obj.__class__.__name__
+                    print(
+                        f"[window] {name} title='{title}' event={int(et)} "
+                        f"geom=({g.x()},{g.y()},{g.width()}x{g.height()}) visible={obj.isVisible()}"
+                    )
+
+                    # Trace suspicious tiny, untitled top-level windows (often the 'flash').
+                    if et == QEvent.Type.Show and not title:
+                        if 0 < g.width() <= 650 and 0 < g.height() <= 120:
+                            self._maybe_trace(obj)
+        except Exception:
+            pass
+
+        return super().eventFilter(obj, event)
+
+
+class WrappingSplashScreen(QSplashScreen):
+    """
+    Custom QSplashScreen that supports text wrapping and padding.
+    """
+    def __init__(self, pixmap):
+        super().__init__(pixmap)
+        self._message = ""
+        self._alignment = Qt.AlignmentFlag.AlignBottom | Qt.AlignmentFlag.AlignHCenter
+        self._color = Qt.GlobalColor.black
+
+    def showMessage(self, message, alignment=Qt.AlignmentFlag.AlignBottom | Qt.AlignmentFlag.AlignHCenter, color=Qt.GlobalColor.black):
+        self._message = message
+        self._alignment = alignment
+        self._color = color
+        # Call super to trigger repaint, but we'll override drawContents
+        super().showMessage(message, alignment, color)
+
+    def drawContents(self, painter: QPainter | None):
+        if painter is None:
+            return
+        painter.setPen(self._color)
+        # Add padding around the edges
+        margin = 20
+        rect = self.rect().adjusted(margin, margin, -margin, -margin)
+        # Draw text with word wrap
+        painter.drawText(rect, self._alignment | Qt.TextFlag.TextWordWrap, self._message)


### PR DESCRIPTION
This PR addresses a code health issue in `main_gui.py` where the `QT_LOGGING_RULES` environment variable was being set at module level, but imports of `PyQt6` were also happening at module level. Since PyQt imports trigger Qt initialization, setting the environment variable afterwards (or even before, if imports are at top level) at module level is fragile or incorrect depending on execution order.

The fix involves:
1.  Moving the environment variable setup into the `main()` function, ensuring it runs before any PyQt imports.
2.  Moving all PyQt-dependent imports and logic inside `main()`.
3.  Extracting the `_TopLevelWindowLogger` (renamed to `TopLevelWindowLogger`) and `WrappingSplashScreen` classes to a new file `src/gui/startup.py` to allow `main_gui.py` to be a clean entry point without module-level class definitions that depend on PyQt.

This ensures that importing `main_gui` (e.g., for testing or introspection) has no side effects and does not load Qt libraries.

---
*PR created automatically by Jules for task [8738190324928063977](https://jules.google.com/task/8738190324928063977) started by @youtube-at-vach*