### PR TITLE
Refactor Oscilloscope formatting to use src.core.utils.format_si

### DIFF
--- a/src/gui/widgets/oscilloscope.py
+++ b/src/gui/widgets/oscilloscope.py
@@ -25,6 +25,7 @@ from PyQt6.QtWidgets import (
 from src.core.analysis import AudioCalc
 from src.core.audio_engine import AudioEngine
 from src.core.localization import tr
+from src.core.utils import format_si
 from src.measurement_modules.base import MeasurementModule
 from src.gui.styles import (
     STYLE_TOGGLE_BTN_DARK,
@@ -1249,26 +1250,6 @@ class OscilloscopeWidget(QWidget):
             self.meas_r_label.setText(tr("R: Vrms: {0:.3f} V  Vpp: {1:.3f} V").format(meas["r_rms"], meas["r_vpp"]))
 
             # Waveform-derived measurements (optional)
-            def _format_time(seconds):
-                if seconds is None or not np.isfinite(seconds) or seconds <= 0:
-                    return "--"
-                if seconds < 1e-6:
-                    return f"{seconds * 1e9:.1f} ns"
-                if seconds < 1e-3:
-                    return f"{seconds * 1e6:.2f} us"
-                if seconds < 1.0:
-                    return f"{seconds * 1e3:.3f} ms"
-                return f"{seconds:.3f} s"
-
-            def _format_freq(hz):
-                if hz is None or not np.isfinite(hz) or hz <= 0:
-                    return "--"
-                if hz >= 1e6:
-                    return f"{hz / 1e6:.3f} MHz"
-                if hz >= 1e3:
-                    return f"{hz / 1e3:.3f} kHz"
-                return f"{hz:.3f} Hz"
-
             wave_meas_enabled = hasattr(self, "chk_wave_meas") and self.chk_wave_meas.isChecked()
             self.meas_l_auto_label.setVisible(wave_meas_enabled and self.module.show_left)
             self.meas_r_auto_label.setVisible(wave_meas_enabled and self.module.show_right)
@@ -1277,24 +1258,34 @@ class OscilloscopeWidget(QWidget):
                 if self.module.show_left:
                     freq_hz = self.module.estimate_frequency_hz(t, l_data)
                     rise_s, fall_s, _low, _high = self.module.estimate_rise_fall_times_s(t, l_data)
+
+                    freq_str = format_si(freq_hz, "Hz", sig_figs=5) if freq_hz is not None and freq_hz > 0 else "--"
+                    rise_str = format_si(rise_s, "s", sig_figs=5) if rise_s is not None and rise_s > 0 else "--"
+                    fall_str = format_si(fall_s, "s", sig_figs=5) if fall_s is not None and fall_s > 0 else "--"
+
                     self.meas_l_auto_label.setText(
                         tr("Freq")
-                        + f": {_format_freq(freq_hz)}  "
+                        + f": {freq_str}  "
                         + tr("Rise")
-                        + f": {_format_time(rise_s)}  "
+                        + f": {rise_str}  "
                         + tr("Fall")
-                        + f": {_format_time(fall_s)}"
+                        + f": {fall_str}"
                     )
                 if self.module.show_right:
                     freq_hz = self.module.estimate_frequency_hz(t, r_data)
                     rise_s, fall_s, _low, _high = self.module.estimate_rise_fall_times_s(t, r_data)
+
+                    freq_str = format_si(freq_hz, "Hz", sig_figs=5) if freq_hz is not None and freq_hz > 0 else "--"
+                    rise_str = format_si(rise_s, "s", sig_figs=5) if rise_s is not None and rise_s > 0 else "--"
+                    fall_str = format_si(fall_s, "s", sig_figs=5) if fall_s is not None and fall_s > 0 else "--"
+
                     self.meas_r_auto_label.setText(
                         tr("Freq")
-                        + f": {_format_freq(freq_hz)}  "
+                        + f": {freq_str}  "
                         + tr("Rise")
-                        + f": {_format_time(rise_s)}  "
+                        + f": {rise_str}  "
                         + tr("Fall")
-                        + f": {_format_time(fall_s)}"
+                        + f": {fall_str}"
                     )
 
             # Store for cursor interpolation

--- a/tests/logic_verification/core/test_utils.py
+++ b/tests/logic_verification/core/test_utils.py
@@ -1,0 +1,91 @@
+import unittest
+import math
+import sys
+import os
+
+# Ensure src can be imported
+sys.path.append(os.getcwd())
+
+from src.core.utils import format_si
+
+class TestUtils(unittest.TestCase):
+    def test_format_si_basic(self):
+        """Test basic SI formatting functionality."""
+        # Simple cases
+        self.assertEqual(format_si(1000, "Hz"), "1 kHz")
+        self.assertEqual(format_si(0.001, "s"), "1 ms")
+        self.assertEqual(format_si(1, "V"), "1 V")
+
+        # Micro
+        # Note: format_si uses 'µ' (U+00B5) or similar. Let's check implementation behavior.
+        # implementation uses _SI_PREFIXES = { ..., -6: "µ", ... }
+        self.assertEqual(format_si(1e-6, "s"), "1 µs")
+
+    def test_format_si_precision(self):
+        """Test sig_figs parameter."""
+        val = 1234.5678
+        # Default sig_figs=4
+        self.assertEqual(format_si(val, "Hz"), "1.235 kHz")
+        # sig_figs=5
+        self.assertEqual(format_si(val, "Hz", sig_figs=5), "1.2346 kHz")
+        # sig_figs=3
+        self.assertEqual(format_si(val, "Hz", sig_figs=3), "1.23 kHz")
+
+        val_small = 0.0012345678
+        self.assertEqual(format_si(val_small, "s", sig_figs=4), "1.235 ms")
+
+    def test_format_si_edge_cases(self):
+        """Test edge cases: 0, None, Inf, NaN."""
+        # Zero
+        self.assertEqual(format_si(0, "Hz"), "0 Hz")
+        self.assertEqual(format_si(0.0, "s"), "0 s")
+
+        # Negative
+        self.assertEqual(format_si(-1000, "Hz"), "-1 kHz")
+
+        # None
+        self.assertEqual(format_si(None, "Hz"), "-")
+
+        # Inf
+        self.assertEqual(format_si(float('inf'), "Hz"), "-")
+        self.assertEqual(format_si(float('-inf'), "Hz"), "-")
+
+        # NaN
+        self.assertEqual(format_si(float('nan'), "Hz"), "-")
+
+    def test_format_si_rounding_up(self):
+        """Test rounding that bumps the prefix (e.g. 999.9 m -> 1.0 k)."""
+        # 999.95 m -> 1.000 s if sig_figs=4
+        val = 999.95e-3
+        # 0.99995 s.
+        # exp3 = -3 (m). scaled = 999.95.
+        # with sig_figs=4 -> 999.95 rounds to 1000.
+        # So format_si logic sees 1000 >= 1000. Bumps prefix to 0 (base).
+        # New scaled: 0.99995.
+        # Formats to "1".
+        self.assertEqual(format_si(val, "s", sig_figs=4), "1 s")
+
+        # Another case: 999.96 Hz
+        # sig_figs=4 -> 1000.
+        val = 999.96
+        self.assertEqual(format_si(val, "Hz", sig_figs=4), "1 kHz")
+
+    def test_format_si_large_numbers(self):
+        """Test very large numbers."""
+        self.assertEqual(format_si(1e6, "Hz"), "1 MHz")
+        self.assertEqual(format_si(1e9, "Hz"), "1 GHz")
+        self.assertEqual(format_si(2.5e6, "Hz"), "2.5 MHz")
+
+    def test_format_si_small_numbers(self):
+        """Test very small numbers."""
+        self.assertEqual(format_si(1e-9, "s"), "1 ns")
+        self.assertEqual(format_si(1e-12, "s"), "1 ps")
+
+        # Test values relevant to Oscilloscope
+        # 123.456 ns -> 1.235e-7 s
+        val = 1.23456e-7
+        self.assertEqual(format_si(val, "s", sig_figs=4), "123.5 ns")
+        self.assertEqual(format_si(val, "s", sig_figs=5), "123.46 ns")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Replaced `_format_time` and `_format_freq` in `src/gui/widgets/oscilloscope.py` with `format_si`.
- Added `tests/logic_verification/core/test_utils.py` to verify `format_si` behavior.
- Ensures consistent formatting and reduces code duplication.

---
*PR created automatically by Jules for task [4123337282432739682](https://jules.google.com/task/4123337282432739682) started by @youtube-at-vach*