### PR TITLE
Refactor delete_profile in CalibrationManager

### DIFF
--- a/src/core/calibration.py
+++ b/src/core/calibration.py
@@ -213,7 +213,7 @@ class CalibrationManager:
 
     def delete_profile(self, name):
         """Deletes a named profile."""
-        if hasattr(self, "profiles") and name in self.profiles:
+        if name in self.profiles:
             del self.profiles[name]
             self.save()
 

--- a/tests/logic_verification/test_calibration_manager.py
+++ b/tests/logic_verification/test_calibration_manager.py
@@ -140,6 +140,12 @@ def test_profile_management(cal_manager):
     cal_manager.delete_profile("test_profile")
     assert "test_profile" not in cal_manager.get_profiles()
 
+def test_delete_non_existent_profile(cal_manager):
+    """Test deleting a profile that doesn't exist (should not raise error)."""
+    # Ensure it handles missing profiles gracefully
+    cal_manager.delete_profile("ghost_profile")
+    assert "ghost_profile" not in cal_manager.get_profiles()
+
 def test_load_non_existent_profile(cal_manager):
     """Test loading a profile that doesn't exist."""
     with pytest.raises(ValueError, match="Profile 'fake' not found"):


### PR DESCRIPTION
Addressed a code health issue where `CalibrationManager.delete_profile` contained a redundant attribute check. Verified that the method is actively used by the GUI (`SettingsWidget`) and covered by functional tests. Added a new logic verification test to confirm that deleting a non-existent profile is handled gracefully (idempotent behavior).

---
*PR created automatically by Jules for task [9820516429526895148](https://jules.google.com/task/9820516429526895148) started by @youtube-at-vach*