### PR TITLE
Refactor FFTManager._create_plan to reduce duplication

### DIFF
--- a/src/core/fft_manager.py
+++ b/src/core/fft_manager.py
@@ -147,21 +147,30 @@ class FFTManager:
             return
 
         try:
-            # We focus on rfft (Real input -> Complex output) and irfft (Complex input -> Real output)
+            # Determine dtypes based on precision
+            if dtype_str == "float32":
+                real_dtype = "float32"
+                complex_dtype = "complex64"
+            else:
+                real_dtype = "float64"
+                complex_dtype = "complex128"
+
+            # Determine input/output shapes and dtypes based on direction
+            # rfft: Real input -> Complex output (FFTW_FORWARD)
+            # irfft: Complex input -> Real output (FFTW_BACKWARD)
             if direction == "FFTW_FORWARD":
-                if dtype_str == "float32":
-                    input_array = pyfftw.empty_aligned(size, dtype="float32")
-                    output_array = pyfftw.empty_aligned(size // 2 + 1, dtype="complex64")
-                else:
-                    input_array = pyfftw.empty_aligned(size, dtype="float64")
-                    output_array = pyfftw.empty_aligned(size // 2 + 1, dtype="complex128")
-            else:  # FFTW_BACKWARD (irfft)
-                if dtype_str == "float32":
-                    input_array = pyfftw.empty_aligned(size // 2 + 1, dtype="complex64")
-                    output_array = pyfftw.empty_aligned(size, dtype="float32")
-                else:
-                    input_array = pyfftw.empty_aligned(size // 2 + 1, dtype="complex128")
-                    output_array = pyfftw.empty_aligned(size, dtype="float64")
+                input_shape = size
+                input_dtype = real_dtype
+                output_shape = size // 2 + 1
+                output_dtype = complex_dtype
+            else:
+                input_shape = size // 2 + 1
+                input_dtype = complex_dtype
+                output_shape = size
+                output_dtype = real_dtype
+
+            input_array = pyfftw.empty_aligned(input_shape, dtype=input_dtype)
+            output_array = pyfftw.empty_aligned(output_shape, dtype=output_dtype)
 
             # Use provided flags (ESTIMATE vs MEASURE)
             fft_object = pyfftw.FFTW(input_array, output_array, direction=direction, flags=flags, threads=self.threads)


### PR DESCRIPTION
🎯 **What:**
Refactored `FFTManager._create_plan` in `src/core/fft_manager.py` to reduce code duplication.

💡 **Why:**
The previous implementation had nested `if/else` blocks that repeated `pyfftw.empty_aligned` calls four times (for each combination of `float32`/`float64` and `FFTW_FORWARD`/`FFTW_BACKWARD`). By determining the correct `input_dtype`, `output_dtype`, `input_shape`, and `output_shape` variables first, the array creation logic is now consolidated into a single block, making the code cleaner and easier to maintain.

✅ **Verification:**
Created a reproduction script `tests/reproduce_issue.py` that mocks `pyfftw` and `numpy` (since they are not installed in the environment) to verify that `_create_plan` calls `pyfftw.empty_aligned` and `pyfftw.FFTW` with the correct arguments for all four permutations. The script confirmed that the refactored code behaves exactly as the original implementation.

✨ **Result:**
Reduced code duplication and improved readability of the FFT planning logic without altering functionality.

---
*PR created automatically by Jules for task [9190927777304214775](https://jules.google.com/task/9190927777304214775) started by @youtube-at-vach*