### PR TITLE
Fix division by zero in frequency axis analysis

### DIFF
--- a/src/core/analysis.py
+++ b/src/core/analysis.py
@@ -1243,7 +1243,8 @@ class AudioCalc:
             if abs(freqs[-1] - expected_end) < 1e-5:
                 # Verify strictly all steps
                 # Use slice to avoid allocating full diff if possible? No, diff is fast.
-                if np.allclose(np.diff(freqs), freq_step, atol=1e-5, rtol=0):
+                # Also ensure freq_step is not zero to avoid division by zero later
+                if freq_step > 1e-9 and np.allclose(np.diff(freqs), freq_step, atol=1e-5, rtol=0):
                     is_linear_freqs = True
 
             if not is_linear_freqs and start_freq > 1e-9:

--- a/tests/logic_verification/test_noise_profile_logic.py
+++ b/tests/logic_verification/test_noise_profile_logic.py
@@ -200,5 +200,24 @@ class TestNoiseProfileLogic(unittest.TestCase):
         self.assertEqual(results['flicker_intercept'], 0.0)
         self.assertEqual(results['corner_freq'], 0.0)
 
+    def test_zero_frequency_step_handling(self):
+        """
+        Regression test for potential DivisionByZero/OverflowError when frequency step is 0.
+        Caused by _analyze_frequency_axis incorrectly flagging constant frequency array as linear.
+        """
+        freqs = np.array([100.0, 100.0, 100.0], dtype=np.float64)
+        mag = np.array([0.5, 0.5, 0.5], dtype=np.float64)
+
+        # This calls calculate_noise_profile -> _analyze_frequency_axis
+        # Should complete without error
+        try:
+            results = AudioCalc.calculate_noise_profile(mag, freqs, self.fs)
+        except Exception as e:
+            self.fail(f"calculate_noise_profile raised exception with zero-step frequency array: {e}")
+
+        # Verify that it didn't return garbage or crash
+        # With non-linear handling, it should fallback to robust methods
+        self.assertIn("white_density", results)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR fixes a bug in `src/core/analysis.py` where a frequency array with identical values (e.g., `[100, 100, 100]`) was incorrectly identified as a linear axis with `freq_step=0`. This led to a division-by-zero error (manifesting as `OverflowError` when converting `inf` to int) in subsequent calculations.

The fix adds a check `freq_step > 1e-9` in `_analyze_frequency_axis` to prevent this misclassification.

A regression test has been added to `tests/logic_verification/test_noise_profile_logic.py` to ensure this edge case is handled gracefully.

---
*PR created automatically by Jules for task [14628449359921606893](https://jules.google.com/task/14628449359921606893) started by @youtube-at-vach*