### PR TITLE
Fix swallowed exceptions in LockInAmplifier

### DIFF
--- a/src/gui/widgets/lock_in_amplifier.py
+++ b/src/gui/widgets/lock_in_amplifier.py
@@ -1,4 +1,5 @@
 
+import logging
 import threading
 import time
 from collections import deque
@@ -29,6 +30,9 @@ from scipy.signal import hilbert
 from src.core.audio_engine import AudioEngine
 from src.core.localization import tr
 from src.measurement_modules.base import MeasurementModule
+
+
+logger = logging.getLogger(__name__)
 
 
 class LockInAmplifier(MeasurementModule):
@@ -99,11 +103,11 @@ class LockInAmplifier(MeasurementModule):
             try:
                 self.reset_postmix_lpf()
             except Exception:
-                pass
+                logger.error("Failed to reset post-mix LPF on harmonic change", exc_info=True)
             try:
                 self.history.clear()
             except Exception:
-                pass
+                logger.error("Failed to clear history on harmonic change", exc_info=True)
 
     def reset_postmix_lpf(self):
         self._postmix_lpf_state = [0j] * 8


### PR DESCRIPTION
**Problem:**
The `LockInAmplifier` widget (`src/gui/widgets/lock_in_amplifier.py`) contained empty `except Exception: pass` blocks in the `harmonic_order` setter, specifically when calling `reset_postmix_lpf()` and `history.clear()`. This prevented potential errors from being surfaced or debugged.

**Solution:**
- Imported `logging` and initialized a module-level logger.
- Replaced `pass` statements with `logger.error("...", exc_info=True)` to log any exceptions that occur during these operations.

**Verification:**
- Verified that `tests/logic_verification/test_lockin_amplifier_logic.py` passes with the changes.
- Manually inspected the code to ensure correct logging implementation.

---
*PR created automatically by Jules for task [7931384981007547686](https://jules.google.com/task/7931384981007547686) started by @youtube-at-vach*