### PR TITLE
Fix noise profile integration logic for logarithmic frequency axes

### DIFF
--- a/src/core/analysis.py
+++ b/src/core/analysis.py
@@ -930,7 +930,10 @@ class AudioCalc:
 
             # Integration: Power = sum(PSD * bin_width)
             # mag is V/rtHz. mag_sq is V^2/Hz (PSD).
-            power = np.sum(mag_sq[idx_start:idx_end]) * bin_width
+            if np.ndim(bin_width) == 0:
+                power = np.sum(mag_sq[idx_start:idx_end]) * bin_width
+            else:
+                power = np.sum(mag_sq[idx_start:idx_end] * bin_width[idx_start:idx_end])
             return power
 
         p50 = get_power_in_band(50.0)
@@ -1077,7 +1080,11 @@ class AudioCalc:
             if idx_start >= idx_end:
                 return 0.0
             # bin_width is pre-calculated
-            return np.sqrt(np.sum(mag_sq[idx_start:idx_end]) * bin_width)
+            if np.ndim(bin_width) == 0:
+                power = np.sum(mag_sq[idx_start:idx_end]) * bin_width
+            else:
+                power = np.sum(mag_sq[idx_start:idx_end] * bin_width[idx_start:idx_end])
+            return np.sqrt(power)
 
         rms_20k = integrate_band(20, 20000)
         rms_100k = integrate_band(20, 100000)
@@ -1131,7 +1138,11 @@ class AudioCalc:
         # Power = sum(PSD * Weight^2 * bin_width)
         # Avoid allocating full weighted magnitude array
         weighted_power_slice = mag_sq[i_a_start:i_a_end] * weighting_sq[i_a_start:i_a_end]
-        power_a = np.sum(weighted_power_slice) * bin_width
+
+        if np.ndim(bin_width) == 0:
+            power_a = np.sum(weighted_power_slice) * bin_width
+        else:
+            power_a = np.sum(weighted_power_slice * bin_width[i_a_start:i_a_end])
 
         return np.sqrt(power_a)
 
@@ -1185,7 +1196,16 @@ class AudioCalc:
 
         # Pre-calculate squared magnitude and bin width
         mag_sq = mag**2
-        bin_width = freq_step if is_linear_freqs else (freqs[1] - freqs[0] if len(freqs) > 1 else 1.0)
+        if is_linear_freqs:
+            bin_width = freq_step
+        else:
+            # Calculate variable bin widths for log/arbitrary scale
+            if len(freqs) > 1:
+                # Use forward difference, append last
+                diffs = np.diff(freqs)
+                bin_width = np.append(diffs, diffs[-1])
+            else:
+                bin_width = 1.0
 
         # 1. Hum Noise Detection (50Hz vs 60Hz)
         hum_rms, hum_freq, hum_components = AudioCalc._calculate_hum_noise(

--- a/tests/logic_verification/test_log_integration.py
+++ b/tests/logic_verification/test_log_integration.py
@@ -1,0 +1,65 @@
+import numpy as np
+import sys
+import os
+
+# Adjust path to import src
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../')))
+
+from src.core.analysis import AudioCalc
+
+def test_log_integration_bug():
+    # 1. Setup
+    # Create a Logarithmic Frequency Axis from 20Hz to 20kHz
+    f_start = 20.0
+    f_end = 20000.0
+    n_bins = 1000
+    freqs = np.geomspace(f_start, f_end, n_bins)
+
+    # constant PSD of 1.0 V^2/Hz (for simplicity)
+    # Magnitude (V/rtHz) = 1.0
+    mag = np.ones_like(freqs)
+
+    # 2. Expected Result (Analytical Integration)
+    # Power = Integral(PSD * df)
+    # Since PSD = 1.0, Power = f_end - f_start
+    expected_power = f_end - f_start
+    expected_rms = np.sqrt(expected_power)
+
+    print(f"Expected Power: {expected_power:.4f}")
+    print(f"Expected RMS: {expected_rms:.4f}")
+
+    # 3. Actual Result using AudioCalc
+    # sampling_rate is just needed for some internal checks, set arbitrarily high
+    sampling_rate = 48000
+
+    results = AudioCalc.calculate_noise_profile(mag, freqs, sampling_rate)
+
+    # Check noise_rms_20k (which integrates from 20 to 20k)
+    # Note: calculate_noise_profile integrates 20Hz-20kHz.
+    # Our axis is exactly 20Hz-20kHz.
+    actual_rms = results["noise_rms_20k"]
+    actual_power = actual_rms ** 2
+
+    print(f"Actual Power: {actual_power:.4f}")
+    print(f"Actual RMS: {actual_rms:.4f}")
+
+    # 4. Analysis
+    # In the bug scenario, bin_width is taken as freqs[1] - freqs[0]
+    bin_0_width = freqs[1] - freqs[0]
+    # Sum of (1.0 * bin_0_width) for n_bins
+    bug_power_estimate = n_bins * bin_0_width
+
+    print(f"Bug Estimate (n_bins * bin_0): {bug_power_estimate:.4f}")
+
+    ratio = actual_power / expected_power
+    print(f"Ratio (Actual/Expected): {ratio:.6f}")
+
+    if abs(ratio - 1.0) > 0.1:
+        print("FAIL: Integration is significantly incorrect.")
+        return False
+    else:
+        print("PASS: Integration is correct.")
+        return True
+
+if __name__ == "__main__":
+    test_log_integration_bug()


### PR DESCRIPTION
This PR fixes a bug in `src/core/analysis.py` where noise integration functions assumed a constant bin width (derived from the first frequency step) even for non-linear frequency axes (like logarithmic scales). This led to significant calculation errors (underestimation) for high frequencies in log plots.

The fix involves:
1. Detecting non-linear frequency axes and calculating an array of bin widths using `np.diff`.
2. Updating integration helper functions to support element-wise multiplication of PSD and bin widths.
3. Adding a test case to verify the fix against analytical integration of a flat PSD.

---
*PR created automatically by Jules for task [3818821069182088120](https://jules.google.com/task/3818821069182088120) started by @youtube-at-vach*