### PR TITLE
Refactor ConfigManager exception handling for better visibility

### DIFF
--- a/src/core/config_manager.py
+++ b/src/core/config_manager.py
@@ -72,8 +72,8 @@ class ConfigManager:
         for instance in cls._instances:
             try:
                 instance.shutdown()
-            except Exception as e:
-                logger.error("Error during shutdown: %s", e)
+            except Exception:
+                logger.exception("Error during shutdown")
 
     def load_config(self):
         """Loads configuration from JSON file."""
@@ -114,8 +114,8 @@ class ConfigManager:
                 # Ensure permissions on existing files (best effort)
                 try:
                     os.chmod(self.config_path, 0o600)
-                except Exception:
-                    pass
+                except Exception as exc:
+                    self.logger.warning(f"Unable to set secure permissions for {self.config_path}: {exc}")
 
                 self.logger.info("Config saved.")
                 self._save_timer = None

--- a/test_config.json
+++ b/test_config.json
@@ -1,0 +1,20 @@
+{
+    "audio": {
+        "input_device": null,
+        "input_hostapi": null,
+        "output_device": null,
+        "output_hostapi": null,
+        "sample_rate": 48000,
+        "block_size": 1024,
+        "input_channels": "stereo",
+        "output_channels": "stereo",
+        "pipewire_jack_resident": false,
+        "offline_mode": false,
+        "offline_sample_rate": 48000
+    },
+    "language": "en",
+    "theme": "system",
+    "screenshot": {
+        "output_dir": "screenshots"
+    }
+}

--- a/tests/logic_verification/test_config_manager_lifecycle.py
+++ b/tests/logic_verification/test_config_manager_lifecycle.py
@@ -14,11 +14,11 @@ class TestConfigManagerLifecycle(unittest.TestCase):
 
     def tearDown(self):
         self.logger_patcher.stop()
-        # Clean up any instances created (though WeakSet handles this if we drop ref)
-        # But we might want to manually clear the WeakSet if possible to avoid state leak,
-        # though it's private.
-        # Calling shutdown on instances is good practice if we have refs.
-        pass
+        if os.path.exists(self.config_path):
+            try:
+                os.remove(self.config_path)
+            except OSError:
+                pass
 
     @patch('src.core.config_manager.os.path.exists')
     @patch('src.core.config_manager.os.makedirs')
@@ -243,7 +243,46 @@ class TestConfigManagerLifecycle(unittest.TestCase):
             if mock_instance in ConfigManager._instances:
                 ConfigManager._instances.remove(mock_instance)
 
-        self.mock_logger.error.assert_called_with("Error during shutdown: %s", exception)
+        self.mock_logger.exception.assert_called_with("Error during shutdown")
+
+    @patch('src.core.config_manager.os.path.exists', return_value=False)
+    @patch('src.core.config_manager.os.makedirs')
+    @patch('src.core.config_manager.os.open')
+    @patch('src.core.config_manager.os.fdopen')
+    @patch('src.core.config_manager.os.chmod')
+    def test_save_config_chmod_failure_logs_warning(self, mock_chmod, mock_fdopen, mock_open, mock_makedirs, mock_exists):
+        """Test that failure to set permissions (chmod) is logged as a warning."""
+        # Setup mocks to succeed until chmod
+        mock_open.return_value = 123
+        mock_file_handle = MagicMock()
+        mock_fdopen.return_value.__enter__.return_value = mock_file_handle
+
+        # Simulate chmod raising an exception (e.g. PermissionError)
+        error = OSError("Operation not permitted")
+        mock_chmod.side_effect = error
+
+        cm = ConfigManager(self.config_path)
+        # Reset mock logger because _ensure_screenshot_dir called during init might have logged warnings
+        self.mock_logger.reset_mock()
+
+        # Force immediate save, which calls _flush_config
+        cm.save_config(force_sync=True)
+
+        # Verify that chmod was called
+        mock_chmod.assert_called_with(self.config_path, 0o600)
+
+        # Verify that a warning was logged.
+        self.mock_logger.warning.assert_called()
+
+        # Check that the log message mentions the error
+        found = False
+        for call in self.mock_logger.warning.call_args_list:
+            args, _ = call
+            if str(error) in str(args):
+                found = True
+                break
+        self.assertTrue(found, "Warning log should contain the error message")
+        cm.shutdown()
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR addresses broad exception handling in `ConfigManager`. Specifically:
1.  The `_flush_config` method previously swallowed exceptions during `os.chmod` (permission setting) with `pass`. It now logs a warning with the exception details.
2.  The `_flush_all` method (used in `atexit`) previously used `logger.error` which might miss stack traces. It now uses `logger.exception`.
3.  A new test case verifies that `chmod` failures are logged correctly.
4.  Existing tests were updated to ensure proper file cleanup.

---
*PR created automatically by Jules for task [17041213856489894806](https://jules.google.com/task/17041213856489894806) started by @youtube-at-vach*