### PR TITLE
Fix missing translation keys for frequency offset

### DIFF
--- a/scripts/update_translations.py
+++ b/scripts/update_translations.py
@@ -13,7 +13,8 @@ LANG_DIR = os.path.join(PROJECT_ROOT, "src", "assets", "lang")
 
 # Missing keys in en.json (from check_trn_keys.py output)
 MISSING_EN_KEYS = [
-    "Device refresh is disabled when JACK is active for safety."
+    "Device refresh is disabled when JACK is active for safety.",
+    "Current Offset: {0:+.3f} ppm"
 ]
 
 # Missing keys in other language files (de, es, fr, ja, ko, pt, ru, zh)

--- a/src/assets/lang/de.json
+++ b/src/assets/lang/de.json
@@ -1104,5 +1104,6 @@
     "No data available.": "Keine Daten.",
     "Not enough data to calibrate. Please wait.": "Nicht genug Daten. Bitte warten.",
     "Stored 1PPS Cal: 0.000 ppm": "Gesp. 1PPS Cal: 0.000 ppm",
-    "Stored 1PPS Cal: {0:+.3f} ppm": "Gesp. 1PPS Cal: {0:+.3f} ppm"
+    "Stored 1PPS Cal: {0:+.3f} ppm": "Gesp. 1PPS Cal: {0:+.3f} ppm",
+    "Current Offset: {0:+.3f} ppm": "Aktueller Versatz: {0:+.3f} ppm"
 }

--- a/src/assets/lang/en.json
+++ b/src/assets/lang/en.json
@@ -1085,5 +1085,6 @@
     "No data available.": "No data available.",
     "Not enough data to calibrate. Please wait.": "Not enough data to calibrate. Please wait.",
     "Stored 1PPS Cal: 0.000 ppm": "Stored 1PPS Cal: 0.000 ppm",
-    "Stored 1PPS Cal: {0:+.3f} ppm": "Stored 1PPS Cal: {0:+.3f} ppm"
+    "Stored 1PPS Cal: {0:+.3f} ppm": "Stored 1PPS Cal: {0:+.3f} ppm",
+    "Current Offset: {0:+.3f} ppm": "Current Offset: {0:+.3f} ppm"
 }

--- a/src/assets/lang/es.json
+++ b/src/assets/lang/es.json
@@ -1104,5 +1104,6 @@
     "No data available.": "Sin datos.",
     "Not enough data to calibrate. Please wait.": "Datos insuficientes. Espere.",
     "Stored 1PPS Cal: 0.000 ppm": "Cal. 1PPS alm: 0.000 ppm",
-    "Stored 1PPS Cal: {0:+.3f} ppm": "Cal. 1PPS alm: {0:+.3f} ppm"
+    "Stored 1PPS Cal: {0:+.3f} ppm": "Cal. 1PPS alm: {0:+.3f} ppm",
+    "Current Offset: {0:+.3f} ppm": "Desviación actual: {0:+.3f} ppm"
 }

--- a/src/assets/lang/fr.json
+++ b/src/assets/lang/fr.json
@@ -1104,5 +1104,6 @@
     "No data available.": "Pas de données.",
     "Not enough data to calibrate. Please wait.": "Pas assez de données. Attendez.",
     "Stored 1PPS Cal: 0.000 ppm": "Cal. 1PPS stockée : 0.000 ppm",
-    "Stored 1PPS Cal: {0:+.3f} ppm": "Cal. 1PPS stockée : {0:+.3f} ppm"
+    "Stored 1PPS Cal: {0:+.3f} ppm": "Cal. 1PPS stockée : {0:+.3f} ppm",
+    "Current Offset: {0:+.3f} ppm": "Décalage actuel: {0:+.3f} ppm"
 }

--- a/src/assets/lang/ja.json
+++ b/src/assets/lang/ja.json
@@ -1093,5 +1093,6 @@
     "No data available.": "データがありません。",
     "Not enough data to calibrate. Please wait.": "校正に必要なデータが不足しています。お待ちください。",
     "Stored 1PPS Cal: 0.000 ppm": "保存済み1PPS校正値: 0.000 ppm",
