### PR TITLE
build: Upgrade Python target to 3.12 in CI workflows and constraints.

### DIFF
--- a/.github/workflows/build_appimage.yml
+++ b/.github/workflows/build_appimage.yml
@@ -18,10 +18,10 @@ jobs:
       with:
         persist-credentials: false
 
-    - name: Set up Python 3.10
+    - name: Set up Python 3.12
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
-        python-version: "3.10"
+        python-version: "3.12"
 
     - name: Install system dependencies
       run: |

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -17,10 +17,10 @@ jobs:
       with:
         persist-credentials: false
 
-    - name: Set up Python 3.10
+    - name: Set up Python 3.12
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
-        python-version: "3.10"
+        python-version: "3.12"
 
     - name: Install System Dependencies
       run: |

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -18,10 +18,10 @@ jobs:
       with:
         persist-credentials: false
 
-    - name: Set up Python 3.10
+    - name: Set up Python 3.12
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
-        python-version: "3.10"
+        python-version: "3.12"
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Python 3.10
+      - name: Set up Python 3.12
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Install system dependencies
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ description: Instructions for running development tools (pytest, ruff, mypy)
 ## 実行環境
 
 - OS: Linux
-- Python: 3.10+ 想定（README 記載）
+- Python: 3.12+ 想定（README 記載）
 - 推奨 Python 実行環境: `./.venv/bin/python`
 
 ## セットアップ (venv)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ To contribute to MeasureLab, you'll need to set up a development environment.
 
 ### Prerequisites
 
-- **Python 3.10** or higher
+- **Python 3.12** or higher
 - `pip` and `venv`
 - **Node.js** (optional, for markdown linting)
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A collection of DIY audio measurement and analysis tools, grown organically as n
 
 - PyQt6 desktop app bundling 29+ DIY modules: signal generator, spectrum/PSD analyzer, sound level & LUFS meters, loopback finder, distortion/IMD tools, network/impedance analyzers, oscilloscope, spectrogram, ultrasound modulator, transient analyzer, lock-in/FRA, inverse filter, frequency counter, 1PPS monitor, recorder/player, sound quality analyzer, noise profiler, boxcar averager, goniometer, BNIM meter (ITD/ILD neural map), HRTF Player, and more.
 - Built for hobbyists and engineers: device routing, calibration (input/output/SPL), multi-language UI, light/dark themes.
-- Runs on Windows/Linux; grab the AppImage/ZIP or `python main_gui.py` from source (Python 3.10+).
+- Runs on Windows/Linux; grab the AppImage/ZIP or `python main_gui.py` from source (Python 3.12+).
 
 ## ✨ 主な機能 (Features)
 
@@ -106,7 +106,7 @@ Linux ではそのまま **PortAudio** バックエンドでも通常利用で�
 
 ### 🐍 ソースコードから実行する場合
 
-**必要条件**: Python 3.10 以上
+**必要条件**: Python 3.12 以上
 
 #### Linux / Ubuntu（推奨）: 仮想環境 (venv) で実行する
 

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,5 +1,5 @@
 # Pinned versions for reproducible installs. Adjust when bumping Python/OS targets.
-# Python target: 3.10 (per CI workflows).
+# Python target: 3.12 (per CI workflows).
 
 numpy==2.2.6
 scipy==1.15.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "measurelab"
 version = "0.4.4"
 description = "DIY audio measurement and analysis suite"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 license = {text = "Unlicense"}
 authors = [
   {name = "MeasureLab maintainers"}
@@ -33,7 +33,7 @@ dev = [
 
 [tool.ruff]
 line-length = 120
-target-version = "py310"
+target-version = "py312"
 
 [tool.ruff.lint]
 # Start with a narrow, low-noise rule set focused on correctness and
@@ -46,7 +46,7 @@ ignore = []
 
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.12"
 ignore_missing_imports = true
 show_error_codes = true
 warn_unused_ignores = true


### PR DESCRIPTION
開発環境及びビルド環境をPython3.12に統一