### PR TITLE
Refactor frequency axis analysis in AudioCalc

### DIFF
--- a/src/core/analysis.py
+++ b/src/core/analysis.py
@@ -1120,15 +1120,17 @@ class AudioCalc:
         return np.sqrt(power_a)
 
     @staticmethod
-    def calculate_noise_profile(mag, freqs, sampling_rate):
+    def _analyze_frequency_axis(freqs):
         """
-        Calculates noise profile including Hum, White, and 1/f noise.
-        mag: Magnitude spectrum (Linear V/rtHz)
-        freqs: Frequency bins
+        Analyzes the frequency axis to determine if it's linear or logarithmic.
+        Returns:
+            is_linear_freqs (bool)
+            is_log_freqs (bool)
+            freq_step (float)
+            start_freq (float)
+            stop_freq (float)
+            bin_width (float)
         """
-        results = {}
-
-        # Optimization: Check if freqs is linear or logarithmic
         is_linear_freqs = False
         is_log_freqs = False
         freq_step = 1.0
@@ -1157,9 +1159,34 @@ class AudioCalc:
                     is_log_freqs = True
                     stop_freq = freqs[-1]
 
-        # Pre-calculate squared magnitude and bin width
+        # Calculate bin width
+        # If linear, bin_width = freq_step
+        # If not linear (or log), we use first bin width or 1.0 as fallback for integration scale
+        bin_width = freqs[1] - freqs[0] if len(freqs) > 1 else 1.0
+
+        return is_linear_freqs, is_log_freqs, freq_step, start_freq, stop_freq, bin_width
+
+    @staticmethod
+    def calculate_noise_profile(mag, freqs, sampling_rate):
+        """
+        Calculates noise profile including Hum, White, and 1/f noise.
+        mag: Magnitude spectrum (Linear V/rtHz)
+        freqs: Frequency bins
+        """
+        results = {}
+
+        # Optimization: Check if freqs is linear or logarithmic
+        (
+            is_linear_freqs,
+            is_log_freqs,
+            freq_step,
+            start_freq,
+            stop_freq,
+            bin_width,
+        ) = AudioCalc._analyze_frequency_axis(freqs)
+
+        # Pre-calculate squared magnitude
         mag_sq = mag**2
-        bin_width = freq_step if is_linear_freqs else (freqs[1] - freqs[0] if len(freqs) > 1 else 1.0)
 
         # 1. Hum Noise Detection (50Hz vs 60Hz)
         hum_rms, hum_freq, hum_components = AudioCalc._calculate_hum_noise(

--- a/tests/logic_verification/test_freq_axis_analysis.py
+++ b/tests/logic_verification/test_freq_axis_analysis.py
@@ -1,0 +1,83 @@
+import unittest
+import numpy as np
+from src.core.analysis import AudioCalc
+
+class TestFreqAxisAnalysis(unittest.TestCase):
+    def test_linear_freqs(self):
+        # Linear frequency array: 0, 10, 20, ..., 100
+        freqs = np.linspace(0, 100, 11)
+
+        is_linear, is_log, step, start, stop, width = AudioCalc._analyze_frequency_axis(freqs)
+
+        self.assertTrue(is_linear)
+        self.assertFalse(is_log)
+        self.assertAlmostEqual(step, 10.0)
+        self.assertAlmostEqual(start, 0.0)
+        self.assertAlmostEqual(width, 10.0)
+        # stop is only set for log freqs in the original logic? No, let's check.
+        # Original logic: stop_freq initialized to 0.0. Only updated if is_log_freqs is True.
+        self.assertEqual(stop, 0.0)
+
+    def test_log_freqs(self):
+        # Logarithmic frequency array: 10, 100, 1000
+        freqs = np.geomspace(10, 1000, 3)
+        # 10, 100, 1000. ratio=10.
+
+        is_linear, is_log, step, start, stop, width = AudioCalc._analyze_frequency_axis(freqs)
+
+        self.assertFalse(is_linear)
+        self.assertTrue(is_log)
+        # step is freqs[1] - freqs[0] = 90.0
+        self.assertAlmostEqual(step, 90.0)
+        self.assertAlmostEqual(start, 10.0)
+        self.assertAlmostEqual(stop, 1000.0)
+        self.assertAlmostEqual(width, 90.0)
+
+    def test_irregular_freqs(self):
+        # Neither linear nor log
+        freqs = np.array([0.0, 10.0, 30.0, 40.0])
+
+        is_linear, is_log, step, start, stop, width = AudioCalc._analyze_frequency_axis(freqs)
+
+        self.assertFalse(is_linear)
+        self.assertFalse(is_log)
+        self.assertAlmostEqual(step, 10.0) # freqs[1] - freqs[0]
+        self.assertAlmostEqual(start, 0.0)
+        self.assertEqual(stop, 0.0)
+        self.assertAlmostEqual(width, 10.0)
+
+    def test_single_element(self):
+        freqs = np.array([100.0])
+
+        is_linear, is_log, step, start, stop, width = AudioCalc._analyze_frequency_axis(freqs)
+
+        self.assertFalse(is_linear)
+        self.assertFalse(is_log)
+        self.assertAlmostEqual(step, 1.0) # Default
+        self.assertAlmostEqual(start, 0.0) # Default start_freq is 0.0 in original logic if len <= 1?
+        # Original logic:
+        # start_freq = 0.0
+        # if len(freqs) > 1: start_freq = freqs[0]
+        # So if len=1, start_freq remains 0.0?
+        # Let's check original code:
+        # start_freq = 0.0
+        # if len(freqs) > 1: start_freq = freqs[0]
+        # So yes, for len=1, start_freq is 0.0.
+        self.assertEqual(start, 0.0)
+        self.assertEqual(stop, 0.0)
+        self.assertEqual(width, 1.0) # Default
+
+    def test_empty_array(self):
+        freqs = np.array([])
+
+        is_linear, is_log, step, start, stop, width = AudioCalc._analyze_frequency_axis(freqs)
+
+        self.assertFalse(is_linear)
+        self.assertFalse(is_log)
+        self.assertEqual(step, 1.0)
+        self.assertEqual(start, 0.0)
+        self.assertEqual(stop, 0.0)
+        self.assertEqual(width, 1.0)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Refactored `AudioCalc.calculate_noise_profile` in `src/core/analysis.py` to extract complex frequency axis analysis logic into a dedicated static helper method `_analyze_frequency_axis`. This improves code readability and testability. Added unit tests for the new helper method. Verified that existing functionality remains unchanged using regression tests.

---
*PR created automatically by Jules for task [16468087045539554666](https://jules.google.com/task/16468087045539554666) started by @youtube-at-vach*