### PR TITLE
🧪 Move BitDepthEstimator tests to core

### DIFF
--- a/tests/logic_verification/core/test_bit_depth_estimator.py
+++ b/tests/logic_verification/core/test_bit_depth_estimator.py
@@ -1,0 +1,147 @@
+import pytest
+import numpy as np
+from src.core.bit_depth_estimator import BitDepthEstimator
+
+@pytest.fixture
+def estimator():
+    return BitDepthEstimator()
+
+def test_initial_state(estimator):
+    """Verify that initially the estimator returns None."""
+    assert estimator.analyze() is None
+
+def test_insufficient_data(estimator):
+    """Verify that estimator returns None if less than 2 samples are added."""
+    estimator.add_samples(np.array([0.5]))
+    assert estimator.analyze() is None
+
+def test_reset(estimator):
+    """Verify that reset clears the buffer."""
+    estimator.add_samples(np.array([0.1, 0.2]))
+    estimator.reset()
+    assert estimator.analyze() is None
+
+def test_bit_depth_16bit(estimator):
+    """Verify 16-bit depth estimation."""
+    # 16-bit step size: 2 / 2^16 (full range 2.0) -> 1 / 2^15
+    step = 2.0 / 65536.0
+
+    # Create a signal that ramps up by exactly 1 step per sample
+    # to ensure we capture the smallest delta
+    quantized_signal = np.arange(-10, 10) * step
+
+    estimator.add_samples(quantized_signal)
+    results = estimator.analyze()
+
+    assert results is not None
+    # Expect ~16.0
+    assert abs(results["bit_depth"] - 16.0) < 0.1
+
+def test_bit_depth_24bit(estimator):
+    """Verify 24-bit depth estimation."""
+    step = 2.0 / (2**24)
+    # Ramp with 1 step per sample
+    quantized_signal = np.arange(-10, 10) * step
+
+    estimator.add_samples(quantized_signal)
+    results = estimator.analyze()
+
+    assert results is not None
+    # Expect ~24.0
+    assert abs(results["bit_depth"] - 24.0) < 0.1
+
+def test_silence(estimator):
+    """Verify behavior with digital silence (all zeros)."""
+    silence = np.zeros(1000)
+    estimator.add_samples(silence)
+    results = estimator.analyze()
+
+    assert results is not None
+    assert results["bit_depth"] == 0.0
+    assert results["delta_hist"] is None
+    # Bit distribution should be all zeros (for 0 input)
+    np.testing.assert_array_equal(results["bit_distribution"], np.zeros(32))
+
+def test_bit_distribution(estimator):
+    """Verify bit distribution calculation with known patterns."""
+    # Test with +1.0 (0x7FFFFFFF)
+    # In 2's complement 32-bit:
+    # 0x7FFFFFFF = 0111...111 (31 bits set, MSB 0)
+    # So bits 0-30 are 1, bit 31 is 0.
+
+    samples_ones = np.ones(100)
+    estimator.add_samples(samples_ones)
+    results = estimator.analyze()
+
+    bit_dist = results["bit_distribution"]
+    # Check bits 0-30 are 1.0 (100% probability)
+    np.testing.assert_allclose(bit_dist[:31], 1.0)
+    # Check bit 31 is 0.0
+    assert bit_dist[31] == 0.0
+
+    estimator.reset()
+
+    # Test with -1.0 (0x80000001 per code logic scaling)
+    # scaling: -1.0 * (2^31 - 1) = -2147483647
+    # int32(-2147483647) is 0x80000001
+    # 0x80000001 = 1000...0001
+    # So bit 31 is 1, bit 0 is 1. Others 0.
+
+    samples_neg = -np.ones(100)
+    estimator.add_samples(samples_neg)
+    results = estimator.analyze()
+
+    bit_dist = results["bit_distribution"]
+    assert bit_dist[0] == 1.0
+    assert bit_dist[31] == 1.0
+    np.testing.assert_allclose(bit_dist[1:31], 0.0)
+
+def test_histogram(estimator):
+    """Verify histogram structure."""
+    # Create random noise to ensure distribution
+    np.random.seed(42)
+    noise = np.random.uniform(-0.1, 0.1, 1000)
+    estimator.add_samples(noise)
+    results = estimator.analyze()
+
+    hist_data = results["delta_hist"]
+    assert hist_data is not None
+    hist, bin_edges = hist_data
+
+    assert len(hist) == 50
+    assert len(bin_edges) == 51
+    assert bin_edges[0] == -13
+    assert bin_edges[-1] == 0
+
+def test_high_bit_depth_limit(estimator):
+    """Verify bit depth estimation near the implementation limit."""
+    # The implementation filters diffs <= 1e-12.
+    # 1e-12 corresponds to roughly 40 bits.
+    # Let's test with a diff slightly larger than 1e-12.
+
+    small_step = 1.1e-12
+    # log2(1.1e-12) ~ -39.7
+    # 1 - (-39.7) ~ 40.7
+
+    signal = np.array([0, small_step, 2*small_step])
+    estimator.add_samples(signal)
+    results = estimator.analyze()
+
+    assert results["bit_depth"] > 40.0
+    assert results["bit_depth"] < 41.0
+
+def test_clamping_low(estimator):
+    """Verify bit depth clamping at 0."""
+    # Large steps -> small bit depth
+    # step = 0.5
+    # log2(0.5) = -1
+    # 1 - (-1) = 2.0
+
+    # If step is 4.0 (possible if signal is not normalized to -1..1 but logic handles it)
+    # log2(4) = 2. 1 - 2 = -1. Should clamp to 0.
+
+    large_step_signal = np.array([0, 4.0, 8.0])
+    estimator.add_samples(large_step_signal)
+    results = estimator.analyze()
+
+    assert results["bit_depth"] == 0.0

