### PR TITLE
🧹 Refactor Duplicate C-Weighting Logic

### DIFF
--- a/src/core/analysis.py
+++ b/src/core/analysis.py
@@ -177,6 +177,77 @@ class AudioCalc:
         return sosfiltfilt(sos, signal)
 
     @staticmethod
+    def _prewarp(f, fs):
+        """Pre-warp analog frequency for bilinear transform."""
+        return (fs / np.pi) * np.tan(np.pi * f / fs)
+
+    @staticmethod
+    def design_a_weighting(sampling_rate):
+        """Design A-weighting filter with pre-warping (IEC 61672). Returns SOS."""
+        fs = float(sampling_rate)
+        if fs <= 0:
+            raise ValueError("Invalid sample rate")
+
+        # Constants for A-weighting (Analog)
+        # 20.6 Hz, 107.7 Hz, 737.9 Hz, 12194 Hz
+        f1 = AudioCalc._prewarp(20.598997, fs)
+        f2 = AudioCalc._prewarp(107.65265, fs)
+        f3 = AudioCalc._prewarp(737.86223, fs)
+        f4 = AudioCalc._prewarp(12194.217, fs)
+
+        # Analog poles and zeros
+        # z: 0, 0, 0, 0
+        pi = np.pi
+        z = [0, 0, 0, 0]
+        p = [
+            -2 * pi * f1,
+            -2 * pi * f1,
+            -2 * pi * f2,
+            -2 * pi * f3,
+            -2 * pi * f4,
+            -2 * pi * f4,
+        ]
+        k = 1.0
+
+        # Convert to discrete
+        zd, pd, kd = scipy.signal.bilinear_zpk(z, p, k, fs)
+        sos = scipy.signal.zpk2sos(zd, pd, kd)
+
+        # Normalize at 1kHz
+        w, h = scipy.signal.sosfreqz(sos, worN=[1000], fs=fs)
+        gain_1k = np.abs(h[0])
+        if gain_1k > 1e-12:
+            sos[0, :3] /= gain_1k
+
+        return sos
+
+    @staticmethod
+    def design_c_weighting(sampling_rate):
+        """Design C-weighting filter with pre-warping (IEC 61672). Returns SOS."""
+        fs = float(sampling_rate)
+        if fs <= 0:
+            raise ValueError("Invalid sample rate")
+
+        f1 = AudioCalc._prewarp(20.598997, fs)
+        f4 = AudioCalc._prewarp(12194.217, fs)
+
+        pi = np.pi
+        z = [0, 0]
+        p = [-2 * pi * f1, -2 * pi * f1, -2 * pi * f4, -2 * pi * f4]
+        k = 1.0
+
+        zd, pd, kd = scipy.signal.bilinear_zpk(z, p, k, fs)
+        sos = scipy.signal.zpk2sos(zd, pd, kd)
+
+        # Normalize at 1kHz
+        w, h = scipy.signal.sosfreqz(sos, worN=[1000], fs=fs)
+        gain_1k = np.abs(h[0])
+        if gain_1k > 1e-12:
+            sos[0, :3] /= gain_1k
+
+        return sos
+
+    @staticmethod
     def bandpass_filter(signal, sampling_rate, lowcut=20.0, highcut=20000.0):
         # Check signal length to ensure padding works (3 * (2 * 8 + 1) = 51)
         def get_sos(nyquist):

--- a/src/gui/widgets/lufs_meter.py
+++ b/src/gui/widgets/lufs_meter.py
@@ -21,6 +21,7 @@ from scipy import signal
 
 from src.core.audio_engine import AudioEngine
 from src.core.localization import tr
+from src.core.analysis import AudioCalc
 from src.measurement_modules.base import MeasurementModule
 
 
@@ -41,8 +42,7 @@ class LufsMeter(MeasurementModule):
         self.zi_hp_r = None
 
         # C-weighting (for SPL calibration compatibility)
-        self.c_b = None
-        self.c_a = None
+        self.c_sos = None
         self.c_zi_l = None
         self.c_zi_r = None
 
@@ -129,37 +129,10 @@ class LufsMeter(MeasurementModule):
         self.zi_hp_r = zi_hp.copy()
 
         # C-weighting (IEC 61672) for SPL calibration compatibility
-        self.c_b, self.c_a = self._design_c_weighting(self.sample_rate)
-        zi = signal.lfilter_zi(self.c_b, self.c_a).astype(np.float32, copy=False)
+        self.c_sos = AudioCalc.design_c_weighting(self.sample_rate).astype(np.float32)
+        zi = signal.sosfilt_zi(self.c_sos).astype(np.float32, copy=False)
         self.c_zi_l = zi.copy()
         self.c_zi_r = zi.copy()