-    "Stored 1PPS Cal: {0:+.3f} ppm": "保存済み1PPS校正値: {0:+.3f} ppm"
+    "Stored 1PPS Cal: {0:+.3f} ppm": "保存済み1PPS校正値: {0:+.3f} ppm",
+    "Current Offset: {0:+.3f} ppm": "現在のオフセット: {0:+.3f} ppm"
 }

--- a/src/assets/lang/ko.json
+++ b/src/assets/lang/ko.json
@@ -1104,5 +1104,6 @@
     "No data available.": "데이터 없음.",
     "Not enough data to calibrate. Please wait.": "교정할 데이터가 부족합니다. 기다려 주세요.",
     "Stored 1PPS Cal: 0.000 ppm": "저장된 1PPS 교정: 0.000 ppm",
-    "Stored 1PPS Cal: {0:+.3f} ppm": "저장된 1PPS 교정: {0:+.3f} ppm"
+    "Stored 1PPS Cal: {0:+.3f} ppm": "저장된 1PPS 교정: {0:+.3f} ppm",
+    "Current Offset: {0:+.3f} ppm": "현재 오프셋: {0:+.3f} ppm"
 }

--- a/src/assets/lang/pt.json
+++ b/src/assets/lang/pt.json
@@ -1104,5 +1104,6 @@
     "No data available.": "Sem dados.",
     "Not enough data to calibrate. Please wait.": "Dados insuficientes. Aguarde.",
     "Stored 1PPS Cal: 0.000 ppm": "Cal. 1PPS arm: 0.000 ppm",
-    "Stored 1PPS Cal: {0:+.3f} ppm": "Cal. 1PPS arm: {0:+.3f} ppm"
+    "Stored 1PPS Cal: {0:+.3f} ppm": "Cal. 1PPS arm: {0:+.3f} ppm",
+    "Current Offset: {0:+.3f} ppm": "Deslocamento atual: {0:+.3f} ppm"
 }

--- a/src/assets/lang/ru.json
+++ b/src/assets/lang/ru.json
@@ -1104,5 +1104,6 @@
     "No data available.": "Нет данных.",
     "Not enough data to calibrate. Please wait.": "Недостаточно данных. Подождите.",
     "Stored 1PPS Cal: 0.000 ppm": "Сохр. кал. 1PPS: 0.000 ppm",
-    "Stored 1PPS Cal: {0:+.3f} ppm": "Сохр. кал. 1PPS: {0:+.3f} ppm"
+    "Stored 1PPS Cal: {0:+.3f} ppm": "Сохр. кал. 1PPS: {0:+.3f} ppm",
+    "Current Offset: {0:+.3f} ppm": "Текущее смещение: {0:+.3f} ppm"
 }

--- a/src/assets/lang/zh.json
+++ b/src/assets/lang/zh.json
@@ -1104,5 +1104,6 @@
     "No data available.": "无可用数据。",
     "Not enough data to calibrate. Please wait.": "数据不足以进行校准。请稍候。",
     "Stored 1PPS Cal: 0.000 ppm": "存储的 1PPS 校准: 0.000 ppm",
-    "Stored 1PPS Cal: {0:+.3f} ppm": "存储的 1PPS 校准: {0:+.3f} ppm"
+    "Stored 1PPS Cal: {0:+.3f} ppm": "存储的 1PPS 校准: {0:+.3f} ppm",
+    "Current Offset: {0:+.3f} ppm": "当前偏移：{0:+.3f} ppm"
 }


### PR DESCRIPTION
This PR fixes a missing translation key issue identified by `scripts/check_trn_keys.py`.

Changes:
- Added `"Current Offset: {0:+.3f} ppm"` to `scripts/update_translations.py` in `MISSING_EN_KEYS`.
- Ran `scripts/update_translations.py` to populate `en.json` and other language files.
- Manually translated the new key in all supported languages (`ja`, `de`, `es`, `fr`, `ko`, `pt`, `ru`, `zh`).
- Verified that `scripts/check_trn_keys.py` passes.

---
*PR created automatically by Jules for task [109014927592759196](https://jules.google.com/task/109014927592759196) started by @youtube-at-vach*