### PR TITLE
🧪 Add tests for PIM calculation logic

### DIFF
--- a/tests/logic_verification/analysis/test_imd.py
+++ b/tests/logic_verification/analysis/test_imd.py
@@ -137,3 +137,150 @@ class TestIMDAnalysis(unittest.TestCase):
         # IMD = 0.14142 / 2.0 = 0.07071 (7.07%)
 
         self.assertAlmostEqual(res['imd'], 7.071, places=3)
+
+    def test_calculate_pim_clean(self):
+        """Test PIM calculation with clean carriers (should be very low)."""
+        # Synthetic spectrum
+        # 1Hz bins, up to 24kHz
+        freqs = np.linspace(0, 24000, 24001)
+        mag = np.zeros_like(freqs)
+
+        f1 = 2000.0
+        f2 = 3000.0
+
+        idx_f1 = 2000
+        idx_f2 = 3000
+
+        mag[idx_f1] = 1.0
+        mag[idx_f2] = 1.0
+
+        res = AudioCalc.calculate_pim(mag, freqs, f1, f2)
+
+        # Expect negligible PIM
+        self.assertLess(res['pim_db'], -100.0)
+        self.assertEqual(len(res['products']), 1)  # Order 3 loop runs
+        self.assertEqual(res['products'][0]['amp_low'], 0.0)
+
+    def test_calculate_pim_no_signal(self):
+        """Test PIM calculation with no signal."""
+        freqs = np.linspace(0, 24000, 24001)
+        mag = np.zeros_like(freqs)
+
+        res = AudioCalc.calculate_pim(mag, freqs, 1000.0, 2000.0)
+
+        self.assertEqual(res['pim_db'], -100.0)
+        self.assertEqual(res['products'], [])
+
+    def test_calculate_pim_im3(self):
+        """Test PIM calculation with known IM3 products."""
+        freqs = np.linspace(0, 24000, 24001)
+        mag = np.zeros_like(freqs)
+
+        f1 = 2000.0
+        f2 = 3000.0
+        idx_f1 = 2000
+        idx_f2 = 3000
+
+        # Carriers
+        mag[idx_f1] = 1.0
+        mag[idx_f2] = 1.0
+
+        # IM3: 2*f1 - f2 = 1000, 2*f2 - f1 = 4000
+        idx_im3_low = 1000
+        idx_im3_high = 4000
+
+        im3_amp = 0.01
+        mag[idx_im3_low] = im3_amp
+        mag[idx_im3_high] = im3_amp
+
+        res = AudioCalc.calculate_pim(mag, freqs, f1, f2, order=3)
+
+        # Expected Calculation:
+        # Carrier Amp = (1+1)/2 = 1.0
+        # PIM RMS = sqrt(0.01^2 + 0.01^2) = sqrt(2e-4) = 0.0141421356
+        # PIM dB = 20 * log10(0.0141421356) = -36.9897 dB
+
+        expected_rms = np.sqrt(2 * (im3_amp**2))
+        expected_db = 20 * np.log10(expected_rms)
+
+        self.assertAlmostEqual(res['pim_db'], expected_db, places=3)
+        self.assertEqual(len(res['products']), 1)
+        self.assertAlmostEqual(res['products'][0]['amp_low'], im3_amp, places=6)
+        self.assertAlmostEqual(res['products'][0]['amp_high'], im3_amp, places=6)
+
+    def test_calculate_pim_im5(self):
+        """Test PIM calculation with IM3 and IM5 products."""
+        freqs = np.linspace(0, 24000, 24001)
+        mag = np.zeros_like(freqs)
+
+        f1 = 2000.0
+        f2 = 3000.0
+
+        # Carriers
+        mag[2000] = 1.0
+        mag[3000] = 1.0
+
+        # IM3: 1000, 4000
+        im3_amp = 0.01
+        mag[1000] = im3_amp
+        mag[4000] = im3_amp
+
+        # IM5: 3*2000 - 2*3000 = 0.  (Index 0)
+        # 3*3000 - 2*2000 = 5000.
+        im5_amp = 0.005
+        mag[0] = im5_amp
+        mag[5000] = im5_amp
+
+        # Calculate with order=5
+        res = AudioCalc.calculate_pim(mag, freqs, f1, f2, order=5)
+
+        # Expected RMS = sqrt(2*0.01^2 + 2*0.005^2)
+        # = sqrt(2e-4 + 2*2.5e-5) = sqrt(2e-4 + 0.5e-4) = sqrt(2.5e-4) = 0.015811
+        expected_rms = np.sqrt(2*(im3_amp**2) + 2*(im5_amp**2))
+        expected_db = 20 * np.log10(expected_rms)
+
+        self.assertAlmostEqual(res['pim_db'], expected_db, places=3)
+        self.assertEqual(len(res['products']), 2) # Order 3 and Order 5
+
+        # Check IM5 product details
+        # products[0] is order 3, products[1] is order 5
+        self.assertEqual(res['products'][1]['order'], 5)
+        self.assertAlmostEqual(res['products'][1]['amp_low'], im5_amp, places=6)
+        self.assertAlmostEqual(res['products'][1]['amp_high'], im5_amp, places=6)
+
+        # Check filtering (if we run with order=3, IM5 should be ignored)
+        res_order3 = AudioCalc.calculate_pim(mag, freqs, f1, f2, order=3)
+        expected_rms_3 = np.sqrt(2 * (im3_amp**2))
+        expected_db_3 = 20 * np.log10(expected_rms_3)
+        self.assertAlmostEqual(res_order3['pim_db'], expected_db_3, places=3)
+        self.assertEqual(len(res_order3['products']), 1)
+
+    def test_calculate_pim_negative_freq(self):
+        """Test PIM calculation where products wrap around DC (negative frequencies)."""
+        freqs = np.linspace(0, 10000, 10001)
+        mag = np.zeros_like(freqs)
+
+        f1 = 2000.0
+        f2 = 5000.0
+
+        mag[2000] = 1.0
+        mag[5000] = 1.0
+
+        # IM3: 2*f1 - f2 = 4000 - 5000 = -1000 -> 1000
+        # 2*f2 - f1 = 10000 - 2000 = 8000
+
+        im3_amp = 0.01
+        mag[1000] = im3_amp
+        mag[8000] = im3_amp
+
+        res = AudioCalc.calculate_pim(mag, freqs, f1, f2, order=3)
+
+        expected_rms = np.sqrt(2 * (im3_amp**2))
+        expected_db = 20 * np.log10(expected_rms)
+
+        self.assertAlmostEqual(res['pim_db'], expected_db, places=3)
+
+        # Check that it correctly identified the negative freq product at positive index
+        prod = res['products'][0]
+        self.assertEqual(prod['freq_low'], -1000.0)
+        self.assertAlmostEqual(prod['amp_low'], im3_amp, places=6)


### PR DESCRIPTION
🎯 **What:** Added unit tests for the `calculate_pim` method in `src/core/analysis.py`, which was previously untested.
📊 **Coverage:** Added tests for clean signals, 3rd and 5th order IMD products, negative frequency aliasing, and zero signal input.
✨ **Result:** `calculate_pim` is now fully tested, ensuring robustness and correctness of PIM measurements.

---
*PR created automatically by Jules for task [9266006219347372032](https://jules.google.com/task/9266006219347372032) started by @youtube-at-vach*