### PR TITLE
🧹 Refactor ConfigManager._flush_all to log exceptions

### DIFF
--- a/src/core/config_manager.py
+++ b/src/core/config_manager.py
@@ -68,11 +68,12 @@ class ConfigManager:
     @classmethod
     def _flush_all(cls):
         """Flushes all active ConfigManager instances."""
+        logger = logging.getLogger(cls.__name__)
         for instance in cls._instances:
             try:
                 instance.shutdown()
-            except Exception:
-                pass
+            except Exception as e:
+                logger.error("Error during shutdown: %s", e)
 
     def load_config(self):
         """Loads configuration from JSON file."""

--- a/tests/logic_verification/test_config_manager_lifecycle.py
+++ b/tests/logic_verification/test_config_manager_lifecycle.py
@@ -229,5 +229,21 @@ class TestConfigManagerLifecycle(unittest.TestCase):
         self.mock_logger.error.assert_called_with("Failed to save config: Permission denied")
         cm.shutdown()
 
+    def test_flush_all_logs_exception(self):
+        """Test that _flush_all logs exceptions from instance shutdown."""
+        mock_instance = MagicMock()
+        exception = Exception("Crash")
+        mock_instance.shutdown.side_effect = exception
+
+        # Manually add to _instances
+        ConfigManager._instances.add(mock_instance)
+        try:
+            ConfigManager._flush_all()
+        finally:
+            if mock_instance in ConfigManager._instances:
+                ConfigManager._instances.remove(mock_instance)
+
+        self.mock_logger.error.assert_called_with("Error during shutdown: %s", exception)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
🎯 **What:** The code health issue addressed is the broad exception swallowing in `ConfigManager._flush_all`. Previously, `try: ... except Exception: pass` was used, hiding any errors that occurred during application shutdown.
💡 **Why:** Silently ignoring errors makes debugging shutdown issues impossible. Logging the error preserves the "best effort" behavior (continuing to the next instance) while providing visibility into what went wrong.
✅ **Verification:** I added a new test case `test_flush_all_logs_exception` to `tests/logic_verification/test_config_manager_lifecycle.py`. This test mocks a `ConfigManager` instance that raises an exception during `shutdown` and asserts that the error is logged using `self.mock_logger.error`. I also verified that all existing tests pass.
✨ **Result:** The `_flush_all` method now logs errors, and the codebase is more robust and maintainable. The test suite covers this scenario.

---
*PR created automatically by Jules for task [1367216622806786289](https://jules.google.com/task/1367216622806786289) started by @youtube-at-vach*