### PR TITLE
Fix silent exception handling in ConfigManager

### DIFF
--- a/src/core/config_manager.py
+++ b/src/core/config_manager.py
@@ -72,8 +72,8 @@ class ConfigManager:
         for instance in cls._instances:
             try:
                 instance.shutdown()
-            except Exception as e:
-                logger.error("Error during shutdown: %s", e)
+            except Exception:
+                logger.exception("Error during shutdown")
 
     def load_config(self):
         """Loads configuration from JSON file."""
@@ -114,8 +114,8 @@ class ConfigManager:
                 # Ensure permissions on existing files (best effort)
                 try:
                     os.chmod(self.config_path, 0o600)
-                except Exception:
-                    pass
+                except Exception as e:
+                    self.logger.warning(f"Failed to set secure permissions for config file: {e}")
 
                 self.logger.info("Config saved.")
                 self._save_timer = None

--- a/tests/logic_verification/test_config_manager_lifecycle.py
+++ b/tests/logic_verification/test_config_manager_lifecycle.py
@@ -14,11 +14,15 @@ class TestConfigManagerLifecycle(unittest.TestCase):
 
     def tearDown(self):
         self.logger_patcher.stop()
+        if os.path.exists(self.config_path):
+            try:
+                os.remove(self.config_path)
+            except OSError:
+                pass
         # Clean up any instances created (though WeakSet handles this if we drop ref)
         # But we might want to manually clear the WeakSet if possible to avoid state leak,
         # though it's private.
         # Calling shutdown on instances is good practice if we have refs.
-        pass
 
     @patch('src.core.config_manager.os.path.exists')
     @patch('src.core.config_manager.os.makedirs')
@@ -243,7 +247,33 @@ class TestConfigManagerLifecycle(unittest.TestCase):
             if mock_instance in ConfigManager._instances:
                 ConfigManager._instances.remove(mock_instance)
 
-        self.mock_logger.error.assert_called_with("Error during shutdown: %s", exception)
+        self.mock_logger.exception.assert_called_with("Error during shutdown")
+
+    @patch('src.core.config_manager.os.path.exists', return_value=False)
+    @patch('src.core.config_manager.os.makedirs')
+    @patch('src.core.config_manager.os.open')
+    @patch('src.core.config_manager.os.fdopen')
+    @patch('src.core.config_manager.os.chmod')
+    def test_flush_config_chmod_failure(self, mock_chmod, mock_fdopen, mock_open, mock_makedirs, mock_exists):
+        """Test that chmod failure in _flush_config is logged as warning."""
+        # Setup mocks
+        mock_open.return_value = 123
+        mock_file_handle = MagicMock()
+        mock_fdopen.return_value.__enter__.return_value = mock_file_handle
+
+        # Make chmod raise an exception
+        exception_msg = "Permission denied for chmod"
+        mock_chmod.side_effect = OSError(exception_msg)
+
+        cm = ConfigManager(self.config_path)
+
+        # Trigger save
+        cm.save_config(force_sync=True)
+
+        # Verify warning logged
+        # self.mock_logger is the mock object returned by logging.getLogger
+        self.mock_logger.warning.assert_called_with(f"Failed to set secure permissions for config file: {exception_msg}")
+        cm.shutdown()
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR addresses a code health issue in `src/core/config_manager.py` where exceptions were being silently ignored or sub-optimally logged.

1.  **Fix `_flush_config`**: The `os.chmod` call in `_flush_config` was wrapped in `try...except Exception: pass`. This meant that if setting secure file permissions failed (e.g., due to file ownership issues), the error was silently swallowed. I have changed this to log a warning with the exception details, ensuring that users are aware of potential security configuration issues.
2.  **Improve `_flush_all`**: The `_flush_all` method caught exceptions during instance shutdown and logged them with `logger.error`. I have upgraded this to `logger.exception`, which includes the full stack trace, making it easier to debug crashes during application shutdown.
3.  **Tests**: I have updated `tests/logic_verification/test_config_manager_lifecycle.py` to verify the new logging behavior for both `_flush_config` (chmod failure) and `_flush_all`. I also improved the test teardown to clean up the temporary `test_config.json` file.

---
*PR created automatically by Jules for task [15341068393822207257](https://jules.google.com/task/15341068393822207257) started by @youtube-at-vach*