### PR TITLE
Refactor ConfigManager path resolution to remove duplication

### DIFF
--- a/src/core/config_manager.py
+++ b/src/core/config_manager.py
@@ -268,6 +268,7 @@ class ConfigManager:
         return config
 
     def _resolve_path(self, path_value: str) -> str:
+        path_value = os.path.expanduser(path_value)
         if os.path.isabs(path_value):
             full_path = os.path.abspath(path_value)
         else:
@@ -279,13 +280,7 @@ class ConfigManager:
         try:
             # Allow arbitrary paths for screenshots (no sandboxing)
             raw_path = config["screenshot"].get("output_dir", "screenshots")
-            # Expand ~ if present
-            raw_path = os.path.expanduser(raw_path)
-
-            if os.path.isabs(raw_path):
-                out_dir = os.path.abspath(raw_path)
-            else:
-                out_dir = os.path.abspath(os.path.join(self.config_dir, raw_path))
+            out_dir = self._resolve_path(raw_path)
 
         except Exception as e:
             self.logger.warning(f"Error resolving screenshot path: {e}. Reverting to default.")
@@ -429,13 +424,8 @@ class ConfigManager:
         if not out_dir:
             return "screenshots"
         # Allow arbitrary paths for screenshots (no sandboxing)
-        out_dir = str(out_dir)
         try:
-            out_dir = os.path.expanduser(out_dir)
-            if os.path.isabs(out_dir):
-                return os.path.abspath(out_dir)
-            else:
-                return os.path.abspath(os.path.join(self.config_dir, out_dir))
+            return self._resolve_path(str(out_dir))
         except Exception:
             return self._get_default_screenshot_dir()
 

--- a/tests/security/test_config_path_resolution.py
+++ b/tests/security/test_config_path_resolution.py
@@ -2,6 +2,7 @@ import os
 import pytest
 import tempfile
 import json
+from unittest.mock import patch
 from src.core.config_manager import ConfigManager
 
 @pytest.fixture
@@ -83,3 +84,35 @@ def test_resolve_base_directory(config_manager_instance):
     path = "."
     resolved = cm._resolve_path(path)
     assert resolved == temp_dir
+
+def test_resolve_home_directory_expansion(config_manager_instance):
+    cm, temp_dir = config_manager_instance
+    path = "~/subdir"
+
+    # Mock expanduser to return a path relative to temp_dir for predictability
+    # We choose an absolute path to simulate successful expansion
+    expanded_path = os.path.join(temp_dir, "home/user/subdir")
+
+    with patch("os.path.expanduser", return_value=expanded_path) as mock_expand:
+        resolved = cm._resolve_path(path)
+
+        # Verify expanduser was called
+        mock_expand.assert_called_with(path)
+
+        # Verify result matches expected expanded path
+        # Since expanded_path is absolute, _resolve_path should return it as is
+        assert resolved == expanded_path
+
+def test_ensure_screenshot_dir_expansion(config_manager_instance):
+    cm, temp_dir = config_manager_instance
+    config = {"screenshot": {"output_dir": "~/screenshots"}}
+
+    expanded_path = os.path.join(temp_dir, "home/user/screenshots")
+
+    with patch("os.path.expanduser", return_value=expanded_path) as mock_expand:
+        # We need to mock makedirs to avoid actual FS operations on non-existent paths
+        with patch("os.makedirs"):
+             out_dir = cm._ensure_screenshot_dir(config)
+
+        mock_expand.assert_called_with("~/screenshots")
+        assert out_dir == expanded_path


### PR DESCRIPTION
🎯 **What:** Refactored `src/core/config_manager.py` to centralized path resolution logic.
💡 **Why:** `_ensure_screenshot_dir` and `get_screenshot_output_dir` contained duplicated logic for path expansion and resolution. Refactoring this to use `_resolve_path` improves maintainability and consistency.
✅ **Verification:**
- Added `test_resolve_home_directory_expansion` to `tests/security/test_config_path_resolution.py` to verify `~` expansion.
- Added `test_ensure_screenshot_dir_expansion` to verify integration.
- Ran `python -m pytest tests/security/test_config_path_resolution.py` (PASS).
- Ran `python -m pytest tests/logic_verification/core/test_config_manager_logic.py` (PASS).
- Ran `python -m pytest tests/security/` (Relevant tests PASS).
✨ **Result:** Code duplication removed, path resolution logic centralized and tested.

---
*PR created automatically by Jules for task [15016047782681484986](https://jules.google.com/task/15016047782681484986) started by @youtube-at-vach*