--- a/tests/logic_verification/gui/test_bit_depth_analyzer.py
+++ b/tests/logic_verification/gui/test_bit_depth_analyzer.py
@@ -7,35 +7,6 @@ from PyQt6.QtWidgets import QApplication
 def app():
     return QApplication.instance() or QApplication([])
 
-@pytest.fixture
-def estimator():
-    from src.core.bit_depth_estimator import BitDepthEstimator
-    return BitDepthEstimator()
-
-def test_bit_depth_estimation_16bit(estimator):
-    # Setup 16-bit quantization
-    step = 2.0 / 65536.0
-    t = np.linspace(-0.1, 0.1, 10000)
-    quantized_signal = np.round(t / step) * step
-
-    estimator.add_samples(quantized_signal)
-    results = estimator.analyze()
-
-    assert results is not None
-    assert abs(results["bit_depth"] - 16.0) < 0.5
-
-def test_bit_depth_estimation_24bit(estimator):
-    # Setup 24-bit quantization
-    step = 2.0 / (2**24)
-    # Ensure enough variance
-    quantized_signal = np.array([0, step, 3*step, 10*step, step, 0, -step])
-
-    estimator.add_samples(quantized_signal)
-    results = estimator.analyze()
-
-    assert results is not None
-    assert abs(results["bit_depth"] - 24.0) < 0.5
-
 def test_bit_depth_dialog(app):
     from src.core.audio_engine import AudioEngine
     from src.gui.widgets.settings import BitDepthDialog


### PR DESCRIPTION
🎯 **What:**
Moved `BitDepthEstimator` logic tests from `tests/logic_verification/gui/test_bit_depth_analyzer.py` to a new dedicated core test file `tests/logic_verification/core/test_bit_depth_estimator.py`.

📊 **Coverage:**
Added comprehensive tests for:
- Initial state and insufficient data (returns `None`).
- Reset functionality.
- 16-bit and 24-bit depth estimation using deterministic ramp signals.
- Digital silence (0 bit depth).
- Bit distribution logic (verifying bit counting with specific integer patterns).
- Histogram generation structure.
- Clamping logic (lower bound 0, upper bound implementation limit ~40 bits).

✨ **Result:**
Improved test coverage and reliability for `BitDepthEstimator`. The tests are now located in the appropriate core logic verification directory, separating pure logic tests from GUI integration tests.

---
*PR created automatically by Jules for task [4860882471428230450](https://jules.google.com/task/4860882471428230450) started by @youtube-at-vach*