### PR TITLE
Refactor MainWindow initialization

### DIFF
--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -161,6 +161,13 @@ class MainWindow(QMainWindow):
         self.setWindowTitle("MeasureLab")
         self.resize(1000, 700)
 
+        self._init_core()
+        self._init_audio()
+        self._init_ui()
+        self._init_state()
+
+    def _init_core(self):
+        """Initialize core components (config, localization, audio engine, theme)."""
         # Initialize Core Components
         self.config_manager = ConfigManager()
 
@@ -181,6 +188,8 @@ class MainWindow(QMainWindow):
         saved_theme = self.config_manager.get_theme()
         self.theme_manager.set_theme(saved_theme)
 
+    def _init_audio(self):
+        """Configure AudioEngine with saved settings."""
         # Load saved config
         audio_cfg = self.config_manager.get_audio_config()
         last_in = audio_cfg.get("input_device")
@@ -242,6 +251,8 @@ class MainWindow(QMainWindow):
             except Exception:
                 pass
 
+    def _init_ui(self):
+        """Initialize UI components (Layouts, Sidebar, StackedWidget, Status Bar)."""
         # Module registry (keep keys identical to module.name strings)
         self._module_keys = list(ALL_MODULE_KEYS)
         self.modules = [None] * len(self._module_keys)
@@ -323,6 +334,8 @@ class MainWindow(QMainWindow):
         self.status_timer.timeout.connect(self.update_status)
         self.status_timer.start(500)  # 500ms update rate
 
+    def _init_state(self):
+        """Initial state synchronization (output destination, offline mode)."""
         # Sync output destination control with engine state on startup
         self._sync_output_destination_ui(self._get_engine_output_destination(), propagate=True)
 

--- a/tests/logic_verification/test_main_window_init_refactor.py
+++ b/tests/logic_verification/test_main_window_init_refactor.py
@@ -1,0 +1,106 @@
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+# Mock PyQt6
+qt_widgets = MagicMock()
+qt_core = MagicMock()
+
+# Mock specific classes
+class MockQMainWindow:
+    def __init__(self, *args, **kwargs):
+        pass
+    def setWindowTitle(self, t): pass
+    def resize(self, w, h): pass
+    def setCentralWidget(self, w): pass
+    def setStatusBar(self, b): pass
+    def addPermanentWidget(self, w): pass
+    def layout(self): return MagicMock()
+
+qt_widgets.QMainWindow = MockQMainWindow
+qt_widgets.QWidget = MagicMock
+qt_widgets.QHBoxLayout = MagicMock()
+qt_widgets.QVBoxLayout = MagicMock()
+qt_widgets.QListWidget = MagicMock()
+qt_widgets.QStackedWidget = MagicMock()
+qt_widgets.QStatusBar = MagicMock()
+qt_widgets.QLabel = MagicMock()
+qt_widgets.QComboBox = MagicMock()
+qt_widgets.QApplication = MagicMock()
+qt_core.QTimer = MagicMock()
+
+# Mock src.core dependencies
+mock_audio_engine_cls = MagicMock()
+mock_audio_engine = mock_audio_engine_cls.return_value
+# Setup default return values for AudioEngine
+mock_audio_engine.list_devices.return_value = []
+mock_audio_engine.get_status.return_value = {
+    "active": False,
+    "input_channels": "stereo",
+    "output_channels": "stereo",
+    "sample_rate": 48000,
+    "cpu_load": 0.0,
+    "active_clients": 0,
+    "offline_mode": False
+}
+mock_audio_engine.offline_mode = False
+mock_audio_engine.loopback = False
+mock_audio_engine.mute_output = False
+
+mock_config_manager_cls = MagicMock()
+mock_config_manager = mock_config_manager_cls.return_value
+# Setup ConfigManager defaults
+mock_config_manager.get_language.return_value = "en"
+mock_config_manager.get_theme.return_value = "dark"
+mock_config_manager.get_audio_config.return_value = {}
+mock_config_manager.get_pipewire_jack_resident.return_value = False
+
+mock_localization = MagicMock()
+mock_localization.tr = lambda x: x # Simple pass-through for translation
+mock_localization.get_manager.return_value = MagicMock()
+
+mock_theme_manager_cls = MagicMock()
+mock_theme_manager = mock_theme_manager_cls.return_value
+
+mock_welcome_cls = MagicMock()
+
+class TestMainWindowInitRefactor(unittest.TestCase):
+    def test_main_window_initialization(self):
+        modules_to_patch = {
+            "PyQt6": MagicMock(),
+            "PyQt6.QtCore": qt_core,
+            "PyQt6.QtWidgets": qt_widgets,
+            "src.core.audio_engine": MagicMock(AudioEngine=mock_audio_engine_cls),
+            "src.core.config_manager": MagicMock(ConfigManager=mock_config_manager_cls),
+            "src.core.localization": mock_localization,
+            "src.core.theme_manager": MagicMock(ThemeManager=mock_theme_manager_cls),
+            "src.gui.widgets.welcome": MagicMock(WelcomeWidget=mock_welcome_cls),
+            # DetachableWrapper is imported in main_window.py
+            "src.gui.widgets.detachable_wrapper": MagicMock(),
+        }
+
+        with patch.dict(sys.modules, modules_to_patch):
+            if "src.gui.main_window" in sys.modules:
+                del sys.modules["src.gui.main_window"]
+
+            from src.gui.main_window import MainWindow
+
+            # Instantiate MainWindow
+            _ = MainWindow()
+
+            # Verify basic calls
+            self.assertTrue(mock_config_manager_cls.called)
+            self.assertTrue(mock_audio_engine_cls.called)
+
+            # Check if UI elements were created (via our mocks)
+            self.assertTrue(qt_widgets.QListWidget.called)
+            self.assertTrue(qt_widgets.QStackedWidget.called)
+
+            # Check if status timer started
+            self.assertTrue(qt_core.QTimer.return_value.start.called)
+
+            # Check if WelcomeWidget was initialized
+            self.assertTrue(mock_welcome_cls.called)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/logic_verification/test_main_window_modules.py
+++ b/tests/logic_verification/test_main_window_modules.py
@@ -1,5 +1,6 @@
+import sys
 import pytest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 from src.core.module_constants import ALL_MODULE_KEYS, MODULE_SIGNAL_GENERATOR
 
 def test_module_keys_constants():
