### PR TITLE
Downgrade numpy to version 2.2.6 in dependency constraints and projec…

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,6 +1,8 @@
 # Pinned versions for reproducible installs. Adjust when bumping Python/OS targets.
 # Python target: 3.12 (per CI workflows).
 
+# numpy 2.4.2 causes "DLL load failed" on Windows (v0.5.0 worked with 2.2.6).
+# Keep pinned to 2.2.6 until the issue is resolved.
 numpy==2.2.6
 scipy==1.17.0
 sounddevice==0.5.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ authors = [
   {name = "MeasureLab maintainers"}
 ]
 dependencies = [
+  # numpy 2.4.2 causes "DLL load failed" on Windows. Keep < 2.4.0.
   "numpy>=1.24,<2.4.0",
   "scipy>=1.11,<1.18",
   "sounddevice>=0.4.6,<0.6",


### PR DESCRIPTION
WindowsでDLLエラーで起動しないバグを修正
おそらくDipendabotが持ってきたnumpyのバージョンアップが原因だと特定
2.2.6に切り戻して対応