### PR TITLE
🧪 Add tests for ThemeManager logic

### DIFF
--- a/tests/logic_verification/test_theme_manager.py
+++ b/tests/logic_verification/test_theme_manager.py
@@ -98,7 +98,7 @@ class TestThemeManager(unittest.TestCase):
         if 'src.core.theme_manager' in sys.modules:
             importlib.reload(sys.modules['src.core.theme_manager'])
         else:
-            import src.core.theme_manager
+            importlib.import_module('src.core.theme_manager')
 
         self.module_under_test = sys.modules['src.core.theme_manager']
         self.ThemeManager = self.module_under_test.ThemeManager


### PR DESCRIPTION
This PR adds comprehensive unit tests for `src/core/theme_manager.py`. It uses `unittest.mock` to simulate PyQt6 components, allowing the tests to run in a headless environment without a display server. The tests cover initialization, valid and invalid theme setting, system theme detection (Qt 6.5+ hints and legacy palette fallback), and platform-specific workarounds for Windows. This improves the test coverage for core UI logic.

---
*PR created automatically by Jules for task [9657476223824296176](https://jules.google.com/task/9657476223824296176) started by @youtube-at-vach*