### PR TITLE
🧹 Refactor AudioEngine master_callback for improved readability

### DIFF
--- a/src/core/audio_engine.py
+++ b/src/core/audio_engine.py
@@ -121,6 +121,10 @@ class AudioEngine:
     Implements a mixer to support multiple simultaneous clients.
     """
 
+    MODE_STEREO = 0
+    MODE_LEFT = 1
+    MODE_RIGHT = 2
+
     def __init__(self):
         self.input_device = None
         self.output_device = None
@@ -143,6 +147,8 @@ class AudioEngine:
         # 'stereo', 'left', 'right'
         self.input_channel_mode = "stereo"
         self.output_channel_mode = "stereo"
+        self._current_in_mode = self.MODE_STEREO
+        self._current_out_mode = self.MODE_STEREO
 
         # Mixer State
         self.callbacks = {}  # id -> callback
@@ -344,6 +350,124 @@ class AudioEngine:
         if should_stop:
             self.stop_stream()
 
+    def _master_callback(self, indata, outdata, frames, time, status):
+        if status:
+            self.accumulated_status |= status
+
+        # Zero out master output buffer first
+        outdata.fill(0)
+
+        # Prepare logical input for clients
+        # Map Hardware Input -> Logical Input (Stereo usually, or as requested)
+
+        # If Loopback is enabled, use the last output buffer as input
+        # Works same for Virtual and Hardware:
+        # Virtual: indata is zeros. loopback copies stored last_out to logical_in.
+        # Hardware: indata is mic. loopback copies stored last_out to logical_in (ignoring mic).
+        # If Loopback is enabled OR we are in Offline Mode (where there is no other input),
+        # use the last output buffer as input.
+        use_loopback = self.loopback or self.offline_mode
+        if use_loopback and self.last_output_buffer is not None and len(self.last_output_buffer) == frames:
+            # We use the mixed output from the previous block
+            # last_output_buffer is (frames, logical_out_ch)
+            # We need to map it to logical_in (frames, 2)
+
+            # Assuming logical_out_ch is 2 (stereo) or 1 (mono)
+            # logical_in is usually stereo (2)
+
+            lb_src = self.last_output_buffer
+            # Reuse logical input buffer if possible to avoid allocation
+            if self._logical_in_buffer is None or self._logical_in_buffer.shape != (frames, 2):
+                # Allocate new buffer (zeros is safer than empty for initial state)
+                self._logical_in_buffer = np.zeros((frames, 2), dtype="float32")
+
+            logical_in = self._logical_in_buffer
+
+            if lb_src.shape[1] >= 2:
+                logical_in[:, :2] = lb_src[:, :2]
+            elif lb_src.shape[1] == 1:
+                logical_in[:, 0] = lb_src[:, 0]
+                logical_in[:, 1] = lb_src[:, 0]
+            else:
+                # Should not happen, but ensure silence if shape is unexpected
+                logical_in.fill(0)
+        else:
+            in_mode = self._current_in_mode
+            # Standard Hardware Input Mapping
+            if in_mode == self.MODE_LEFT:
+                logical_in = indata[:, 0:1]
+            elif in_mode == self.MODE_RIGHT:
+                if indata.shape[1] >= 2:
+                    logical_in = indata[:, 1:2]
+                else:
+                    logical_in = np.zeros((frames, 1))
+            else:  # stereo
+                logical_in = indata[:, 0:2]
+
+        out_mode = self._current_out_mode
+        # Create a temp output buffer for clients
+        logical_out_ch = 2 if out_mode == self.MODE_STEREO else 1
+
+        # Use cached callbacks (atomic read)
+        active_callbacks = self._cached_callbacks
+
+        if not active_callbacks:
+            # Even if no callbacks, we might need to update last_output_buffer (silence)
+            if use_loopback:
+                if self.last_output_buffer is None or len(self.last_output_buffer) != frames:
+                    self.last_output_buffer = np.zeros((frames, logical_out_ch), dtype="float32")
+                else:
+                    self.last_output_buffer.fill(0)
+            return
+
+        # Mix buffer
+        if self._mix_buffer is not None and self._mix_buffer.shape == (frames, logical_out_ch):
+            mix_buffer = self._mix_buffer
+            mix_buffer.fill(0)
+        else:
+            mix_buffer = np.zeros((frames, logical_out_ch), dtype="float32")
+            self._mix_buffer = mix_buffer
+
+        for cb in active_callbacks:
+            # Temp buffer for this client
+            if self._client_buffer is not None and self._client_buffer.shape == (frames, logical_out_ch):
+                client_out = self._client_buffer
+                client_out.fill(0)
+            else:
+                client_out = np.zeros_like(mix_buffer)
+                self._client_buffer = client_out
+
+            try:
+                cb(logical_in, client_out, frames, time, status)
+            except Exception as e:
+                # Optimization: Use non-blocking error tracking instead of print to avoid audio dropouts
+                self.last_callback_error = e
+                self.callback_error_count += 1
+                continue
+
+            # Sum to mix
+            mix_buffer += client_out
+
+        # Store for next loopback cycle
+        if use_loopback:
+            if self.last_output_buffer is None or self.last_output_buffer.shape != mix_buffer.shape:
+                self.last_output_buffer = np.empty_like(mix_buffer)
+            np.copyto(self.last_output_buffer, mix_buffer)
+
+        # Map Logical Output -> Hardware Output
+        if not self.mute_output:
+            if out_mode == self.MODE_STEREO:
+                outdata[:, 0:2] = mix_buffer
+            elif out_mode == self.MODE_LEFT:
+                outdata[:, 0:1] = mix_buffer
+                if outdata.shape[1] > 1:
+                    outdata[:, 1:] = 0
+            elif out_mode == self.MODE_RIGHT:
+                if outdata.shape[1] >= 2:
+                    outdata[:, 1:2] = mix_buffer
+                    outdata[:, 0] = 0
+        # If muted, outdata is already 0 filled at start of callback
+
     def _start_master_stream(self):
         """Starts the underlying sounddevice stream or VirtualStream."""
         if self.stream is not None:
@@ -353,24 +477,19 @@ class AudioEngine:
         in_mode_str = self.input_channel_mode
         out_mode_str = self.output_channel_mode
 
-        # Performance Optimization: Pre-calculate mode integers to avoid string comparison in callback
-        MODE_STEREO = 0
-        MODE_LEFT = 1
-        MODE_RIGHT = 2
-
         if in_mode_str == "left":
-            in_mode = MODE_LEFT
+            self._current_in_mode = self.MODE_LEFT
         elif in_mode_str == "right":
-            in_mode = MODE_RIGHT
+            self._current_in_mode = self.MODE_RIGHT
         else:
-            in_mode = MODE_STEREO
+            self._current_in_mode = self.MODE_STEREO
 
         if out_mode_str == "left":
-            out_mode = MODE_LEFT
+            self._current_out_mode = self.MODE_LEFT
         elif out_mode_str == "right":
-            out_mode = MODE_RIGHT
+            self._current_out_mode = self.MODE_RIGHT
         else:
-            out_mode = MODE_STEREO
+            self._current_out_mode = self.MODE_STEREO
 
         hw_in_ch = 2 if in_mode_str in ["right", "stereo"] else 1
         hw_out_ch = 2 if out_mode_str in ["right", "stereo"] else 1
@@ -378,131 +497,13 @@ class AudioEngine:
         # Reset loopback buffer
         self.last_output_buffer = None
 
-        def master_callback(indata, outdata, frames, time, status):
-            if status:
-                self.accumulated_status |= status
-
-            # Zero out master output buffer first
-            outdata.fill(0)
-
-            # Prepare logical input for clients
-            # Map Hardware Input -> Logical Input (Stereo usually, or as requested)
-
-            # If Loopback is enabled, use the last output buffer as input
-            # Works same for Virtual and Hardware: 
-            # Virtual: indata is zeros. loopback copies stored last_out to logical_in.
-            # Hardware: indata is mic. loopback copies stored last_out to logical_in (ignoring mic).
-            # If Loopback is enabled OR we are in Offline Mode (where there is no other input),
-            # use the last output buffer as input.
-            # Virtual: indata is zeros. loopback copies stored last_out to logical_in.
-            # Hardware: indata is mic. loopback copies stored last_out to logical_in (ignoring mic).
-            use_loopback = self.loopback or self.offline_mode
-            if use_loopback and self.last_output_buffer is not None and len(self.last_output_buffer) == frames:
-                # We use the mixed output from the previous block
-                # last_output_buffer is (frames, logical_out_ch)
-                # We need to map it to logical_in (frames, 2)
-
-                # Assuming logical_out_ch is 2 (stereo) or 1 (mono)
-                # logical_in is usually stereo (2)
-
-                lb_src = self.last_output_buffer
-                # Reuse logical input buffer if possible to avoid allocation
-                if self._logical_in_buffer is None or self._logical_in_buffer.shape != (frames, 2):
-                    # Allocate new buffer (zeros is safer than empty for initial state)
-                    self._logical_in_buffer = np.zeros((frames, 2), dtype="float32")
-
-                logical_in = self._logical_in_buffer
-
-                if lb_src.shape[1] >= 2:
-                    logical_in[:, :2] = lb_src[:, :2]
-                elif lb_src.shape[1] == 1:
-                    logical_in[:, 0] = lb_src[:, 0]
-                    logical_in[:, 1] = lb_src[:, 0]
-                else:
-                    # Should not happen, but ensure silence if shape is unexpected
-                    logical_in.fill(0)
-            else:
-                # Standard Hardware Input Mapping
-                if in_mode == MODE_LEFT:
-                    logical_in = indata[:, 0:1]
-                elif in_mode == MODE_RIGHT:
-                    if indata.shape[1] >= 2:
-                        logical_in = indata[:, 1:2]
-                    else:
-                        logical_in = np.zeros((frames, 1))
-                else:  # stereo
-                    logical_in = indata[:, 0:2]
-
-            # Create a temp output buffer for clients
-            logical_out_ch = 2 if out_mode == MODE_STEREO else 1
-
-            # Use cached callbacks (atomic read)
-            active_callbacks = self._cached_callbacks
-
-            if not active_callbacks:
-                # Even if no callbacks, we might need to update last_output_buffer (silence)
-                if use_loopback:
-                    if self.last_output_buffer is None or len(self.last_output_buffer) != frames:
-                        self.last_output_buffer = np.zeros((frames, logical_out_ch), dtype="float32")
-                    else:
-                        self.last_output_buffer.fill(0)
-                return
-
-            # Mix buffer
-            if self._mix_buffer is not None and self._mix_buffer.shape == (frames, logical_out_ch):
-                mix_buffer = self._mix_buffer
-                mix_buffer.fill(0)
-            else:
-                mix_buffer = np.zeros((frames, logical_out_ch), dtype="float32")
-                self._mix_buffer = mix_buffer
-
-            for cb in active_callbacks:
-                # Temp buffer for this client
-                if self._client_buffer is not None and self._client_buffer.shape == (frames, logical_out_ch):
-                    client_out = self._client_buffer
-                    client_out.fill(0)
-                else:
-                    client_out = np.zeros_like(mix_buffer)
-                    self._client_buffer = client_out
-
-                try:
-                    cb(logical_in, client_out, frames, time, status)
-                except Exception as e:
-                    # Optimization: Use non-blocking error tracking instead of print to avoid audio dropouts
-                    self.last_callback_error = e
-                    self.callback_error_count += 1
-                    continue
-
-                # Sum to mix
-                mix_buffer += client_out
-
-            # Store for next loopback cycle
-            if use_loopback:
-                if self.last_output_buffer is None or self.last_output_buffer.shape != mix_buffer.shape:
-                    self.last_output_buffer = np.empty_like(mix_buffer)
-                np.copyto(self.last_output_buffer, mix_buffer)
-
-            # Map Logical Output -> Hardware Output
-            if not self.mute_output:
-                if out_mode == MODE_STEREO:
-                    outdata[:, 0:2] = mix_buffer
-                elif out_mode == MODE_LEFT:
-                    outdata[:, 0:1] = mix_buffer
-                    if outdata.shape[1] > 1:
-                        outdata[:, 1:] = 0
-                elif out_mode == MODE_RIGHT:
-                    if outdata.shape[1] >= 2:
-                        outdata[:, 1:2] = mix_buffer
-                        outdata[:, 0] = 0
-            # If muted, outdata is already 0 filled at start of callback
-
         try:
             if self.offline_mode:
                 self.stream = VirtualStream(
                     samplerate=self.sample_rate,
                     blocksize=self.block_size,
                     channels=(hw_in_ch, hw_out_ch),
-                    callback=master_callback
+                    callback=self._master_callback
                 )
                 self.stream.start()
                 self.logger.info(f"Virtual (Offline) audio stream started. SR={self.sample_rate}")
@@ -528,7 +529,7 @@ class AudioEngine:
                     device=(self.input_device, self.output_device),
                     samplerate=self.sample_rate,
                     blocksize=self.block_size,
-                    callback=master_callback,
+                    callback=self._master_callback,
                     channels=(hw_in_ch, hw_out_ch),
                     dtype="float32",
                     latency="high",


### PR DESCRIPTION
This PR refactors `src/core/audio_engine.py` to address the "Complex Audio Stream Initialization" code health issue.

The `_start_master_stream` method contained a large inner function `master_callback` that handled complex logic for audio buffering, channel mapping, loopback, and mixing. This made the initialization method hard to read and maintain.

Changes:
- Extracted `master_callback` into a new private method `_master_callback`.
- Introduced class constants `MODE_STEREO`, `MODE_LEFT`, `MODE_RIGHT` to replace local constants.
- Introduced instance variables `self._current_in_mode` and `self._current_out_mode` to pass configuration state to the callback, eliminating the need for closure capturing.
- Updated `_start_master_stream` to calculate modes, set state, and pass `self._master_callback` to the stream.

Verification:
- Ran `tests/logic_verification/test_audio_engine_channel_mapping.py` and `tests/logic_verification/test_audio_engine_logic.py`.
- Tests passed, confirming that channel mapping, loopback logic, and callback registration work as expected.


---
*PR created automatically by Jules for task [13115190225569117100](https://jules.google.com/task/13115190225569117100) started by @youtube-at-vach*