### PR TITLE
⚡ Optimize TimecodeMonitor memory allocation

### DIFF
--- a/src/gui/widgets/timecode_monitor.py
+++ b/src/gui/widgets/timecode_monitor.py
@@ -52,6 +52,7 @@ class _LTCGenState:
     gen_current_tc: str = "--:--:--:--"
     gen_pos: int = 0
     frames_generated: int = 0
+    recycle_pool: deque = field(default_factory=deque)
     tod_epoch_base: Optional[float] = None
     free_run_start_time: float = 0.0
     jam_base_total_frames: Optional[int] = None
@@ -112,7 +113,15 @@ class LTCEncoder:
         self.fps = fps
         self.samples_per_frame = self.sample_rate / fps
 
-    def generate_frame(self, hh: int, mm: int, ss: int, ff: int, user_bits: list = None) -> np.ndarray:
+    def generate_frame(
+        self,
+        hh: int,
+        mm: int,
+        ss: int,
+        ff: int,
+        user_bits: list = None,
+        out_buffer: Optional[np.ndarray] = None,
+    ) -> np.ndarray:
         """Generates audio samples for one LTC frame."""
         bits = [0] * 80
 
@@ -178,7 +187,11 @@ class LTCEncoder:
         # Calculate samples per bit (80 bits total)
         # Note: Samples per bit is not integer usually. We need sub-sample precision or just accumulate phase.
 
-        samples = np.zeros(int(self.samples_per_frame) + 2, dtype=np.float32)  # Over allocate slightly
+        req_size = int(self.samples_per_frame) + 2
+        if out_buffer is not None and len(out_buffer) >= req_size:
+            samples = out_buffer
+        else:
+            samples = np.zeros(req_size, dtype=np.float32)  # Over allocate slightly
 
         samples_per_bit = self.samples_per_frame / 80.0
 
@@ -851,6 +864,17 @@ class TimecodeMonitor(MeasurementModule):
 
         while out_pos < frames:
             if ch.gen.gen_current is None or ch.gen.gen_pos >= len(ch.gen.gen_current):
+                if ch.gen.gen_current is not None:
+                    # Recycle the underlying buffer if possible
+                    cand = ch.gen.gen_current
+                    if getattr(cand, "base", None) is not None:
+                        cand = cand.base
+
+                    if isinstance(cand, np.ndarray):
+                        if len(ch.gen.recycle_pool) < 16:
+                            ch.gen.recycle_pool.append(cand)
+                    ch.gen.gen_current = None
+
                 if ch.gen.gen_buffer:
                     ch.gen.gen_current = ch.gen.gen_buffer.popleft()
                     if ch.gen.gen_tc_buffer:
@@ -989,7 +1013,18 @@ class TimecodeMonitor(MeasurementModule):
             ch.gen.frames_generated += 1
 
         tc = f"{int(hh):02}:{int(mm):02}:{int(ss):02}:{int(ff):02}"
-        samples = ch.gen.encoder.generate_frame(hh, mm, ss, ff)
+
+        # Attempt to reuse buffer from recycle pool
+        out_buf = None
+        req_size = int(ch.gen.encoder.samples_per_frame) + 2
+        while ch.gen.recycle_pool:
+            cand = ch.gen.recycle_pool.pop()
+            if len(cand) >= req_size:
+                out_buf = cand
+                break
+            # Discard too-small buffers (e.g. if FPS changed)
+
+        samples = ch.gen.encoder.generate_frame(hh, mm, ss, ff, out_buffer=out_buf)
         ch.gen.gen_buffer.append(samples)
         ch.gen.gen_tc_buffer.append(tc)
 


### PR DESCRIPTION
Implemented memory recycling for LTC frame generation in `TimecodeMonitor` to avoid memory allocation (`np.zeros`) inside the audio callback path. 

- Modified `LTCEncoder.generate_frame` to accept an optional `out_buffer` for reuse.
- Added `recycle_pool` (deque) to `_LTCGenState` to store reusable buffers.
- Updated `TimecodeMonitor._generate_next_frame` to retrieve buffers from the pool.
- Updated `TimecodeMonitor._get_generator_samples` to recycle consumed buffers back into the pool.
- Verified performance and correctness via benchmarks (showing successful recycling) and existing test suite.

---
*PR created automatically by Jules for task [607440059499834994](https://jules.google.com/task/607440059499834994) started by @youtube-at-vach*