### PR TITLE
🧹 Log startup exceptions in main_gui.py instead of silencing them

### DIFF
--- a/main_gui.py
+++ b/main_gui.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import logging
 import os
 import signal
 import sys
@@ -11,6 +12,8 @@ from src.core.fft_manager import fft_manager
 
 def main():
     """GUI Application Entry Point"""
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+
     # Suppress benign GNOME portal Settings warnings like:
     #   qt.qpa.theme.gnome: dbus reply error: ... org.freedesktop.portal.Settings
     # This must be set before importing Qt/PyQt.
@@ -35,7 +38,8 @@ def main():
     try:
         config_manager = ConfigManager()
         get_manager().load_language(config_manager.get_language())
-    except Exception:
+    except Exception as e:
+        logging.error(f"Failed to load configuration or translations: {e}")
         # If config or translations fail, proceed with defaults.
         pass
 
@@ -106,7 +110,7 @@ def main():
         # 2. Preload Modules
         window.preload_all_modules(progress_callback=_update_splash)
     except Exception as e:
-        print(f"Startup error: {e}")
+        logging.error(f"Startup error: {e}")
         # If preload fails, still show the window; individual pages may show errors.
         pass
 

--- a/tests/test_main_gui_exception.py
+++ b/tests/test_main_gui_exception.py
@@ -1,0 +1,78 @@
+import sys
+import os
+import unittest
+import logging
+from unittest.mock import MagicMock, patch
+
+# Add root directory to sys.path to import main_gui
+sys.path.append(os.getcwd())
+
+# Mock dependencies before importing main_gui
+sys.modules["src.core.fft_manager"] = MagicMock()
+sys.modules["src.core.audio_engine"] = MagicMock()
+sys.modules["numpy"] = MagicMock()
+sys.modules["scipy"] = MagicMock()
+sys.modules["sounddevice"] = MagicMock()
+sys.modules["PyQt6"] = MagicMock()
+sys.modules["PyQt6.QtCore"] = MagicMock()
+sys.modules["PyQt6.QtGui"] = MagicMock()
+sys.modules["PyQt6.QtWidgets"] = MagicMock()
+
+# Mock internal modules
+sys.modules["src.gui.main_window"] = MagicMock()
+sys.modules["src.gui.startup"] = MagicMock()
+
+# Setup mocks for ConfigManager and Localization
+config_manager_module_mock = MagicMock()
+config_manager_cls_mock = MagicMock()
+config_manager_module_mock.ConfigManager = config_manager_cls_mock
+sys.modules["src.core.config_manager"] = config_manager_module_mock
+
+localization_module_mock = MagicMock()
+localization_mock = MagicMock()
+localization_module_mock.get_manager = MagicMock(return_value=localization_mock)
+localization_module_mock.tr = MagicMock(side_effect=lambda x: x)
+sys.modules["src.core.localization"] = localization_module_mock
+
+utils_module_mock = MagicMock()
+utils_module_mock.resource_path = MagicMock(side_effect=lambda x: x)
+sys.modules["src.core.utils"] = utils_module_mock
+
+
+# Now import main_gui
+import main_gui
+
+class TestMainGuiExceptionLogging(unittest.TestCase):
+    def test_config_load_exception_is_logged(self):
+        # Arrange
+        # ConfigManager() raises Exception
+        config_manager_cls_mock.side_effect = Exception("Config load failed test")
+
+        # Configure logging to ensure capture works (though assertLogs handles it)
+        # We need to patch main_gui.logging if we add it, but currently it's not there.
+        # If main_gui uses logging.error, assertLogs will capture it on the root logger.
+
+        with patch("sys.exit") as mock_exit, \
+             patch("PyQt6.QtWidgets.QApplication") as mock_app, \
+             patch("signal.signal"):
+
+            mock_app_instance = MagicMock()
+            mock_app.return_value = mock_app_instance
+
+            # We expect an ERROR log
+            try:
+                with self.assertLogs(level='ERROR') as cm:
+                    main_gui.main()
+
+                # Assert
+                found = any("Config load failed test" in o for o in cm.output)
+                self.assertTrue(found, f"Expected log not found in: {cm.output}")
+
+            except AssertionError as e:
+                # If assertLogs fails (no logs), it raises AssertionError
+                print(f"Caught expected assertion error (test confirms missing logs): {e}")
+                # This is expected for reproduction before fix
+                raise e
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** The code health issue addressed is the broad exception handling (`except Exception: pass`) in `main_gui.py` during configuration and translation loading.
💡 **Why:** Silently swallowing exceptions at startup makes debugging difficult. Logging these errors improves maintainability and observability.
✅ **Verification:** Created `tests/test_main_gui_exception.py` which mocks dependencies and asserts that exceptions raised during startup are captured by `logging`. The test passes. Also verified `scripts/check_trn_keys.py`.
✨ **Result:** Startup errors are now logged to stderr instead of being ignored.

---
*PR created automatically by Jules for task [3314000735453054334](https://jules.google.com/task/3314000735453054334) started by @youtube-at-vach*