### PR TITLE
Refactor: Move hardcoded filter coefficients to AudioCalc

### DIFF
--- a/src/core/analysis.py
+++ b/src/core/analysis.py
@@ -4,7 +4,7 @@ import numpy as np
 import scipy.signal
 import soundfile as sf
 from scipy.optimize import minimize_scalar
-from scipy.signal import butter, get_window, sosfiltfilt, firwin
+from scipy.signal import butter, get_window, sosfiltfilt, firwin, bilinear_zpk, zpk2tf
 
 
 from src.core.fft_manager import fft_manager
@@ -1299,3 +1299,41 @@ class AudioCalc:
         phase = np.arctan2(val_y, val_x)
 
         return magnitude, np.degrees(phase)
+
+    @staticmethod
+    def get_k_weighting_filter(sampling_rate=48000):
+        """
+        Returns K-weighting filter coefficients (ITU-R BS.1770-4).
+        Currently only supports 48kHz coefficients.
+        Returns: (b0, a0, b1, a1) where 0 is shelf, 1 is highpass.
+        """
+        # Coefficients for 48kHz
+        b0_shelf = np.array([1.53512485958697, -2.69169618940638, 1.19839281085285], dtype=np.float32)
+        a0_shelf = np.array([1.0, -1.69065929318241, 0.73248077421585], dtype=np.float32)
+        b1_hp = np.array([1.0, -2.0, 1.0], dtype=np.float32)
+        a1_hp = np.array([1.0, -1.99004745483398, 0.99007225036621], dtype=np.float32)
+
+        return b0_shelf, a0_shelf, b1_hp, a1_hp
+
+    @staticmethod
+    def design_c_weighting(sr: float):
+        """Design digital C-weighting filter (IEC 61672) for sample rate sr."""
+        sr = float(sr)
+        if sr <= 0:
+            raise ValueError("Invalid sample rate")
+
+        w1 = 2 * np.pi * 20.6
+        w2 = 2 * np.pi * 12194.0
+
+        zeros = np.array([0.0, 0.0])
+        poles = np.array([-w1, -w1, -w2, -w2])
+        gain = 1.0
+
+        # Normalize to 0 dB at 1 kHz
+        s = 1j * 2 * np.pi * 1000.0
+        h = gain * (s**2) / ((s + w1) ** 2 * (s + w2) ** 2)
+        gain = 1.0 / np.abs(h)
+
+        z, p, k = bilinear_zpk(zeros, poles, gain, fs=sr)
+        b, a = zpk2tf(z, p, k)
+        return b.astype(np.float32), a.astype(np.float32)

--- a/src/gui/widgets/lufs_meter.py
+++ b/src/gui/widgets/lufs_meter.py
@@ -19,6 +19,7 @@ from PyQt6.QtWidgets import (
 )
 from scipy import signal
 
+from src.core.analysis import AudioCalc
 from src.core.audio_engine import AudioEngine
 from src.core.localization import tr
 from src.measurement_modules.base import MeasurementModule
@@ -115,10 +116,7 @@ class LufsMeter(MeasurementModule):
     def _init_filters(self):
         # K-weighting filter coefficients (ITU-R BS.1770-4)
         # Keep float32 to avoid per-block float64 upcasts in the audio callback.
-        self.b0_shelf = np.array([1.53512485958697, -2.69169618940638, 1.19839281085285], dtype=np.float32)
-        self.a0_shelf = np.array([1.0, -1.69065929318241, 0.73248077421585], dtype=np.float32)
-        self.b1_hp = np.array([1.0, -2.0, 1.0], dtype=np.float32)
-        self.a1_hp = np.array([1.0, -1.99004745483398, 0.99007225036621], dtype=np.float32)
+        self.b0_shelf, self.a0_shelf, self.b1_hp, self.a1_hp = AudioCalc.get_k_weighting_filter(self.sample_rate)
 
         # Initial filter states (per-channel)
         zi_shelf = signal.lfilter_zi(self.b0_shelf, self.a0_shelf).astype(np.float32, copy=False)
@@ -129,37 +127,10 @@ class LufsMeter(MeasurementModule):
         self.zi_hp_r = zi_hp.copy()
 
         # C-weighting (IEC 61672) for SPL calibration compatibility
-        self.c_b, self.c_a = self._design_c_weighting(self.sample_rate)
+        self.c_b, self.c_a = AudioCalc.design_c_weighting(self.sample_rate)
         zi = signal.lfilter_zi(self.c_b, self.c_a).astype(np.float32, copy=False)
         self.c_zi_l = zi.copy()
         self.c_zi_r = zi.copy()
-
-    def _design_c_weighting(self, sr: float):
-        """Design digital C-weighting filter (IEC 61672) for sample rate sr.
-
-        Matches the SPL calibration wizard's filter so that measured dBFS_C
-        is compatible with the stored SPL offset.
-        """
-        sr = float(sr)
-        if sr <= 0:
-            raise ValueError("Invalid sample rate")
-
-        w1 = 2 * np.pi * 20.6
-        w2 = 2 * np.pi * 12194.0
-
-        zeros = np.array([0.0, 0.0])
-        poles = np.array([-w1, -w1, -w2, -w2])
-        gain = 1.0
-
-        # Normalize to 0 dB at 1 kHz
-        s = 1j * 2 * np.pi * 1000.0
-        h = gain * (s**2) / ((s + w1) ** 2 * (s + w2) ** 2)
-        gain = 1.0 / np.abs(h)
-
-        z, p, k = signal.bilinear_zpk(zeros, poles, gain, fs=sr)
-        b, a = signal.zpk2tf(z, p, k)
-        # Use float32 for callback efficiency; response accuracy remains sufficient for metering.
-        return b.astype(np.float32), a.astype(np.float32)
 
     def reset_peaks(self):
         self.peak_hold_l = self._db_floor