-
-    def _design_c_weighting(self, sr: float):
-        """Design digital C-weighting filter (IEC 61672) for sample rate sr.
-
-        Matches the SPL calibration wizard's filter so that measured dBFS_C
-        is compatible with the stored SPL offset.
-        """
-        sr = float(sr)
-        if sr <= 0:
-            raise ValueError("Invalid sample rate")
-
-        w1 = 2 * np.pi * 20.6
-        w2 = 2 * np.pi * 12194.0
-
-        zeros = np.array([0.0, 0.0])
-        poles = np.array([-w1, -w1, -w2, -w2])
-        gain = 1.0
-
-        # Normalize to 0 dB at 1 kHz
-        s = 1j * 2 * np.pi * 1000.0
-        h = gain * (s**2) / ((s + w1) ** 2 * (s + w2) ** 2)
-        gain = 1.0 / np.abs(h)
-
-        z, p, k = signal.bilinear_zpk(zeros, poles, gain, fs=sr)
-        b, a = signal.zpk2tf(z, p, k)
-        # Use float32 for callback efficiency; response accuracy remains sufficient for metering.
-        return b.astype(np.float32), a.astype(np.float32)
 
     def reset_peaks(self):
         self.peak_hold_l = self._db_floor
@@ -294,10 +267,10 @@ class LufsMeter(MeasurementModule):
             # --- C-weighted RMS/Peak (for SPL calibration) ---
             # Calibration wizard measures dBFS_C using a C-weighting IIR filter and RMS.
             # We compute the same here so that SPL = dBFS_C + offset is consistent.
-            if self.c_b is not None and self.c_a is not None and self.c_zi_l is not None and self.c_zi_r is not None:
+            if self.c_sos is not None and self.c_zi_l is not None and self.c_zi_r is not None:
                 # Keep float32 throughout; input stream is float32.
-                l_c, self.c_zi_l = signal.lfilter(self.c_b, self.c_a, l_channel, zi=self.c_zi_l)
-                r_c, self.c_zi_r = signal.lfilter(self.c_b, self.c_a, r_channel, zi=self.c_zi_r)
+                l_c, self.c_zi_l = signal.sosfilt(self.c_sos, l_channel, zi=self.c_zi_l)
+                r_c, self.c_zi_r = signal.sosfilt(self.c_sos, r_channel, zi=self.c_zi_r)
 
                 if frames > 0:
                     rms_c_l_linear = float(np.sqrt(np.dot(l_c, l_c) / float(frames) + 1e-24))

--- a/src/gui/widgets/settings.py
+++ b/src/gui/widgets/settings.py
@@ -26,6 +26,7 @@ from src.core.audio_engine import AudioEngine
 from src.core.config_manager import ConfigManager
 from src.core.localization import get_manager, tr
 from src.core.generators import PinkNoise
+from src.core.analysis import AudioCalc
 
 from src.core.fft_manager import fft_manager
 from PyQt6.QtWidgets import QProgressDialog
@@ -33,31 +34,6 @@ from PyQt6.QtCore import Qt
 
 from src.core.bit_depth_estimator import BitDepthEstimator
 import pyqtgraph as pg
-
-
-def _design_c_weighting(sr: float):
-    """Design digital C-weighting filter (IEC 61672) for sample rate sr."""
-    sr = float(sr)
-    if sr <= 0:
-        raise ValueError("Invalid sample rate")
-
-    # Analog poles (rad/s)
-    w1 = 2 * np.pi * 20.6
-    w2 = 2 * np.pi * 12194.0
-
-    # C-weighting analog transfer function: H(s) = K * s^2 / ((s + w1)^2 (s + w2)^2)
-    zeros = np.array([0.0, 0.0])
-    poles = np.array([-w1, -w1, -w2, -w2])
-    gain = 1.0
-
-    # Normalize to 0 dB at 1 kHz
-    s = 1j * 2 * np.pi * 1000.0
-    h = gain * (s**2) / ((s + w1) ** 2 * (s + w2) ** 2)
-    gain = 1.0 / np.abs(h)
-
-    z, p, k = scipy.signal.bilinear_zpk(zeros, poles, gain, fs=sr)
-    b, a = scipy.signal.zpk2tf(z, p, k)
-    return b.astype(np.float64), a.astype(np.float64)
 
 
 class SplCalibrationDialog(QDialog):
