### PR TITLE
🔒 Fix DoS vulnerability in audio file loading (limit MAX_AUDIO_SAMPLES)

### DIFF
--- a/src/core/analysis.py
+++ b/src/core/analysis.py
@@ -112,7 +112,7 @@ class AudioCalc:
     """
     Shared audio calculation utilities.
     """
-    MAX_AUDIO_SAMPLES = 500_000_000
+    MAX_AUDIO_SAMPLES = 100_000_000
 
     @staticmethod
     def validate_audio_file_size(filepath):

--- a/tests/security/test_unbounded_loading.py
+++ b/tests/security/test_unbounded_loading.py
@@ -17,7 +17,7 @@ def test_validate_audio_file_size_small():
 
 def test_validate_audio_file_size_large():
     with patch("src.core.analysis.sf.info") as mock_info:
-        # Large file: 300M samples * 2 channels = 600M > 500M
+        # Large file: 300M samples * 2 channels = 600M > 100M
         mock_info.return_value = MockInfo(300_000_000, 2)
 
         valid, msg = AudioCalc.validate_audio_file_size("dummy_large.wav")
@@ -25,10 +25,20 @@ def test_validate_audio_file_size_large():
         assert "File too large" in msg
         assert "600000000" in msg
 
+def test_validate_audio_file_size_medium():
+    with patch("src.core.analysis.sf.info") as mock_info:
+        # Medium file: 150M samples * 1 channel = 150M > 100M
+        mock_info.return_value = MockInfo(150_000_000, 1)
+
+        valid, msg = AudioCalc.validate_audio_file_size("dummy_medium.wav")
+        assert not valid
+        assert "File too large" in msg
+        assert "150000000" in msg
+
 def test_validate_audio_file_size_exact_limit():
     with patch("src.core.analysis.sf.info") as mock_info:
-        # Exact limit: 500M samples * 1 channel = 500M
-        mock_info.return_value = MockInfo(500_000_000, 1)
+        # Exact limit: 100M samples * 1 channel = 100M
+        mock_info.return_value = MockInfo(100_000_000, 1)
 
         valid, msg = AudioCalc.validate_audio_file_size("dummy_exact.wav")
         assert valid # Should be valid (<=)


### PR DESCRIPTION
🎯 **What:**
Reduced `AudioCalc.MAX_AUDIO_SAMPLES` from 500,000,000 to 100,000,000 in `src/core/analysis.py`.
Updated `tests/security/test_unbounded_loading.py` to enforce the new limit.

⚠️ **Risk:**
The previous limit of 500M samples could allow loading up to ~4GB (float64) or ~2GB (float32) of audio data into RAM, potentially crashing the application or system (DoS) if a malicious or large file was loaded.

🛡️ **Solution:**
Lowering the limit to 100M samples (approx 800MB/400MB) provides a safer upper bound for in-memory processing while still supporting reasonable file sizes (e.g., ~19 minutes of stereo CD quality audio).

---
*PR created automatically by Jules for task [15330833548035195967](https://jules.google.com/task/15330833548035195967) started by @youtube-at-vach*