### PR TITLE
🧹 Refactor AudioEngine startup logic

### DIFF
--- a/src/core/audio_engine.py
+++ b/src/core/audio_engine.py
@@ -468,12 +468,11 @@ class AudioEngine:
                     outdata[:, 0] = 0
         # If muted, outdata is already 0 filled at start of callback
 
-    def _start_master_stream(self):
-        """Starts the underlying sounddevice stream or VirtualStream."""
-        if self.stream is not None:
-            return
-
-        # Determine hardware channels needed based on mode
+    def _update_channel_modes(self):
+        """
+        Updates internal channel mode integers based on string settings.
+        Returns the required hardware channel count (in, out).
+        """
         in_mode_str = self.input_channel_mode
         out_mode_str = self.output_channel_mode
 
@@ -494,6 +493,38 @@ class AudioEngine:
         hw_in_ch = 2 if in_mode_str in ["right", "stereo"] else 1
         hw_out_ch = 2 if out_mode_str in ["right", "stereo"] else 1
 
+        return hw_in_ch, hw_out_ch
+
+    def _get_jack_settings(self):
+        """
+        Returns sd.JackSettings if the output device is JACK/PipeWire, else None.
+        """
+        # If running on JACK (including PipeWire-JACK), attempt to fix the client/node name.
+        try:
+            hostapi_name = None
+            dev_id = self.output_device
+            if dev_id is None:
+                # Fallback to default output device.
+                dev_id = sd.default.device[1]
+            if dev_id is not None and dev_id != -1:
+                device_info = sd.query_devices(dev_id)
+                hostapi_idx = device_info.get("hostapi")
+                if hostapi_idx is not None:
+                    hostapi_info = sd.query_hostapis(hostapi_idx)
+                    hostapi_name = hostapi_info.get("name")
+            if hostapi_name and "jack" in str(hostapi_name).lower():
+                return sd.JackSettings(client_name=self.jack_client_name)
+        except Exception:
+            pass
+        return None
+
+    def _start_master_stream(self):
+        """Starts the underlying sounddevice stream or VirtualStream."""
+        if self.stream is not None:
+            return
+
+        hw_in_ch, hw_out_ch = self._update_channel_modes()
+
         # Reset loopback buffer
         self.last_output_buffer = None
 
@@ -508,22 +539,7 @@ class AudioEngine:
                 self.stream.start()
                 self.logger.info(f"Virtual (Offline) audio stream started. SR={self.sample_rate}")
             else:
