### PR TITLE
Fix SI formatting precision issue on rounding spillover

### DIFF
--- a/src/core/utils.py
+++ b/src/core/utils.py
@@ -47,8 +47,11 @@ def format_si(value, unit: str = "", sig_figs: int = 4, space: str = " ") -> str
     exp3 = int(math.floor(math.log10(ax) / 3.0) * 3)
     exp3 = max(min(exp3, 24), -24)
 
-    scale = 10.0**exp3
-    scaled = x / scale
+    # Use multiplication for negative exponents to avoid precision loss from dividing by small numbers.
+    if exp3 < 0:
+        scaled = x * (10.0**-exp3)
+    else:
+        scaled = x / (10.0**exp3)
 
     # Format first to check if rounding causes spillover
     number = f"{scaled:.{int(sig_figs)}g}"
@@ -57,8 +60,10 @@ def format_si(value, unit: str = "", sig_figs: int = 4, space: str = " ") -> str
     # If the formatted number rounds up to 1000 (or -1000), bump to next prefix.
     if abs(float(number)) >= 1000.0 and exp3 < 24:
         exp3 += 3
-        scale *= 1000.0
-        scaled = x / scale
+        if exp3 < 0:
+            scaled = x * (10.0**-exp3)
+        else:
+            scaled = x / (10.0**exp3)
         number = f"{scaled:.{int(sig_figs)}g}"
 
     prefix = _SI_PREFIXES.get(exp3, "")

--- a/tests/logic_verification/test_utils.py
+++ b/tests/logic_verification/test_utils.py
@@ -45,6 +45,11 @@ class TestFormatSI:
         # 999.99 with 5 sig figs is 999.99
         assert format_si(999.99, sig_figs=5) == "999.99"
 
+        # Edge case: Floating point precision issue (e.g., 0.99995 with 4 sig figs)
+        # 0.99995 -> rounds to 1.000 (1000 m or 1)
+        # Previous logic might return "999.9 m" due to precision loss in division by 0.001
+        assert format_si(0.99995) == "1"
+
     def test_sig_figs(self):
         """Test significant figures formatting."""
         val = 12345.6789


### PR DESCRIPTION
This PR fixes a precision issue in `format_si` where division by small numbers (e.g., 0.001) caused rounding errors for values just below a prefix boundary.

Changes:
- Modified `src/core/utils.py`: Replaced `scaled = x / scale` with a conditional check to use multiplication `scaled = x * (10.0**-exp3)` when `exp3` is negative. This avoids division by small numbers which is less precise.
- Updated `tests/logic_verification/test_utils.py`: Added a test case for `0.99995` which previously failed.

Verification:
- Ran `pytest tests/logic_verification/test_utils.py` and `tests/functional/test_si_formatting.py`. All tests passed.
- Manually verified edge cases with a script.

---
*PR created automatically by Jules for task [8616800014926030230](https://jules.google.com/task/8616800014926030230) started by @youtube-at-vach*