### PR TITLE
🧪 Add unit tests for PinkNoise generator

### DIFF
--- a/tests/logic_verification/generators/test_pink_noise.py
+++ b/tests/logic_verification/generators/test_pink_noise.py
@@ -74,7 +74,7 @@ class TestPinkNoise(unittest.TestCase):
             mock_randn.return_value = np.ones(10, dtype=np.float32)
 
             # First call
-            out1 = pn.generate(10)
+            _ = pn.generate(10)
 
             # Check that state variables are no longer 0
             state_vars = [pn.b0, pn.b1, pn.b2, pn.b3, pn.b4, pn.b5, pn.b6]
@@ -84,7 +84,7 @@ class TestPinkNoise(unittest.TestCase):
             state_after_first = list(state_vars)
 
             # Second call (mock still returns ones)
-            out2 = pn.generate(10)
+            _ = pn.generate(10)
 
             # Check that state has evolved further
             state_after_second = [pn.b0, pn.b1, pn.b2, pn.b3, pn.b4, pn.b5, pn.b6]


### PR DESCRIPTION
Added unit tests for the `PinkNoise` generator in `src/core/generators.py`. 
The tests verify:
1.  **Initialization**: Ensures internal state variables `b0` through `b6` are initialized to 0.0.
2.  **Output Format**: Verifies the generator returns a numpy array of `float32` with the requested length.
3.  **Spectral Slope**: Generates a long buffer of pink noise and uses Welch's method to compute the Power Spectral Density. It verifies that the slope of the log-log PSD is approximately -10 dB/decade, which is the defining characteristic of pink noise ($1/f$).
4.  **Statefulness**: Mocks `numpy.random.randn` to ensure deterministic input and verifies that the internal state variables evolve upon subsequent calls.


---
*PR created automatically by Jules for task [2254937621455935602](https://jules.google.com/task/2254937621455935602) started by @youtube-at-vach*