### PR TITLE
Enable Spectrogram Log Buffer Test

### DIFF
--- a/tests/gui/widgets/test_spectrogram_log_buffer.py
+++ b/tests/gui/widgets/test_spectrogram_log_buffer.py
@@ -28,7 +28,7 @@ class TestSpectrogramLogBuffer(unittest.TestCase):
     def setUpClass(cls):
         # Create QApplication if it doesn't exist
         if not QApplication.instance():
-            cls.app = QApplication(sys.argv)
+            cls.app = QApplication(sys.argv + ['-platform', 'offscreen'])
         else:
             cls.app = QApplication.instance()
 
@@ -56,9 +56,6 @@ class TestSpectrogramLogBuffer(unittest.TestCase):
         self.widget.on_worker_result(data_v1)
 
         # Verify log_buffer exists and is populated
-        if not hasattr(self.widget, 'log_spectrogram_buffer'):
-            self.skipTest("Optimization not yet implemented")
-
         self.assertIsNotNone(self.widget.log_spectrogram_buffer)
         self.assertEqual(self.widget.log_spectrogram_buffer.shape[0], self.module.history_length)
 


### PR DESCRIPTION
This change enables the `test_log_buffer_logic` test in `tests/gui/widgets/test_spectrogram_log_buffer.py` by removing a conditional skip block that checked for the existence of `log_spectrogram_buffer`. The attribute is initialized in the widget's constructor, so the check was redundant and potentially hiding failures if the logic was broken in other ways. Additionally, the test setup was improved to explicitly use the `offscreen` platform for `QApplication`, ensuring reliability in CI/CD environments.

---
*PR created automatically by Jules for task [2386763009369551650](https://jules.google.com/task/2386763009369551650) started by @youtube-at-vach*