### PR TITLE
Refactor _load_module_class to reduce boilerplate

### DIFF
--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -109,35 +109,35 @@ def _pyinstaller_imports():
     This function is never called.
     """
     if False:
-        from src.gui.widgets.advanced_distortion_meter import AdvancedDistortionMeter
-        from src.gui.widgets.bnim_meter import BNIMMeter
-        from src.gui.widgets.boxcar_averager import BoxcarAverager
-        from src.gui.widgets.distortion_analyzer import DistortionAnalyzer
-        from src.gui.widgets.frequency_counter import FrequencyCounter
-        from src.gui.widgets.goniometer import Goniometer
-        from src.gui.widgets.hrtf_player import HRTFPlayer
-        from src.gui.widgets.impedance_analyzer import ImpedanceAnalyzer
-        from src.gui.widgets.inverse_filter import InverseFilter
-        from src.gui.widgets.linearity_analyzer import LinearityAnalyzer
-        from src.gui.widgets.lock_in_amplifier import LockInAmplifier
-        from src.gui.widgets.lock_in_frequency_counter import LockInFrequencyCounter
-        from src.gui.widgets.lockin_thd_analyzer import LockInTHDAnalyzer
-        from src.gui.widgets.loopback_finder import LoopbackFinder
-        from src.gui.widgets.lufs_meter import LufsMeter
-        from src.gui.widgets.network_analyzer import NetworkAnalyzer
-        from src.gui.widgets.noise_profiler import NoiseProfiler
-        from src.gui.widgets.one_pps_monitor import OnePPSMonitor
-        from src.gui.widgets.oscilloscope import Oscilloscope
-        from src.gui.widgets.raw_time_series import RawTimeSeries
-        from src.gui.widgets.recorder_player import RecorderPlayer
-        from src.gui.widgets.signal_generator import SignalGenerator
-        from src.gui.widgets.sound_level_meter import SoundLevelMeter
-        from src.gui.widgets.sound_quality_analyzer import SoundQualityAnalyzer
-        from src.gui.widgets.spectrogram import Spectrogram
-        from src.gui.widgets.spectrum_analyzer import SpectrumAnalyzer
-        from src.gui.widgets.timecode_monitor import TimecodeMonitor
-        from src.gui.widgets.transient_analyzer import TransientAnalyzer
-        from src.gui.widgets.ultrasound_modulator import UltrasoundModulator
+        from src.gui.widgets.advanced_distortion_meter import AdvancedDistortionMeter  # noqa: F401
+        from src.gui.widgets.bnim_meter import BNIMMeter  # noqa: F401
+        from src.gui.widgets.boxcar_averager import BoxcarAverager  # noqa: F401
+        from src.gui.widgets.distortion_analyzer import DistortionAnalyzer  # noqa: F401
+        from src.gui.widgets.frequency_counter import FrequencyCounter  # noqa: F401
+        from src.gui.widgets.goniometer import Goniometer  # noqa: F401
+        from src.gui.widgets.hrtf_player import HRTFPlayer  # noqa: F401
+        from src.gui.widgets.impedance_analyzer import ImpedanceAnalyzer  # noqa: F401
+        from src.gui.widgets.inverse_filter import InverseFilter  # noqa: F401
+        from src.gui.widgets.linearity_analyzer import LinearityAnalyzer  # noqa: F401
+        from src.gui.widgets.lock_in_amplifier import LockInAmplifier  # noqa: F401
+        from src.gui.widgets.lock_in_frequency_counter import LockInFrequencyCounter  # noqa: F401
+        from src.gui.widgets.lockin_thd_analyzer import LockInTHDAnalyzer  # noqa: F401
+        from src.gui.widgets.loopback_finder import LoopbackFinder  # noqa: F401
+        from src.gui.widgets.lufs_meter import LufsMeter  # noqa: F401
+        from src.gui.widgets.network_analyzer import NetworkAnalyzer  # noqa: F401
+        from src.gui.widgets.noise_profiler import NoiseProfiler  # noqa: F401
+        from src.gui.widgets.one_pps_monitor import OnePPSMonitor  # noqa: F401
+        from src.gui.widgets.oscilloscope import Oscilloscope  # noqa: F401
+        from src.gui.widgets.raw_time_series import RawTimeSeries  # noqa: F401
+        from src.gui.widgets.recorder_player import RecorderPlayer  # noqa: F401
+        from src.gui.widgets.signal_generator import SignalGenerator  # noqa: F401
+        from src.gui.widgets.sound_level_meter import SoundLevelMeter  # noqa: F401
+        from src.gui.widgets.sound_quality_analyzer import SoundQualityAnalyzer  # noqa: F401
+        from src.gui.widgets.spectrogram import Spectrogram  # noqa: F401
+        from src.gui.widgets.spectrum_analyzer import SpectrumAnalyzer  # noqa: F401
+        from src.gui.widgets.timecode_monitor import TimecodeMonitor  # noqa: F401
+        from src.gui.widgets.transient_analyzer import TransientAnalyzer  # noqa: F401
+        from src.gui.widgets.ultrasound_modulator import UltrasoundModulator  # noqa: F401
 
 
 def _load_settings_widget_class():


### PR DESCRIPTION
Refactored `src/gui/main_window.py` to eliminate repetitive module loading functions.
Introduced `MODULE_REGISTRY` mapping module keys to their paths and class names.
Implemented `_load_module_class` using `importlib` for cleaner code.
Added `_pyinstaller_imports` to ensure static analysis tools (like PyInstaller) can still discover the lazy-loaded modules.
Verified the changes with a script that mocks heavy dependencies to ensure correct module resolution in a headless environment.

---
*PR created automatically by Jules for task [1026112853479872677](https://jules.google.com/task/1026112853479872677) started by @youtube-at-vach*