### PR TITLE
Fix off-by-one error in harmonic analysis boundary check

### DIFF
--- a/src/core/analysis.py
+++ b/src/core/analysis.py
@@ -554,7 +554,7 @@ class AudioCalc:
             idx_max = idx_min + 1
 
         # Find max in range
-        if idx_max < len(amplitude_spectrum):
+        if idx_max <= len(amplitude_spectrum):
             subset = amplitude_spectrum[idx_min:idx_max]
             if len(subset) > 0:
                 local_max_idx = np.argmax(subset)
@@ -600,8 +600,20 @@ class AudioCalc:
             h_idx_min = np.searchsorted(freqs, harmonic_freq - search_window)
             h_idx_max = np.searchsorted(freqs, harmonic_freq + search_window)
 
-            if h_idx_max < len(amplitude_spectrum) and h_idx_max > h_idx_min:
+            if h_idx_max <= len(amplitude_spectrum) and h_idx_max > h_idx_min:
                 subset = amplitude_spectrum[h_idx_min:h_idx_max]
+                if len(subset) == 0:
+                    # Can happen if h_idx_min >= len
+                    harmonic_results.append(
+                        {
+                            "order": i,
+                            "frequency": harmonic_freq,
+                            "amplitude_dbr": min_db,
+                            "amplitude_linear": 0,
+                        }
+                    )
+                    continue
+
                 local_max_h = np.argmax(subset)
                 h_peak_idx = h_idx_min + local_max_h
 

--- a/tests/logic_verification/analysis/test_harmonic_boundary.py
+++ b/tests/logic_verification/analysis/test_harmonic_boundary.py
@@ -1,0 +1,58 @@
+import unittest
+import numpy as np
+from src.core.analysis import AudioCalc
+
+class TestHarmonicBoundary(unittest.TestCase):
+    def test_harmonic_near_nyquist(self):
+        # Setup: Freqs up to 100Hz.
+        # Fundamental at 49.5Hz.
+        # 2nd Harmonic at 99.0Hz.
+        # SR = 200. Nyquist = 100.
+        # Harmonic < Nyquist.
+
+        freqs = np.array([0.0, 49.5, 99.0, 100.0])
+        # Spectrum: Peak at 49.5Hz and 99.0Hz.
+        amplitude_spectrum = np.array([0.0, 1.0, 0.5, 0.0])
+
+        max_freq = 49.5
+        max_amplitude = 1.0
+        sampling_rate = 200.0
+        search_window = 5.0  # Window +/- 5Hz.
+        min_db = -100.0
+
+        # Harmonic 2: 99.0Hz.
+        # Window: 94.0 - 104.0.
+        # searchsorted(freqs, 94.0) -> index 2 (99.0).
+        # searchsorted(freqs, 104.0) -> index 4 (len).
+
+        # Original code:
+        # h_idx_max = 4. len = 4.
+        # if 4 < 4: False. Harmonic skipped.
+
+        # Fixed code:
+        # if 4 <= 4: True.
+        # subset = amp[2:4] -> [0.5, 0.0].
+        # argmax -> 0.
+        # found.
+
+        results, amplitudes = AudioCalc._analyze_harmonics_list(
+            freqs, amplitude_spectrum, max_freq, max_amplitude, sampling_rate, search_window, min_db
+        )
+
+        # Check if harmonic 2 is found
+        found_harmonic_2 = False
+        for h in results:
+            if h['order'] == 2:
+                if h['amplitude_linear'] > 0:
+                    found_harmonic_2 = True
+                    self.assertAlmostEqual(h['amplitude_linear'], 0.5)
+
+        if not found_harmonic_2:
+            print("\nBug reproduced: 2nd harmonic near Nyquist was not detected.")
+        else:
+            print("\nTest passed: 2nd harmonic detected.")
+
+        self.assertTrue(found_harmonic_2, "Harmonic near Nyquist should be detected")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixed an issue where harmonics or fundamental frequencies located exactly at the upper boundary of the frequency spectrum (e.g., Nyquist frequency) were skipped during analysis. This was caused by an index check `idx < len` which failed when `idx` was equal to `len` (which is a valid stop index for array slicing).

Modified `src/core/analysis.py` to use inclusive comparison `idx <= len`.
Added `tests/logic_verification/analysis/test_harmonic_boundary.py` to verify the fix.

---
*PR created automatically by Jules for task [13689144354354880098](https://jules.google.com/task/13689144354354880098) started by @youtube-at-vach*