### PR TITLE
Refactor CalibrationManager initialization and cache logic

### DIFF
--- a/src/core/calibration.py
+++ b/src/core/calibration.py
@@ -27,6 +27,11 @@ class CalibrationManager:
         self.spl_offset_db = None
         self.profiles = {}
         self.last_profile = None
+        self.frequency_map = []
+        # Caches for vectorized interpolation
+        self._map_freqs = np.array([])
+        self._map_mags = np.array([])
+        self._map_phases = np.array([])
         self.load()
 
     def load(self):
@@ -252,6 +257,7 @@ class CalibrationManager:
                 data = json.load(f)
                 # Sort by frequency just in case
                 self.frequency_map = sorted(data, key=lambda x: x[0])
+                self._update_map_cache()
                 self.logger.info("Loaded calibration map with %d points.", len(self.frequency_map))
                 return True
         except Exception as e:
@@ -267,6 +273,7 @@ class CalibrationManager:
             with open(path, "w") as f:
                 json.dump(data, f, indent=4)
             self.frequency_map = sorted(data, key=lambda x: x[0])
+            self._update_map_cache()
             self.logger.info("Saved calibration map to %s", path)
             return True
         except Exception as e:
@@ -279,7 +286,7 @@ class CalibrationManager:
         Uses linear interpolation.
         Returns (0.0, 0.0) if no map is loaded.
         """
-        if not hasattr(self, "frequency_map") or not self.frequency_map:
+        if not self.frequency_map:
             return 0.0, 0.0
 
         # If out of range, clamp to nearest
@@ -288,30 +295,14 @@ class CalibrationManager:
         if freq >= self.frequency_map[-1][0]:
             return self.frequency_map[-1][1], self.frequency_map[-1][2]
 
-        # Binary search or simple search (map size usually < 1000)
-        # np.interp is convenient if we separate arrays, but here we have list of lists.
-        # Let's do a simple search or convert to numpy arrays on load?
-        # For now, simple search is fine for < 1000 points.
-
-        # Optimization: Convert to numpy arrays on load if performance is critical.
-        # But for now, let's just do it simply.
-
-        # Find index i such that map[i][0] <= freq < map[i+1][0]
-        # Using bisect would be faster but let's stick to basic python for clarity unless needed.
-
-        # Let's use numpy for interpolation, it's robust.
-        # We can cache the numpy arrays if this is called often (it is).
-
-        if not hasattr(self, "_map_freqs"):
-            self._update_map_cache()
-
+        # Use cached numpy arrays for interpolation
         mag_corr = np.interp(freq, self._map_freqs, self._map_mags)
         phase_corr = np.interp(freq, self._map_freqs, self._map_phases)
 
         return mag_corr, phase_corr
 
     def _update_map_cache(self):
-        if not hasattr(self, "frequency_map") or not self.frequency_map:
+        if not self.frequency_map:
             self._map_freqs = np.array([])
             self._map_mags = np.array([])
             self._map_phases = np.array([])

--- a/tests/logic_verification/test_calibration_manager.py
+++ b/tests/logic_verification/test_calibration_manager.py
@@ -236,9 +236,35 @@ def test_frequency_map_load_external(cal_manager, tmp_path):
 
 def test_no_frequency_map(cal_manager):
     """Test behavior when no frequency map is loaded."""
-    if hasattr(cal_manager, "frequency_map"):
-        del cal_manager.frequency_map
+    # Ensure it's empty
+    cal_manager.frequency_map = []
+    cal_manager._update_map_cache()
 
     mag, phase = cal_manager.get_frequency_correction(1000)
     assert mag == 0.0
     assert phase == 0.0
+
+def test_frequency_map_reload_cache_update(cal_manager, tmp_path):
+    """Test that reloading a frequency map updates the cache."""
+    map_path1 = tmp_path / "map1.json"
+    map_path2 = tmp_path / "map2.json"
+
+    # Map 1: 100Hz -> 10.0 dB
+    data1 = [[100, 10.0, 0.0]]
+    with open(map_path1, "w") as f:
+        json.dump(data1, f)
+
+    # Map 2: 100Hz -> 20.0 dB
+    data2 = [[100, 20.0, 0.0]]
+    with open(map_path2, "w") as f:
+        json.dump(data2, f)
+
+    # Load Map 1
+    cal_manager.load_frequency_map(str(map_path1))
+    mag, _ = cal_manager.get_frequency_correction(100)
+    assert mag == 10.0
+
+    # Load Map 2
+    cal_manager.load_frequency_map(str(map_path2))
+    mag, _ = cal_manager.get_frequency_correction(100)
+    assert mag == 20.0


### PR DESCRIPTION
🎯 **What:**
- Initialized `frequency_map` and numpy array caches (`_map_freqs`, `_map_mags`, `_map_phases`) in `CalibrationManager.__init__`.
- Updated `load_frequency_map` and `save_frequency_map` to call `_update_map_cache` ensures caches are always synchronized with `frequency_map`.
- Removed `hasattr` checks in `get_frequency_correction` and `_update_map_cache` as attributes are now guaranteed to exist.

💡 **Why:**
- Prevents potential `AttributeError` by ensuring consistent object state.
- Fixes a bug where reloading a frequency map would not update the internal interpolation caches, leading to stale data usage.
- Improves code readability by removing defensive `hasattr` checks.

✅ **Verification:**
- Ran `pytest tests/logic_verification/test_calibration_manager.py` which passed.
- Added `test_frequency_map_reload_cache_update` to verify the fix for the stale cache bug.
- Updated `test_no_frequency_map` to align with the new initialization logic.

✨ **Result:**
- `CalibrationManager` is more robust and predictable.
- Stale cache bug fixed.
- Code is cleaner and easier to maintain.

---
*PR created automatically by Jules for task [9864642218584141503](https://jules.google.com/task/9864642218584141503) started by @youtube-at-vach*