### PR TITLE
🔒 Security Fix: Move docs dependencies to requirements-docs.txt

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -28,5 +28,5 @@ jobs:
           path: .cache
           restore-keys: |
             mkdocs-material-
-      - run: pip install mkdocs-material mkdocs-with-pdf mkdocs-static-i18n pyyaml mini-racer
+      - run: pip install -r requirements-docs.txt
       - run: mkdocs gh-deploy --force

--- a/.github/workflows/pdf_draft.yml
+++ b/.github/workflows/pdf_draft.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Install MkDocs and plugins
         run: |
-          pip install mkdocs-material mkdocs-with-pdf mkdocs-static-i18n pyyaml qrcode mini-racer
+          pip install -r requirements-docs.txt
 
       - name: Build Docs
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,7 +135,7 @@ jobs:
         pip install "setuptools<70.0.0"
         pip install -r requirements.txt
         pip install pyinstaller
-        pip install mkdocs-material mkdocs-with-pdf mkdocs-static-i18n pyyaml qrcode mini-racer
+        pip install -r requirements-docs.txt
 
     - name: Build standalone binary with PyInstaller
       run: |

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,7 @@
+mkdocs
+mkdocs-material
+mkdocs-with-pdf
+mkdocs-static-i18n
+mini-racer
+pyyaml
+qrcode

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,9 +9,4 @@ soundfile
 PyWavelets
 netCDF4
 pyfftw
-mkdocs
-mkdocs-material
-mkdocs-with-pdf
-mkdocs-static-i18n
-mini-racer
 


### PR DESCRIPTION
**What:** Moved documentation-only dependencies (including `mini-racer`, which was flagged as an unnecessary runtime dependency) from `requirements.txt` to a new `requirements-docs.txt`.

**Risk:** Including development/documentation dependencies in the main `requirements.txt` increases the attack surface and image size for end-user deployments. `mini-racer` specifically executes V8 JavaScript, which is unnecessary for the core Python application.

**Solution:** 
- Created `requirements-docs.txt` containing `mkdocs`, `mini-racer`, and other docs tools.
- Removed these packages from `requirements.txt`.
- Updated `.github/workflows/deploy_docs.yml`, `.github/workflows/release.yml`, and `.github/workflows/pdf_draft.yml` to install from the new file where appropriate.

---
*PR created automatically by Jules for task [15161349616499793703](https://jules.google.com/task/15161349616499793703) started by @youtube-at-vach*