### PR TITLE
🧹 Move PyInstaller hidden imports to dedicated file

### DIFF
--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -98,7 +98,7 @@ def _load_module_class(module_key: str):
     """Return MeasurementModule class by key.
 
     Uses _load_class to avoid importing heavy GUI modules at application startup.
-    Explicit imports for PyInstaller discovery are handled in _pyinstaller_imports.
+    Explicit imports for PyInstaller discovery are handled in src.gui.pyinstaller_imports.
     """
     if module_key not in MODULE_REGISTRY:
         raise KeyError(f"Unknown module key: {module_key}")
@@ -106,43 +106,9 @@ def _load_module_class(module_key: str):
     return _load_class(*MODULE_REGISTRY[module_key])
 
 
-def _pyinstaller_imports():
-    """Explicit imports so PyInstaller can discover modules.
-
-    This function is never called.
-    """
-    if False:
-        from src.gui.widgets.advanced_distortion_meter import AdvancedDistortionMeter  # noqa: F401
-        from src.gui.widgets.bnim_meter import BNIMMeter  # noqa: F401
-        from src.gui.widgets.boxcar_averager import BoxcarAverager  # noqa: F401
-        from src.gui.widgets.distortion_analyzer import DistortionAnalyzer  # noqa: F401
-        from src.gui.widgets.frequency_counter import FrequencyCounter  # noqa: F401
-        from src.gui.widgets.goniometer import Goniometer  # noqa: F401
-        from src.gui.widgets.hrtf_player import HRTFPlayer  # noqa: F401
-        from src.gui.widgets.impedance_analyzer import ImpedanceAnalyzer  # noqa: F401
-        from src.gui.widgets.inverse_filter import InverseFilter  # noqa: F401
-        from src.gui.widgets.linearity_analyzer import LinearityAnalyzer  # noqa: F401
-        from src.gui.widgets.lock_in_amplifier import LockInAmplifier  # noqa: F401
-        from src.gui.widgets.lock_in_frequency_counter import LockInFrequencyCounter  # noqa: F401
-        from src.gui.widgets.lockin_thd_analyzer import LockInTHDAnalyzer  # noqa: F401
-        from src.gui.widgets.loopback_finder import LoopbackFinder  # noqa: F401
-        from src.gui.widgets.lufs_meter import LufsMeter  # noqa: F401
-        from src.gui.widgets.network_analyzer import NetworkAnalyzer  # noqa: F401
-        from src.gui.widgets.noise_profiler import NoiseProfiler  # noqa: F401
-        from src.gui.widgets.one_pps_monitor import OnePPSMonitor  # noqa: F401
-        from src.gui.widgets.oscilloscope import Oscilloscope  # noqa: F401
-        from src.gui.widgets.raw_time_series import RawTimeSeries  # noqa: F401
-        from src.gui.widgets.recorder_player import RecorderPlayer  # noqa: F401
-        from src.gui.widgets.signal_generator import SignalGenerator  # noqa: F401
-        from src.gui.widgets.sound_level_meter import SoundLevelMeter  # noqa: F401
-        from src.gui.widgets.sound_quality_analyzer import SoundQualityAnalyzer  # noqa: F401
-        from src.gui.widgets.spectrogram import Spectrogram  # noqa: F401
-        from src.gui.widgets.spectrum_analyzer import SpectrumAnalyzer  # noqa: F401
-        from src.gui.widgets.timecode_monitor import TimecodeMonitor  # noqa: F401
-        from src.gui.widgets.transient_analyzer import TransientAnalyzer  # noqa: F401
-        from src.gui.widgets.ultrasound_modulator import UltrasoundModulator  # noqa: F401
-        from src.gui.widgets.settings import SettingsWidget  # noqa: F401
-        from src.gui.widgets.welcome import WelcomeWidget  # noqa: F401
+if False:
+    # Explicit imports so PyInstaller can discover modules.
+    import src.gui.pyinstaller_imports  # noqa: F401
 
 
 def _load_settings_widget_class():