-                extra_settings = None
-                # If running on JACK (including PipeWire-JACK), attempt to fix the client/node name.
-                try:
-                    hostapi_name = None
-                    dev_id = self.output_device
-                    if dev_id is None:
-                        # Fallback to default output device.
-                        dev_id = sd.default.device[1]
-                    if dev_id is not None and dev_id != -1:
-                        hostapi_idx = sd.query_devices(dev_id).get("hostapi")
-                        if hostapi_idx is not None:
-                            hostapi_name = sd.query_hostapis(hostapi_idx).get("name")
-                    if hostapi_name and "jack" in str(hostapi_name).lower():
-                        extra_settings = sd.JackSettings(client_name=self.jack_client_name)
-                except Exception:
-                    extra_settings = None
+                extra_settings = self._get_jack_settings()
 
                 self.stream = sd.Stream(
                     device=(self.input_device, self.output_device),

--- a/tests/logic_verification/test_audio_engine_logic.py
+++ b/tests/logic_verification/test_audio_engine_logic.py
@@ -1,17 +1,25 @@
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 import sys
-
-# Mock sounddevice before importing AudioEngine
-sys.modules['sounddevice'] = MagicMock()
-
-from src.core.audio_engine import AudioEngine  # noqa: E402
+import importlib
 
 class TestAudioEngineLogic(unittest.TestCase):
     def setUp(self):
-        self.engine = AudioEngine()
+        # Patch sys.modules to mock sounddevice
+        self.patcher = patch.dict(sys.modules, {'sounddevice': MagicMock()})
+        self.patcher.start()
+
+        # Import and reload AudioEngine to use the mock
+        import src.core.audio_engine
+        importlib.reload(src.core.audio_engine)
+        self.AudioEngineClass = src.core.audio_engine.AudioEngine
+
+        self.engine = self.AudioEngineClass()
         self.engine.stream = MagicMock() # Pretend stream is created so we don't hit _start_master_stream logic logic
         self.engine.logger = MagicMock()
+
+    def tearDown(self):
+        self.patcher.stop()
 
     def test_register_unregister(self):
         def cb(*args):

--- a/tests/logic_verification/test_audio_engine_start_logic.py
+++ b/tests/logic_verification/test_audio_engine_start_logic.py
@@ -1,0 +1,106 @@
+import unittest
+from unittest.mock import MagicMock, patch
+import sys
+import importlib
+
+class TestAudioEngineStartLogic(unittest.TestCase):
+    def setUp(self):
+        # Patch sys.modules to mock sounddevice
+        self.patcher = patch.dict(sys.modules, {'sounddevice': MagicMock()})
+        self.patcher.start()
+
+        # Import and reload AudioEngine to use the mock
+        import src.core.audio_engine
+        importlib.reload(src.core.audio_engine)
+        self.AudioEngineClass = src.core.audio_engine.AudioEngine
+
+        self.engine = self.AudioEngineClass()
+        # Mock logger to avoid clutter
+        self.engine.logger = MagicMock()
+
+    def tearDown(self):
+        self.patcher.stop()
+
+    def test_update_channel_modes_stereo(self):
+        self.engine.input_channel_mode = "stereo"
+        self.engine.output_channel_mode = "stereo"
+
+        # Call the method
+        hw_in, hw_out = self.engine._update_channel_modes()
+
+        self.assertEqual(self.engine._current_in_mode, self.AudioEngineClass.MODE_STEREO)
+        self.assertEqual(self.engine._current_out_mode, self.AudioEngineClass.MODE_STEREO)
+        self.assertEqual(hw_in, 2)
+        self.assertEqual(hw_out, 2)
+
+    def test_update_channel_modes_left(self):
+        self.engine.input_channel_mode = "left"
+        self.engine.output_channel_mode = "left"
+
+        hw_in, hw_out = self.engine._update_channel_modes()
+
+        self.assertEqual(self.engine._current_in_mode, self.AudioEngineClass.MODE_LEFT)
+        self.assertEqual(self.engine._current_out_mode, self.AudioEngineClass.MODE_LEFT)
+        self.assertEqual(hw_in, 1)
+        self.assertEqual(hw_out, 1)
+
+    def test_update_channel_modes_right(self):
+        self.engine.input_channel_mode = "right"
+        self.engine.output_channel_mode = "right"
+
+        hw_in, hw_out = self.engine._update_channel_modes()
+
+        self.assertEqual(self.engine._current_in_mode, self.AudioEngineClass.MODE_RIGHT)
+        self.assertEqual(self.engine._current_out_mode, self.AudioEngineClass.MODE_RIGHT)
+        self.assertEqual(hw_in, 2)
+        self.assertEqual(hw_out, 2)
+
+    @patch('sounddevice.query_devices')
+    @patch('sounddevice.query_hostapis')
+    def test_get_jack_settings_with_jack(self, mock_hostapis, mock_devices):
+        # NOTE: patching 'sounddevice.query_devices' patches the attribute on the mock object in sys.modules
+
+        # Setup mocks to simulate a JACK device
+        self.engine.output_device = 1
+        self.engine.jack_client_name = "TestClient"
+
+        # Mock device query return
+        mock_devices.return_value = {"hostapi": 0} # Device 1 uses hostapi 0
+
+        # Mock hostapi query return
+        mock_hostapis.return_value = {"name": "JACK Audio Connection Kit"} # Hostapi 0 is JACK
+
+        # Call method
+        settings = self.engine._get_jack_settings()
+
+        # Verify it returns a JackSettings object
+        import sounddevice as sd
+        # sd is the mock
+        sd.JackSettings.assert_called_with(client_name="TestClient")
+        self.assertEqual(settings, sd.JackSettings.return_value)
+
+    @patch('sounddevice.query_devices')
+    @patch('sounddevice.query_hostapis')
+    def test_get_jack_settings_no_jack(self, mock_hostapis, mock_devices):
+        self.engine.output_device = 1
+
+        mock_devices.return_value = {"hostapi": 0}
+        mock_hostapis.return_value = {"name": "ALSA"} # Not JACK
+
+        settings = self.engine._get_jack_settings()
+
+        self.assertIsNone(settings)
+
+    @patch('sounddevice.query_devices')
+    def test_get_jack_settings_no_device(self, mock_devices):
+        self.engine.output_device = None
+
+        import sounddevice as sd
+        # Mock sd.default.device to return [0, 1]
+        type(sd.default).device = unittest.mock.PropertyMock(return_value=[0, 1])
+
+        # Mock device 1 as non-JACK
+        mock_devices.return_value = {"hostapi": 0}
+
+        settings = self.engine._get_jack_settings()
+        self.assertIsNone(settings)


### PR DESCRIPTION
🎯 **What:** Refactored `_start_master_stream` in `src/core/audio_engine.py` to reduce complexity.
💡 **Why:** The startup method was doing too much (channel configuration, JACK settings, stream creation). Extracting logic into `_update_channel_modes` and `_get_jack_settings` makes the code cleaner and easier to maintain.
✅ **Verification:** Added new unit tests in `tests/logic_verification/test_audio_engine_start_logic.py` covering the extracted methods. Verified existing tests pass. Also improved test isolation in `tests/logic_verification/test_audio_engine_logic.py`.
✨ **Result:** `_start_master_stream` is now a high-level orchestration method, and the logic is modularized.

---
*PR created automatically by Jules for task [11518063576985000562](https://jules.google.com/task/11518063576985000562) started by @youtube-at-vach*