### PR TITLE
Fix RingBuffer crash when writing fewer channels than capacity

### DIFF
--- a/src/core/ring_buffer.py
+++ b/src/core/ring_buffer.py
@@ -67,6 +67,12 @@ class RingBuffer:
         # Handle channel mismatch (e.g. input 4ch -> buffer 2ch)
         if n_channels > self._channels:
             data = data[:, :self._channels]
+        elif 1 < n_channels < self._channels:
+            # Handle input with fewer channels (but > 1) -> Pad with zeros
+            # Note: input 1ch (mono) is handled by broadcasting in assignment
+            padded = np.zeros((n_frames, self._channels), dtype=self._dtype)
+            padded[:, :n_channels] = data
+            data = padded
 
         # Handle overflow if writing more than capacity (only keep latest)
         if n_frames > self._capacity:

--- a/tests/logic_verification/core/test_ring_buffer_mismatch.py
+++ b/tests/logic_verification/core/test_ring_buffer_mismatch.py
@@ -1,0 +1,33 @@
+import os
+import sys
+import unittest
+import numpy as np
+
+# Adjust path to import src if needed
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../")))
+
+from src.core.ring_buffer import RingBuffer
+
+class TestRingBufferMismatch(unittest.TestCase):
+    def test_stereo_to_quad_write(self):
+        # Buffer is 4-channel
+        rb = RingBuffer(capacity=100, channels=4, dtype=np.float32)
+
+        # Input is 2-channel (stereo)
+        data = np.ones((10, 2), dtype=np.float32)
+
+        # This currently raises ValueError
+        rb.write(data)
+
+        # Should zero-pad the missing channels
+        read_data = rb.read()
+        self.assertEqual(read_data.shape, (10, 4))
+
+        # Check first 2 channels are 1.0
+        np.testing.assert_array_equal(read_data[:, :2], np.ones((10, 2), dtype=np.float32))
+
+        # Check last 2 channels are 0.0 (padded)
+        np.testing.assert_array_equal(read_data[:, 2:], np.zeros((10, 2), dtype=np.float32))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixed a bug in `src/core/ring_buffer.py` where writing multi-channel audio data (e.g., stereo) to a buffer with more channels (e.g., quad) would crash with a `ValueError` because NumPy cannot broadcast `(N, 2)` to `(N, 4)`.

The fix implements zero-padding for the missing channels in this specific scenario (`1 < input_channels < buffer_channels`).

Verified with a new reproduction test case `tests/logic_verification/core/test_ring_buffer_mismatch.py` and existing regression tests.

---
*PR created automatically by Jules for task [12953855056138830301](https://jules.google.com/task/12953855056138830301) started by @youtube-at-vach*