@@ -7,31 +8,42 @@ def test_module_keys_constants():
     assert len(ALL_MODULE_KEYS) > 0
     assert MODULE_SIGNAL_GENERATOR in ALL_MODULE_KEYS
 
-@patch('src.gui.main_window.ConfigManager')
-@patch('src.gui.main_window.AudioEngine')
-@patch('src.gui.main_window.get_manager')
-def test_load_module_class(mock_get_manager, mock_audio_engine, mock_config_manager):
-    # We don't need to mock ThemeManager as it is imported inside MainWindow.__init__
-    # ConfigManager and AudioEngine are mocked to avoid heavy initialization if they were imported at top level
-    # (though in the refactored main_window they are imported at top level, so mocking here might be too late
-    # if we were importing MainWindow, but we are only importing _load_module_class which is a function).
+def test_load_module_class():
+    # Mock PyQt6 and other heavy dependencies to allow importing main_window
+    modules_to_patch = {
+        "PyQt6": MagicMock(),
+        "PyQt6.QtCore": MagicMock(),
+        "PyQt6.QtWidgets": MagicMock(),
+        "numpy": MagicMock(),
+        "scipy": MagicMock(),
+        "scipy.signal": MagicMock(),
+        "src.core.audio_engine": MagicMock(),
+        "src.core.config_manager": MagicMock(),
+        "src.core.localization": MagicMock(),
+        "src.core.theme_manager": MagicMock(),
+        "src.gui.widgets.detachable_wrapper": MagicMock(),
+    }
 
-    # Actually, main_window.py imports AudioEngine and ConfigManager at the top level.
-    # The patch decorator patches them where they are *looked up*, which is src.gui.main_window.
-    # So this should work.
+    with patch.dict(sys.modules, modules_to_patch):
+        # We must mock dependencies BEFORE importing main_window
+        # Ensure it is importable
 
-    from src.gui.main_window import _load_module_class
+        with patch('src.gui.main_window.ConfigManager'), \
+             patch('src.gui.main_window.AudioEngine'), \
+             patch('src.gui.main_window.get_manager'):
 
-    try:
-        cls = _load_module_class(MODULE_SIGNAL_GENERATOR)
-        # We check the name of the class
-        assert cls.__name__ == "SignalGenerator"
-    except ImportError:
-        # If dependencies are missing, that's fine for this test as long as it TRIED.
-        pass
-    except KeyError:
-        pytest.fail("MODULE_SIGNAL_GENERATOR key raised KeyError")
+            from src.gui.main_window import _load_module_class
 
-    # Verify invalid key raises KeyError
-    with pytest.raises(KeyError):
-        _load_module_class("Invalid Key")
+            try:
+                cls = _load_module_class(MODULE_SIGNAL_GENERATOR)
+                # We check the name of the class
+                assert cls.__name__ == "SignalGenerator"
+            except ImportError:
+                # If dependencies are missing, that's fine for this test as long as it TRIED.
+                pass
+            except KeyError:
+                pytest.fail("MODULE_SIGNAL_GENERATOR key raised KeyError")
+
+            # Verify invalid key raises KeyError
+            with pytest.raises(KeyError):
+                _load_module_class("Invalid Key")


### PR DESCRIPTION
Refactored `MainWindow.__init__` in `src/gui/main_window.py` to reduce complexity and improve readability.
- Created `_init_core` for core components (Config, Localization, AudioEngine, Theme).
- Created `_init_audio` for audio engine configuration.
- Created `_init_ui` for UI setup.
- Created `_init_state` for initial state synchronization.
- Added regression test `tests/logic_verification/test_main_window_init_refactor.py`.
- Fixed `tests/logic_verification/test_main_window_modules.py` to run in environments without PyQt6/numpy.

---
*PR created automatically by Jules for task [11295173966922413334](https://jules.google.com/task/11295173966922413334) started by @youtube-at-vach*