### PR TITLE
Fix race condition in AudioEngine stream startup

### DIFF
--- a/src/core/audio_engine.py
+++ b/src/core/audio_engine.py
@@ -186,7 +186,8 @@ class AudioEngine:
 
         if enabled:
             # Ensure master stream is open even with zero clients.
-            self._start_master_stream()
+            with self.lock:
+                self._start_master_stream()
             return
 
         # Disabled: revert to legacy behavior (only keep stream open while clients exist).
@@ -597,8 +598,9 @@ class AudioEngine:
 
     def _restart_stream(self):
         self.stop_stream()
-        if self.callbacks:
-            self._start_master_stream()
+        with self.lock:
+            if self.callbacks:
+                self._start_master_stream()
 
     def is_active(self):
         """Returns True if the stream is active."""


### PR DESCRIPTION
Identified a race condition in `src/core/audio_engine.py` where `_start_master_stream` was called without holding `self.lock` in `_restart_stream` and `set_pipewire_jack_resident`. This could lead to conflicts with `stop_stream` or concurrent `register_callback` calls.

Added `with self.lock:` blocks around these calls to ensure exclusive access to `self.stream`.
Verified the fix by creating a temporary test case that mocked `threading.Lock` and asserted that `acquire` was called during these operations. The test passed after the fix was applied.

---
*PR created automatically by Jules for task [8916485628810553758](https://jules.google.com/task/8916485628810553758) started by @youtube-at-vach*