### PR TITLE
🧹 Replace print with logging in UltrasoundModulator

### DIFF
--- a/src/gui/widgets/ultrasound_modulator.py
+++ b/src/gui/widgets/ultrasound_modulator.py
@@ -1,3 +1,4 @@
+import logging
 import numpy as np
 import scipy.signal
 from PyQt6.QtCore import Qt, QTimer
@@ -24,6 +25,8 @@ from PyQt6.QtWidgets import (
 from src.core.audio_engine import AudioEngine
 from src.core.localization import tr
 from src.measurement_modules.base import MeasurementModule
+
+logger = logging.getLogger(__name__)
 
 
 # Precomputed Hilbert coefficients for fallback (approx 48kHz, width=800, 65 taps)
@@ -122,7 +125,7 @@ class UltrasoundModulator(MeasurementModule):
                 try:
                     self._hilbert_coeffs = scipy.signal.remez(numtaps, bands, [1], type="hilbert", fs=fs)
                 except Exception as e:
-                    print(f"Error designing Hilbert filter: {e}. Fallback to basic.")
+                    logger.warning(f"Error designing Hilbert filter: {e}. Fallback to basic.")
                     # Fallback to precomputed coefficients
                     self._hilbert_coeffs = np.array(_FALLBACK_HILBERT_COEFFS)
 
@@ -147,7 +150,7 @@ class UltrasoundModulator(MeasurementModule):
 
         def callback(indata, outdata, frames, time, status):
             if status:
-                print(status)
+                logger.warning(f"Audio callback status: {status}")
 
             fs = self.audio_engine.sample_rate
 

--- a/tests/logic_verification/test_ultrasound_modulator.py
+++ b/tests/logic_verification/test_ultrasound_modulator.py
@@ -26,8 +26,11 @@ class TestUltrasoundModulator(unittest.TestCase):
         # Test fallback when remez fails
         with patch('scipy.signal.remez') as mock_remez:
             mock_remez.side_effect = ValueError("Convergence failed")
-            self.modulator._update_filter(48000)
 
+            with self.assertLogs('src.gui.widgets.ultrasound_modulator', level='WARNING') as cm:
+                self.modulator._update_filter(48000)
+
+            self.assertTrue(any("Error designing Hilbert filter" in output for output in cm.output))
             self.assertIsNotNone(self.modulator._hilbert_coeffs)
             self.assertEqual(len(self.modulator._hilbert_coeffs), 65)
 


### PR DESCRIPTION
🎯 **What:**
- Replaced `print` statements in `src/gui/widgets/ultrasound_modulator.py` with `logger.warning`.
- Specifically addressed the error handling block for `scipy.signal.remez` and the audio callback status check.
- Added `import logging` and initialized a module-level logger.

💡 **Why:**
- Using `print` for error reporting is bad practice as it spams stdout and is hard to manage/filter in production.
- Logging allows for better integration with the application's logging infrastructure (e.g., file logs, levels).
- Printing in the audio callback (even conditionally) is generally discouraged; logging provides a more structured way to report issues like buffer underflows (`status`).

✅ **Verification:**
- Updated `tests/logic_verification/test_ultrasound_modulator.py` to assert that a warning is logged when filter design fails.
- Ran tests successfully (`python3 -m pytest tests/logic_verification/test_ultrasound_modulator.py`).
- Verified code style with `ruff`.

✨ **Result:**
- Cleaner code with standard logging practices.
- Robust test coverage for the error handling path.

---
*PR created automatically by Jules for task [7018845600054560019](https://jules.google.com/task/7018845600054560019) started by @youtube-at-vach*