--- a/src/gui/widgets/sound_quality_analyzer.py
+++ b/src/gui/widgets/sound_quality_analyzer.py
@@ -182,12 +182,8 @@ class AnalysisWorker(QThread):
             # Fallback warning or attempt to design filter
             pass
 
-        # Stage 1: Shelf
-        b1 = np.array([1.53512485958697, -2.69169618940638, 1.19839281085285])
-        a1 = np.array([1.0, -1.69065929318241, 0.73248077421585])
-        # Stage 2: High-pass
-        b2 = np.array([1.0, -2.0, 1.0])
-        a2 = np.array([1.0, -1.99004745483398, 0.99007225036621])
+        # Stage 1: Shelf, Stage 2: High-pass
+        b1, a1, b2, a2 = AudioCalc.get_k_weighting_filter(sr)
 
         y = signal.lfilter(b1, a1, audio)
         y = signal.lfilter(b2, a2, y)

--- a/tests/logic_verification/analysis/test_analysis_filter_constants.py
+++ b/tests/logic_verification/analysis/test_analysis_filter_constants.py
@@ -1,0 +1,47 @@
+import pytest
+import numpy as np
+from src.core.analysis import AudioCalc
+
+def test_k_weighting_coefficients():
+    """Verify that get_k_weighting_filter returns the expected coefficients for 48kHz."""
+    b0, a0, b1, a1 = AudioCalc.get_k_weighting_filter(48000)
+
+    # Expected values (from ITU-R BS.1770-4 Table 1)
+    expected_b0 = np.array([1.53512485958697, -2.69169618940638, 1.19839281085285], dtype=np.float32)
+    expected_a0 = np.array([1.0, -1.69065929318241, 0.73248077421585], dtype=np.float32)
+    expected_b1 = np.array([1.0, -2.0, 1.0], dtype=np.float32)
+    expected_a1 = np.array([1.0, -1.99004745483398, 0.99007225036621], dtype=np.float32)
+
+    assert np.allclose(b0, expected_b0), "b0 coefficients mismatch"
+    assert np.allclose(a0, expected_a0), "a0 coefficients mismatch"
+    assert np.allclose(b1, expected_b1), "b1 coefficients mismatch"
+    assert np.allclose(a1, expected_a1), "a1 coefficients mismatch"
+
+    assert b0.dtype == np.float32
+    assert a0.dtype == np.float32
+
+def test_c_weighting_design():
+    """Verify that design_c_weighting returns coefficients."""
+    sr = 48000
+    b, a = AudioCalc.design_c_weighting(sr)
+
+    assert isinstance(b, np.ndarray)
+    assert isinstance(a, np.ndarray)
+    assert b.dtype == np.float32
+    assert a.dtype == np.float32
+    assert len(b) > 0
+    assert len(a) > 0
+
+    # Sanity check: gain at 1kHz should be roughly 0dB (magnitude 1.0)
+    # We need freqz
+    from scipy.signal import freqz
+    w, h = freqz(b, a, worN=[1000], fs=sr)
+    magnitude = np.abs(h[0])
+
+    # Should be close to 1.0 (0 dB)
+    assert 0.95 < magnitude < 1.05
+
+def test_c_weighting_invalid_sr():
+    """Verify that design_c_weighting raises error for invalid sr."""
+    with pytest.raises(ValueError):
+        AudioCalc.design_c_weighting(0)


### PR DESCRIPTION
🎯 **What:**
- Moved hardcoded K-weighting filter coefficients (ITU-R BS.1770-4) from `src/gui/widgets/lufs_meter.py` and `src/gui/widgets/sound_quality_analyzer.py` to `AudioCalc.get_k_weighting_filter` in `src/core/analysis.py`.
- Moved C-weighting filter design logic from `src/gui/widgets/lufs_meter.py` to `AudioCalc.design_c_weighting`.
- Updated `LufsMeter` and `SoundQualityAnalyzer` to use these centralized methods.

💡 **Why:**
- Improves code health by eliminating duplication of filter coefficients.
- Centralizes signal processing logic in `AudioCalc`.
- Improves maintainability and reduces risk of inconsistencies.

✅ **Verification:**
- Added `tests/logic_verification/analysis/test_analysis_filter_constants.py` to verify that `get_k_weighting_filter` returns the correct ITU-R BS.1770-4 coefficients and `design_c_weighting` returns valid filters.
- Ran existing `tests/logic_verification/test_lufs_meter_logic.py` to ensure no regression in LUFS metering logic.
- Manually verified imports and usage in `SoundQualityAnalyzer`.

✨ **Result:**
- Cleaner code with centralized filter definitions.
- No change in functionality (filter coefficients are identical).

---
*PR created automatically by Jules for task [3550125152572779397](https://jules.google.com/task/3550125152572779397) started by @youtube-at-vach*