### PR TITLE
Refactor DPSS window caching to FFTManager

### DIFF
--- a/src/core/fft_manager.py
+++ b/src/core/fft_manager.py
@@ -1,3 +1,4 @@
+import functools
 import numpy as np
 import multiprocessing
 import threading
@@ -344,6 +345,20 @@ class FFTManager:
             "tukey",
             "taylor",
         ]
+
+
+@functools.lru_cache(maxsize=16)
+def get_dpss_windows(N, NW=3, Kmax=None):
+    """
+    Get DPSS windows, caching them for performance.
+    """
+    # Lazy import to avoid hard dependency at module level
+    from scipy.signal.windows import dpss
+
+    if Kmax is None:
+        Kmax = int(2 * NW - 1)
+
+    return dpss(N, NW, int(Kmax))
 
 
 # Global instance for easy access

--- a/src/gui/widgets/spectrum_analyzer.py
+++ b/src/gui/widgets/spectrum_analyzer.py
@@ -16,11 +16,10 @@ from PyQt6.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-from scipy.signal.windows import dpss
 
 from src.core.analysis import get_cached_window
 from src.core.audio_engine import AudioEngine
-from src.core.fft_manager import fft_manager
+from src.core.fft_manager import fft_manager, get_dpss_windows
 from src.core.localization import tr
 from src.measurement_modules.base import MeasurementModule
 
@@ -48,10 +47,6 @@ class SpectrumAnalyzer(MeasurementModule):
         self.multitaper_enabled = False
         self.display_unit = "dBFS"  # 'dBFS', 'dBV', 'dB SPL'
         self.weighting = "Z"  # 'Z', 'A', 'C'
-
-        # Multitaper cache
-        self._dpss_windows = None
-        self._dpss_cache_key = None  # (N, NW, K)
 
         # State
         self._avg_magnitude = None
@@ -81,9 +76,6 @@ class SpectrumAnalyzer(MeasurementModule):
         self._avg_cross_spectrum = None
         self._peak_magnitude = None
         self._avg_weighted_power = None
-        # Reset DPSS cache as N changed
-        self._dpss_windows = None
-        self._dpss_cache_key = None
 
     def start_analysis(self):
         if self.is_running:
@@ -175,22 +167,6 @@ class SpectrumAnalyzer(MeasurementModule):
                 self.audio_engine.unregister_callback(self.callback_id)
                 self.callback_id = None
             self.is_running = False
