### PR TITLE
Move PyInstaller imports to build config

### DIFF
--- a/.github/workflows/build_appimage.yml
+++ b/.github/workflows/build_appimage.yml
@@ -40,7 +40,7 @@ jobs:
         # Create libs directory if it doesn't exist (though not strictly needed for system-wide pyinstaller)
         mkdir -p libs
         # Run PyInstaller
-        pyinstaller --onefile --windowed --name MeasureLab --icon=app_icon.png --add-data "src:src" --exclude-module matplotlib --collect-all backports --collect-all soundfile --collect-all pyfftw --hidden-import pyfftw main_gui.py
+        pyinstaller --onefile --windowed --name MeasureLab --icon=app_icon.png --add-data "src:src" --exclude-module matplotlib --collect-all backports --collect-all soundfile --collect-all pyfftw --hidden-import pyfftw --hidden-import src.gui.pyinstaller_imports main_gui.py
 
     - name: Build AppImage
       run: |

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -68,6 +68,7 @@ jobs:
           --collect-all soundfile \
           --collect-all pyfftw \
           --hidden-import pyfftw \
+          --hidden-import src.gui.pyinstaller_imports \
           --distpath dist \
           --workpath build \
           --target-architecture arm64 \

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -47,7 +47,7 @@ jobs:
         ls libs
 
         # Note: Windows uses ; as separator for add-data
-        pyinstaller --onefile --windowed --name MeasureLab --icon=app_icon.ico --add-data "src;src" --add-binary "libs/icu*.dll;." --exclude-module matplotlib --collect-all backports --collect-all soundfile --collect-all pyfftw --hidden-import pyfftw --distpath dist/onefile --workpath build/onefile main_gui.py
+        pyinstaller --onefile --windowed --name MeasureLab --icon=app_icon.ico --add-data "src;src" --add-binary "libs/icu*.dll;." --exclude-module matplotlib --collect-all backports --collect-all soundfile --collect-all pyfftw --hidden-import pyfftw --hidden-import src.gui.pyinstaller_imports --distpath dist/onefile --workpath build/onefile main_gui.py
 
     - name: Verify Windows Executable (GUI Self-Test)
       run: |
@@ -58,7 +58,7 @@ jobs:
       run: |
         # Default PyInstaller mode is onedir (folder-based distribution)
         # Default PyInstaller mode is onedir (folder-based distribution)
-        pyinstaller --windowed --name MeasureLab --icon=app_icon.ico --add-data "src;src" --add-binary "libs/icu*.dll;." --exclude-module matplotlib --collect-all backports --collect-all soundfile --collect-all pyfftw --hidden-import pyfftw --distpath dist/onedir --workpath build/onedir main_gui.py
+        pyinstaller --windowed --name MeasureLab --icon=app_icon.ico --add-data "src;src" --add-binary "libs/icu*.dll;." --exclude-module matplotlib --collect-all backports --collect-all soundfile --collect-all pyfftw --hidden-import pyfftw --hidden-import src.gui.pyinstaller_imports --distpath dist/onedir --workpath build/onedir main_gui.py
         copy scripts/enable_asio.bat dist/onedir/MeasureLab/
         copy scripts/disable_asio.bat dist/onedir/MeasureLab/
         copy scripts/README_ASIO.txt dist/onedir/MeasureLab/

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -98,17 +98,13 @@ def _load_module_class(module_key: str):
     """Return MeasurementModule class by key.
 
     Uses _load_class to avoid importing heavy GUI modules at application startup.
-    Explicit imports for PyInstaller discovery are handled in src.gui.pyinstaller_imports.
+    Explicit imports for PyInstaller discovery are handled in src.gui.pyinstaller_imports
+    (included via --hidden-import in build scripts).
     """
     if module_key not in MODULE_REGISTRY:
         raise KeyError(f"Unknown module key: {module_key}")
 
     return _load_class(*MODULE_REGISTRY[module_key])
-
-
-if False:
-    # Explicit imports so PyInstaller can discover modules.
-    import src.gui.pyinstaller_imports  # noqa: F401
 
 
 def _load_settings_widget_class():

--- a/src/gui/pyinstaller_imports.py
+++ b/src/gui/pyinstaller_imports.py
@@ -1,7 +1,8 @@
 """
 Explicit imports so PyInstaller can discover dynamically loaded modules.
 
-This file is never imported at runtime, but PyInstaller's static analysis
+This file is included via the `--hidden-import` flag in build scripts.
+It is never imported at runtime, but PyInstaller's static analysis
 will detect these imports and include the modules in the bundle.
 """
 


### PR DESCRIPTION
Removed the dead code block in src/gui/main_window.py that conditionally imported src.gui.pyinstaller_imports. Updated build workflows (build_appimage.yml, build_windows.yml, build_macos.yml) to include the module via the --hidden-import flag instead. This improves code health by removing source-level build hacks.

---
*PR created automatically by Jules for task [16183783456649226829](https://jules.google.com/task/16183783456649226829) started by @youtube-at-vach*