@@ -80,8 +56,7 @@ class SplCalibrationDialog(QDialog):
         self._bpf_zi = None
         self._noise_ref_rms = None
         self._target_fs_rms = None
-        self._c_b = None
-        self._c_a = None
+        self._c_sos = None
         self._c_zi = None
         self._measure_bw_sos = None
         self._measure_bw_zi = None
@@ -356,10 +331,8 @@ class SplCalibrationDialog(QDialog):
             self._noise_ref_rms = 1.0
 
         # C-weighting for input measurement
-        c_b, c_a = _design_c_weighting(sr)
-        self._c_b = c_b
-        self._c_a = c_a
-        self._c_zi = scipy.signal.lfilter_zi(c_b, c_a).astype(np.float64)
+        self._c_sos = AudioCalc.design_c_weighting(sr)
+        self._c_zi = scipy.signal.sosfilt_zi(self._c_sos).astype(np.float64)
 
         # Measurement bandwidth (input side)
         meas_band = self._get_measurement_band_hz()
@@ -431,7 +404,7 @@ class SplCalibrationDialog(QDialog):
                 x = indata[:, 0].astype(np.float64)
                 if self._measure_bw_sos is not None and self._measure_bw_zi is not None:
                     x, self._measure_bw_zi = scipy.signal.sosfilt(self._measure_bw_sos, x, zi=self._measure_bw_zi)
-                xw, self._c_zi = scipy.signal.lfilter(self._c_b, self._c_a, x, zi=self._c_zi)
+                xw, self._c_zi = scipy.signal.sosfilt(self._c_sos, x, zi=self._c_zi)
                 p = float(np.mean(xw * xw) + 1e-24)
 
                 # EMA on power for stable reading