-
-    def _get_dpss_windows(self, N, NW=3, Kmax=None):
-        """
-        Get DPSS windows, caching them for performance.
-        """
-        if Kmax is None:
-            Kmax = 2 * NW - 1
-
-        key = (N, NW, Kmax)
-        if self._dpss_windows is None or self._dpss_cache_key != key:
-            # Generate windows
-            # dpss returns (K, N) array
-            self._dpss_windows = dpss(N, NW, int(Kmax))
-            self._dpss_cache_key = key
-
-        return self._dpss_windows
 
     def compute_weighting(self, freqs, weighting_type):
         """
@@ -703,7 +679,7 @@ class SpectrumAnalyzerWidget(QWidget):
         if self.module.multitaper_enabled:
             # --- Multitaper Method ---
             # Get DPSS windows
-            windows = self.module._get_dpss_windows(len(data))  # (K, N)
+            windows = get_dpss_windows(len(data))  # (K, N)
             K = windows.shape[0]
 
             if self.module.analysis_mode == "Spectrum" or self.module.analysis_mode == "PSD":

--- a/tests/logic_verification/test_fft_manager_windows.py
+++ b/tests/logic_verification/test_fft_manager_windows.py
@@ -1,0 +1,100 @@
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+# Create mock objects
+mock_scipy = MagicMock()
+mock_signal = MagicMock()
+mock_windows = MagicMock()
+mock_dpss = MagicMock()
+
+# Configure scipy mocks
+mock_windows.dpss = mock_dpss
+mock_signal.windows = mock_windows
+mock_scipy.signal = mock_signal
+
+# Configure numpy mock
+mock_numpy = MagicMock()
+mock_numpy.float32 = 'float32'
+mock_numpy.float64 = 'float64'
+mock_numpy.complex64 = 'complex64'
+mock_numpy.complex128 = 'complex128'
+
+class TestFFTManagerWindows(unittest.TestCase):
+    def setUp(self):
+        # Patch sys.modules to simulate scipy and numpy presence
+        self.modules_patcher = patch.dict(sys.modules, {
+            'scipy': mock_scipy,
+            'scipy.signal': mock_signal,
+            'scipy.signal.windows': mock_windows,
+            'numpy': mock_numpy
+        })
+        self.modules_patcher.start()
+
+        # Reset mock_dpss for each test
+        mock_dpss.reset_mock()
+
+        # Import the function under test
+        # Ensure clean import by removing from sys.modules if present
+        if 'src.core.fft_manager' in sys.modules:
+            del sys.modules['src.core.fft_manager']
+
+        from src.core.fft_manager import get_dpss_windows
+        self.get_dpss_windows = get_dpss_windows
+
+        # Clear cache to ensure clean state
+        self.get_dpss_windows.cache_clear()
+
+    def tearDown(self):
+        self.modules_patcher.stop()
+
+    def test_get_dpss_windows_defaults(self):
+        """Test basic call with defaults."""
+        N = 1024
+        mock_dpss.return_value = "windows_1024"
+
+        result = self.get_dpss_windows(N)
+
+        # Verify defaults: NW=3, Kmax=None -> Kmax=2*3-1=5
+        mock_dpss.assert_called_once_with(N, 3, 5)
+        self.assertEqual(result, "windows_1024")
+
+    def test_get_dpss_windows_explicit(self):
+        """Test call with explicit parameters."""
+        N = 512
+        NW = 4
+        Kmax = 7
+        mock_dpss.return_value = "windows_512_explicit"
+
+        result = self.get_dpss_windows(N, NW, Kmax)
+
+        mock_dpss.assert_called_once_with(N, NW, Kmax)
+        self.assertEqual(result, "windows_512_explicit")
+
+    def test_get_dpss_windows_caching(self):
+        """Test that repeated calls use the cache."""
+        N = 2048
+        mock_dpss.return_value = "windows_2048"
+
+        # First call
+        res1 = self.get_dpss_windows(N)
+        mock_dpss.assert_called_once_with(N, 3, 5)
+
+        # Second call
+        res2 = self.get_dpss_windows(N)
+        # Should NOT call dpss again
+        mock_dpss.assert_called_once()
+        self.assertIs(res1, res2)
+
+    def test_get_dpss_windows_kmax_logic(self):
+        """Verify Kmax calculation logic."""
+        N = 100
+        NW = 2.5
+        # Kmax = 2 * 2.5 - 1 = 4.0 -> int(4.0) = 4
+
+        self.get_dpss_windows(N, NW)
+
+        mock_dpss.assert_called_with(N, NW, 4)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Refactor DPSS Window Caching

- Moved `_get_dpss_windows` logic from `src/gui/widgets/spectrum_analyzer.py` to `src/core/fft_manager.py` as a standalone function `get_dpss_windows`.
- Decorated `get_dpss_windows` with `@functools.lru_cache(maxsize=16)` for efficient caching.
- Implemented lazy import of `scipy.signal.windows.dpss` within `get_dpss_windows` to avoid hard module-level dependency on `scipy`, ensuring robustness in environments where `scipy` might be missing or optional.
- Updated `SpectrumAnalyzer` to use the new shared function.
- Added comprehensive unit test `tests/logic_verification/test_fft_manager_windows.py` that mocks `scipy` and `numpy` to verify behavior and caching logic in isolation.

---
*PR created automatically by Jules for task [13486496174882620098](https://jules.google.com/task/13486496174882620098) started by @youtube-at-vach*