--- a/src/gui/pyinstaller_imports.py
+++ b/src/gui/pyinstaller_imports.py
@@ -1,0 +1,39 @@
+"""
+Explicit imports so PyInstaller can discover dynamically loaded modules.
+
+This file is never imported at runtime, but PyInstaller's static analysis
+will detect these imports and include the modules in the bundle.
+"""
+
+if False:
+    from src.gui.widgets.advanced_distortion_meter import AdvancedDistortionMeter  # noqa: F401
+    from src.gui.widgets.bnim_meter import BNIMMeter  # noqa: F401
+    from src.gui.widgets.boxcar_averager import BoxcarAverager  # noqa: F401
+    from src.gui.widgets.distortion_analyzer import DistortionAnalyzer  # noqa: F401
+    from src.gui.widgets.frequency_counter import FrequencyCounter  # noqa: F401
+    from src.gui.widgets.goniometer import Goniometer  # noqa: F401
+    from src.gui.widgets.hrtf_player import HRTFPlayer  # noqa: F401
+    from src.gui.widgets.impedance_analyzer import ImpedanceAnalyzer  # noqa: F401
+    from src.gui.widgets.inverse_filter import InverseFilter  # noqa: F401
+    from src.gui.widgets.linearity_analyzer import LinearityAnalyzer  # noqa: F401
+    from src.gui.widgets.lock_in_amplifier import LockInAmplifier  # noqa: F401
+    from src.gui.widgets.lock_in_frequency_counter import LockInFrequencyCounter  # noqa: F401
+    from src.gui.widgets.lockin_thd_analyzer import LockInTHDAnalyzer  # noqa: F401
+    from src.gui.widgets.loopback_finder import LoopbackFinder  # noqa: F401
+    from src.gui.widgets.lufs_meter import LufsMeter  # noqa: F401
+    from src.gui.widgets.network_analyzer import NetworkAnalyzer  # noqa: F401
+    from src.gui.widgets.noise_profiler import NoiseProfiler  # noqa: F401
+    from src.gui.widgets.one_pps_monitor import OnePPSMonitor  # noqa: F401
+    from src.gui.widgets.oscilloscope import Oscilloscope  # noqa: F401
+    from src.gui.widgets.raw_time_series import RawTimeSeries  # noqa: F401
+    from src.gui.widgets.recorder_player import RecorderPlayer  # noqa: F401
+    from src.gui.widgets.signal_generator import SignalGenerator  # noqa: F401
+    from src.gui.widgets.sound_level_meter import SoundLevelMeter  # noqa: F401
+    from src.gui.widgets.sound_quality_analyzer import SoundQualityAnalyzer  # noqa: F401
+    from src.gui.widgets.spectrogram import Spectrogram  # noqa: F401
+    from src.gui.widgets.spectrum_analyzer import SpectrumAnalyzer  # noqa: F401
+    from src.gui.widgets.timecode_monitor import TimecodeMonitor  # noqa: F401
+    from src.gui.widgets.transient_analyzer import TransientAnalyzer  # noqa: F401
+    from src.gui.widgets.ultrasound_modulator import UltrasoundModulator  # noqa: F401
+    from src.gui.widgets.settings import SettingsWidget  # noqa: F401
+    from src.gui.widgets.welcome import WelcomeWidget  # noqa: F401


### PR DESCRIPTION
Moved the list of explicit imports for PyInstaller from `src/gui/main_window.py` to `src/gui/pyinstaller_imports.py` to improve code health and remove "dead code" warnings. The new file is imported conditionally inside `main_window.py` to ensure PyInstaller still discovers the dependencies. Verified by running lint checks and the full test suite.

---
*PR created automatically by Jules for task [18026820960643915195](https://jules.google.com/task/18026820960643915195) started by @youtube-at-vach*