### PR TITLE
Fix negative frequency handling in IMD/PIM analysis

### DIFF
--- a/src/core/analysis.py
+++ b/src/core/analysis.py
@@ -736,8 +736,9 @@ class AudioCalc:
         # d3
         d3_low = 2 * f1 - f2
         d3_high = 2 * f2 - f1
-        amp_d3_low = AudioCalc._find_peak(mag, freqs, d3_low) if d3_low > 0 else 0
-        amp_d3_high = AudioCalc._find_peak(mag, freqs, d3_high)
+        # Use abs() because distortion products wrap around DC (negative frequencies alias to positive)
+        amp_d3_low = AudioCalc._find_peak(mag, freqs, abs(d3_low))
+        amp_d3_high = AudioCalc._find_peak(mag, freqs, abs(d3_high))
 
         distortion_sum_sq = amp_d2**2 + amp_d3_low**2 + amp_d3_high**2
         imd = np.sqrt(distortion_sum_sq) / total_amp
@@ -885,8 +886,9 @@ class AudioCalc:
             # Upper side
             im_high = k * f2 - m * f1
 
-            amp_low = AudioCalc._find_peak(mag, freqs, im_low) if im_low > 0 else 0
-            amp_high = AudioCalc._find_peak(mag, freqs, im_high)
+            # Use abs() because IMD products can wrap around 0Hz
+            amp_low = AudioCalc._find_peak(mag, freqs, abs(im_low))
+            amp_high = AudioCalc._find_peak(mag, freqs, abs(im_high))
 
             sum_sq_pim += amp_low**2 + amp_high**2
 

--- a/tests/logic_verification/analysis/test_imd.py
+++ b/tests/logic_verification/analysis/test_imd.py
@@ -102,3 +102,38 @@ class TestIMDAnalysis(unittest.TestCase):
         # Expected ~1.0%
         # AudioCalc.calculate_imd_ccif likely calculates ratio of d2 to sum of carriers (or similar standard)
         self.assertAlmostEqual(res['imd'], 1.0, delta=0.1)
+
+    def test_calculate_imd_ccif_negative_freq(self):
+        """Test CCIF IMD with wide spacing causing negative 2*f1-f2 frequency."""
+        f1 = 2000.0
+        f2 = 5000.0
+        # 2*f1 - f2 = -1000 Hz (wraps to 1000 Hz)
+        # 2*f2 - f1 = 8000 Hz
+
+        # Use synthetic magnitude spectrum directly to avoid windowing/aliasing issues in signal gen
+        # and ensure precise amplitude injection.
+        freqs = np.linspace(0, 10000, 10001)
+        mag = np.zeros_like(freqs)
+
+        idx_f1 = 2000
+        idx_f2 = 5000
+        idx_d3_low = 1000 # abs(2*2000 - 5000)
+        idx_d3_high = 8000 # 2*5000 - 2000
+
+        mag[idx_f1] = 1.0
+        mag[idx_f2] = 1.0
+
+        # Inject distortion
+        dist_amp = 0.1
+        mag[idx_d3_low] = dist_amp
+        mag[idx_d3_high] = dist_amp
+
+        # Calculate
+        res = AudioCalc.calculate_imd_ccif(mag, freqs, f1, f2)
+
+        # Expected:
+        # Total Amp = 2.0
+        # Distortion RMS = sqrt(0^2 + 0.1^2 + 0.1^2) = sqrt(0.02) = 0.14142
+        # IMD = 0.14142 / 2.0 = 0.07071 (7.07%)
+
+        self.assertAlmostEqual(res['imd'], 7.071, places=3)


### PR DESCRIPTION
Fixed a bug in `src/core/analysis.py` where Intermodulation Distortion (IMD) and Passive Intermodulation (PIM) calculations ignored distortion products falling into negative frequencies (e.g., `2*f1 - f2` where `2*f1 < f2`). Since `rfft` magnitude spectra represent aliased positive frequencies for real signals, these products appear at their absolute frequency.

Changes:
- Modified `AudioCalc.calculate_imd_ccif` to use `abs(d3_low)` etc.
- Modified `AudioCalc.calculate_pim` to use `abs(im_low)` etc.
- Added `test_calculate_imd_ccif_negative_freq` to `tests/logic_verification/analysis/test_imd.py` to verify the fix with a synthetic spectrum.

---
*PR created automatically by Jules for task [15474415575179328503](https://jules.google.com/task/15474415575179328503) started by @youtube-at-vach*