### PR TITLE
🧹 Clean up dead code reference and improve PyInstaller import documentation

### DIFF
--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -107,7 +107,7 @@ def _load_module_class(module_key: str):
 
 
 if False:
-    # Explicit imports so PyInstaller can discover modules.
+    # Explicit imports via src.gui.pyinstaller_imports so PyInstaller can discover dynamically loaded modules.
     import src.gui.pyinstaller_imports  # noqa: F401
 
 


### PR DESCRIPTION
🎯 **What:** The issue reported dead code `def _pyinstaller_imports` in `src/gui/main_window.py`. Upon analysis, this function was already removed from the codebase and replaced by a module-level import of `src.gui.pyinstaller_imports` guarded by `if False`.
💡 **Why:** The codebase already uses the correct pattern (separate file for PyInstaller hooks). This PR updates the comment in `src/gui/main_window.py` to explicitly reference `src.gui.pyinstaller_imports` and clarify its purpose, resolving the intent of the issue (better documentation).
✅ **Verification:** Verified that `_pyinstaller_imports` function is absent. Verified that `src/gui/pyinstaller_imports.py` correctly covers all modules in `MODULE_REGISTRY` using a script. Ran `tests/logic_verification/` suite (432 tests passed).
✨ **Result:** Codebase is verified clean and documentation is improved.

---
*PR created automatically by Jules for task [2089860667236212647](https://jules.google.com/task/2089860667236212647) started by @youtube-at-vach*