--- a/src/gui/widgets/sound_level_meter.py
+++ b/src/gui/widgets/sound_level_meter.py
@@ -19,6 +19,7 @@ from PyQt6.QtWidgets import (
 
 from src.core.audio_engine import AudioEngine
 from src.core.localization import tr
+from src.core.analysis import AudioCalc
 from src.measurement_modules.base import MeasurementModule
 
 
@@ -182,63 +183,11 @@ class SoundLevelMeter(MeasurementModule):
             self.sos_filter = None
             self.filter_state = None
         elif self.freq_weighting == "A":
-            self.sos_filter = self._design_a_weighting(sr)
+            self.sos_filter = AudioCalc.design_a_weighting(sr)
             self.filter_state = np.zeros((self.sos_filter.shape[0], 2))
         elif self.freq_weighting == "C":
-            self.sos_filter = self._design_c_weighting(sr)
+            self.sos_filter = AudioCalc.design_c_weighting(sr)
             self.filter_state = np.zeros((self.sos_filter.shape[0], 2))
-
-    def _prewarp(self, f, fs):
-        """Pre-warp analog frequency for bilinear transform."""
-        return (fs / np.pi) * np.tan(np.pi * f / fs)
-
-    def _design_a_weighting(self, fs):
-        """Design A-weighting filter with pre-warping."""
-        # Constants for A-weighting (Analog)
-        f1 = self._prewarp(20.598997, fs)
-        f2 = self._prewarp(107.65265, fs)
-        f3 = self._prewarp(737.86223, fs)
-        f4 = self._prewarp(12194.217, fs)
-
-        # Analog poles and zeros
-        # z: 0, 0, 0, 0 (s-plane zeros at 0)
-        # p: -2*pi*f1, -2*pi*f1, -2*pi*f2, -2*pi*f3, -2*pi*f4, -2*pi*f4
-
-        pi = np.pi
-        z = [0, 0, 0, 0]
-        p = [-2 * pi * f1, -2 * pi * f1, -2 * pi * f2, -2 * pi * f3, -2 * pi * f4, -2 * pi * f4]
-        k = 1.0
-
-        # Convert to discrete
-        zd, pd, kd = scipy.signal.bilinear_zpk(z, p, k, fs)
-        sos = scipy.signal.zpk2sos(zd, pd, kd)
-
-        # Normalize at 1kHz (using actual digital frequency)
-        w, h = scipy.signal.sosfreqz(sos, worN=[1000], fs=fs)
-        gain_1k = np.abs(h[0])
-        sos[0, :3] /= gain_1k
-
-        return sos
-
-    def _design_c_weighting(self, fs):
-        """Design C-weighting filter with pre-warping."""
-        f1 = self._prewarp(20.598997, fs)
-        f4 = self._prewarp(12194.217, fs)
-
-        pi = np.pi
-        z = [0, 0]
-        p = [-2 * pi * f1, -2 * pi * f1, -2 * pi * f4, -2 * pi * f4]
-        k = 1.0
-
-        zd, pd, kd = scipy.signal.bilinear_zpk(z, p, k, fs)
-        sos = scipy.signal.zpk2sos(zd, pd, kd)
-
-        # Normalize at 1kHz
-        w, h = scipy.signal.sosfreqz(sos, worN=[1000], fs=fs)
-        gain_1k = np.abs(h[0])
-        sos[0, :3] /= gain_1k
-
-        return sos
 
     def _apply_impulse_weighting(self, sq_sig, sr):
         """

--- a/tests/logic_verification/analysis/test_c_weighting_design.py
+++ b/tests/logic_verification/analysis/test_c_weighting_design.py
@@ -4,89 +4,95 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import scipy.signal
 
-# Mock modules that are imported by src.gui.widgets.settings but not needed for _design_c_weighting
-# We must do this BEFORE importing the function under test
+# Mock modules that are imported by src.core.analysis
 mock_modules = {
-    "PyQt6": MagicMock(),
-    "PyQt6.QtCore": MagicMock(),
-    "PyQt6.QtWidgets": MagicMock(),
-    "src.core.audio_engine": MagicMock(),
-    "src.core.config_manager": MagicMock(),
-    "src.core.localization": MagicMock(),
+    "soundfile": MagicMock(),
     "src.core.fft_manager": MagicMock(),
-    "sounddevice": MagicMock(),
-    "pyqtgraph": MagicMock(),
-    "pyqtgraph.Qt": MagicMock(),
 }
 
 # Apply mocks
 with patch.dict(sys.modules, mock_modules):
-    # Import the function to test
-    from src.gui.widgets.settings import _design_c_weighting
+    from src.core.analysis import AudioCalc
 
-class TestCWeightingDesign(unittest.TestCase):
+class TestWeightingDesign(unittest.TestCase):
     def test_design_c_weighting_validity(self):
-        """Test that the function returns valid filter coefficients."""
+        """Test that the function returns valid SOS coefficients."""
         sr = 48000
-        b, a = _design_c_weighting(sr)
+        sos = AudioCalc.design_c_weighting(sr)
 
-        self.assertIsInstance(b, np.ndarray)
-        self.assertIsInstance(a, np.ndarray)
-        self.assertEqual(b.ndim, 1)
-        self.assertEqual(a.ndim, 1)
-        # Verify it's not empty
-        self.assertGreater(len(b), 0)
-        self.assertGreater(len(a), 0)
-        # Verify dtype
-        self.assertEqual(b.dtype, np.float64)
-        self.assertEqual(a.dtype, np.float64)
+        self.assertIsInstance(sos, np.ndarray)
+        self.assertEqual(sos.ndim, 2)
+        self.assertEqual(sos.shape[1], 6)
+        self.assertEqual(sos.dtype, np.float64)
 
     def test_design_c_weighting_frequency_response(self):
-        """Verify the frequency response at key frequencies (IEC 61672 C-weighting).
+        """Verify the C-weighting frequency response at key frequencies (IEC 61672).
 
-        We use a high sample rate (192 kHz) for this test to minimize frequency warping
-        effects of the bilinear transform near Nyquist, allowing us to verify that the
-        analog prototype parameters (poles/zeros) are correct.
-        At 48 kHz, the gain at 20 kHz deviates significantly due to warping (-27 dB vs -11.2 dB).
+        We use 192kHz sample rate to minimize bilinear transform warping effects
+        at high frequencies (20kHz), allowing us to verify the filter design
+        parameters (poles/zeros) against the analog standard.
         """
         sr = 192000
-        b, a = _design_c_weighting(sr)
+        sos = AudioCalc.design_c_weighting(sr)
 
-        # Test frequencies
-        test_freqs = [10.0, 20.0, 1000.0, 20000.0]
+        # Test frequencies: 20Hz, 1kHz, 20kHz
+        test_freqs = [20.0, 1000.0, 20000.0]
 
-        # Calculate frequency response at specific points
-        w, h = scipy.signal.freqz(b, a, worN=test_freqs, fs=sr)
+        # Calculate frequency response
+        w, h = scipy.signal.sosfreqz(sos, worN=test_freqs, fs=sr)
         gain_db = 20 * np.log10(np.abs(h) + 1e-12)
 
-        # 1. Gain at 1 kHz must be exactly 0 dB (normalization point)
-        # 1000.0 is at index 2
-        gain_1k = gain_db[2]
+        # 1. Gain at 1 kHz must be exactly 0 dB
+        gain_1k = gain_db[1]
         self.assertAlmostEqual(gain_1k, 0.0, places=1, msg=f"Gain at 1kHz ({gain_1k:.2f} dB) should be approx 0 dB")
 
         # 2. Gain at 20 Hz (approx -6.2 dB)
-        # 20.0 is at index 1
-        gain_20 = gain_db[1]
+        gain_20 = gain_db[0]
         self.assertAlmostEqual(gain_20, -6.2, delta=0.5, msg=f"Gain at 20Hz ({gain_20:.2f} dB) should be approx -6.2 dB")
 
         # 3. Gain at 20 kHz (approx -11.2 dB)
-        # 20000.0 is at index 3
-        gain_20k = gain_db[3]
-        # Using delta=1.0 because discretization error still exists.
-        # Ideally it's around -11.75 dB vs -11.2 nominal.
-        self.assertAlmostEqual(gain_20k, -11.2, delta=1.0, msg=f"Gain at 20kHz ({gain_20k:.2f} dB) should be approx -11.2 dB")
+        # At 192k, warping is minimal.
+        gain_20k = gain_db[2]
+        self.assertAlmostEqual(gain_20k, -11.2, delta=0.5, msg=f"Gain at 20kHz ({gain_20k:.2f} dB) should be approx -11.2 dB")
 
-        # 4. Check rolloff behavior (low frequency should be dropping)
-        # 10.0 is at index 0
-        gain_10 = gain_db[0]
-        self.assertLess(gain_10, gain_20, msg="Gain at 10Hz should be lower than at 20Hz")
+    def test_design_a_weighting_validity(self):
+        """Test that A-weighting design returns valid SOS."""
+        sr = 48000
+        sos = AudioCalc.design_a_weighting(sr)
+        self.assertIsInstance(sos, np.ndarray)
+        self.assertEqual(sos.ndim, 2)
+        self.assertEqual(sos.shape[1], 6)
 
-    def test_design_c_weighting_invalid_sr(self):
+    def test_design_a_weighting_frequency_response(self):
+        """Verify A-weighting frequency response at key frequencies.
+        Using 192kHz to minimize warping.
+        """
+        sr = 192000
+        sos = AudioCalc.design_a_weighting(sr)
+
+        test_freqs = [20.0, 1000.0, 20000.0]
+
+        w, h = scipy.signal.sosfreqz(sos, worN=test_freqs, fs=sr)
+        gain_db = 20 * np.log10(np.abs(h) + 1e-12)
+
+        # 1kHz
+        gain_1k = gain_db[1]
+        self.assertAlmostEqual(gain_1k, 0.0, places=1, msg="A-weighting 1kHz should be 0dB")
+
+        # 20Hz
+        gain_20 = gain_db[0]
+        self.assertAlmostEqual(gain_20, -50.5, delta=1.0, msg="A-weighting 20Hz should be approx -50.5dB")
+
+        # 20kHz
+        gain_20k = gain_db[2]
+        self.assertAlmostEqual(gain_20k, -9.3, delta=1.0, msg="A-weighting 20kHz should be approx -9.3dB")
+
+    def test_design_invalid_sr(self):
         """Test invalid sample rates raise ValueError."""
         with self.assertRaises(ValueError):
-            _design_c_weighting(0)
+            AudioCalc.design_c_weighting(0)
         with self.assertRaises(ValueError):
-            _design_c_weighting(-48000)
+            AudioCalc.design_a_weighting(-100)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR refactors the C-weighting filter design logic, which was duplicated across `src/gui/widgets/lufs_meter.py`, `src/gui/widgets/settings.py`, and `src/gui/widgets/sound_level_meter.py`.

Key changes:
- Created `AudioCalc.design_c_weighting` and `AudioCalc.design_a_weighting` in `src/core/analysis.py`.
- Implemented these methods using frequency pre-warping and SOS (Second-Order Sections) output for better numerical stability and accuracy.
- Updated `LufsMeter`, `SoundLevelMeter`, and `SplCalibrationDialog` (in `settings.py`) to use the new centralized methods.
- Updated `SplCalibrationDialog` and `LufsMeter` to use `sosfilt` instead of `lfilter`.
- Added `tests/logic_verification/analysis/test_c_weighting_design.py` to verify the filter design logic against IEC 61672 standards (using high sample rate to verify coefficients).
- Verified regressions with existing tests for `SoundLevelMeter` and `LufsMeter`.

This improves code health by removing duplication and standardizing on a more robust filter implementation.

---
*PR created automatically by Jules for task [16727531024160757326](https://jules.google.com/task/16727531024160757326) started by @youtube-at-vach*