### PR TITLE
🔒 Remove misleading SSL verification comments in UpdateChecker

### DIFF
--- a/src/core/update_checker.py
+++ b/src/core/update_checker.py
@@ -12,10 +12,6 @@ class UpdateChecker(QThread):
     def run(self):
         try:
             url = "https://api.github.com/repos/youtube-at-vach/MeasureLab/releases/latest"
-            # Create a context that ignores SSL certificate errors (for simplicity in some envs, though properly verified is better)
-            # However, for standard shipping, standard validation is preferred.
-            # If encountering issues, we might need ssl._create_unverified_context()
-            # But let's try standard request first.
 
             req = urllib.request.Request(url)
             req.add_header("User-Agent", f"MeasureLab/{__version__}")


### PR DESCRIPTION
**What:** Removed comments in `src/core/update_checker.py` that suggested using `ssl._create_unverified_context()`.
**Risk:** Leaving these comments could lead future developers to implement insecure SSL practices, making the application vulnerable to Man-in-the-Middle (MITM) attacks during update checks.
**Solution:** Removed the misleading comments. The existing code uses standard `urllib.request.urlopen` which enforces SSL verification by default. No functional code was changed.

---
*PR created automatically by Jules for task [10995126852227518058](https://jules.google.com/task/10995126852227518058) started by @youtube-at-vach*