### PR TITLE
Refactor UpdateChecker tests for robustness

### DIFF
--- a/src/core/update_checker.py
+++ b/src/core/update_checker.py
@@ -10,6 +10,25 @@ from src.core.constants import UPDATE_CHECK_URL
 from src.core.version import __version__
 
 
+def is_newer_version(latest: str, current: str) -> bool:
+    """
+    Compares two version strings (e.g., "1.0.0" and "0.9.5").
+    Returns True if latest > current, False otherwise.
+    """
+    try:
+        l_parts = [int(x) for x in latest.split(".")]
+        c_parts = [int(x) for x in current.split(".")]
+
+        # Pad with zeros if lengths differ
+        length = max(len(l_parts), len(c_parts))
+        l_parts.extend([0] * (length - len(l_parts)))
+        c_parts.extend([0] * (length - len(c_parts)))
+
+        return l_parts > c_parts
+    except ValueError:
+        return False
+
+
 class UpdateChecker(QThread):
     update_available = pyqtSignal(str)  # Emits the new version string
 
@@ -36,7 +55,7 @@ class UpdateChecker(QThread):
                     clean_latest = latest_tag.lstrip("v")
                     clean_current = __version__.lstrip("v")
 
-                    if self._is_newer(clean_latest, clean_current):
+                    if is_newer_version(clean_latest, clean_current):
                         self.update_available.emit(latest_tag)
 
         except Exception as e:
@@ -44,15 +63,5 @@ class UpdateChecker(QThread):
             self.logger.error(f"Update check failed: {e}")
 
     def _is_newer(self, latest: str, current: str) -> bool:
-        try:
-            l_parts = [int(x) for x in latest.split(".")]
-            c_parts = [int(x) for x in current.split(".")]
-
-            # Pad with zeros if lengths differ
-            length = max(len(l_parts), len(c_parts))
-            l_parts.extend([0] * (length - len(l_parts)))
-            c_parts.extend([0] * (length - len(c_parts)))
-
-            return l_parts > c_parts
-        except ValueError:
-            return False
+        """Deprecated: Use is_newer_version instead."""
+        return is_newer_version(latest, current)

--- a/tests/logic_verification/core/test_update_checker.py
+++ b/tests/logic_verification/core/test_update_checker.py
@@ -1,65 +1,29 @@
-import importlib
-import sys
 import unittest
 from unittest.mock import MagicMock, patch
-from src.core.constants import UPDATE_CHECK_URL  # noqa: E402
+from src.core.update_checker import UpdateChecker, is_newer_version
+from src.core.constants import UPDATE_CHECK_URL
+
+
+class TestVersionComparison(unittest.TestCase):
+    def test_version_newer(self):
+        self.assertTrue(is_newer_version("0.4.4", "0.4.3"))
+        self.assertTrue(is_newer_version("1.0.0", "0.4.3"))
+        self.assertTrue(is_newer_version("0.4.3.1", "0.4.3"))
+
+    def test_version_older_or_equal(self):
+        self.assertFalse(is_newer_version("0.4.3", "0.4.3"))
+        self.assertFalse(is_newer_version("0.4.2", "0.4.3"))
+        self.assertFalse(is_newer_version("0.3.9", "0.4.3"))
+
+    def test_invalid_version_string(self):
+        # Should return False on ValueError
+        self.assertFalse(is_newer_version("invalid", "0.4.3"))
+        self.assertFalse(is_newer_version("0.4.3", "invalid"))
+
 
 class TestUpdateChecker(unittest.TestCase):
     def setUp(self):
-        # Create mocks
-        self.mock_pyqt_core = MagicMock()
-        self.mock_pyqt6 = MagicMock()
-
-        # Mock QThread
-        class MockQThread:
-            def __init__(self, parent=None):
-                pass
-            def start(self):
-                self.run()
-            def run(self):
-                pass
-            def wait(self):
-                pass
-
-        self.mock_pyqt_core.QThread = MockQThread
-        self.mock_pyqt_core.QCoreApplication = MagicMock()
-
-        # Mock pyqtSignal
-        mock_signal_instance = MagicMock()
-        self.mock_pyqt_core.pyqtSignal = MagicMock(return_value=mock_signal_instance)
-
-        self.modules_patcher = patch.dict(sys.modules, {
-            "PyQt6": self.mock_pyqt6,
-            "PyQt6.QtCore": self.mock_pyqt_core
-        })
-        self.modules_patcher.start()
-
-        # Import/Reload module under test
-        import src.core.update_checker
-        importlib.reload(src.core.update_checker)
-        self.UpdateChecker = src.core.update_checker.UpdateChecker
-
-    def tearDown(self):
-        self.modules_patcher.stop()
-        # Clean up imported module to avoid stale mocks
-        if 'src.core.update_checker' in sys.modules:
-            # We can either reload it with real modules (if they existed) or leave it
-            # But since we patched sys.modules, the 'real' PyQt6 might be back.
-            # Ideally, reload it again so it picks up the real PyQt6 if needed.
-            # However, for this test suite, avoiding side effects is key.
-            pass
-
-    def test_version_comparison_newer(self):
-        checker = self.UpdateChecker()
-        self.assertTrue(checker._is_newer("0.4.4", "0.4.3"))
-        self.assertTrue(checker._is_newer("1.0.0", "0.4.3"))
-        self.assertTrue(checker._is_newer("0.4.3.1", "0.4.3"))
-
-    def test_version_comparison_older_or_equal(self):
-        checker = self.UpdateChecker()
-        self.assertFalse(checker._is_newer("0.4.3", "0.4.3"))
-        self.assertFalse(checker._is_newer("0.4.2", "0.4.3"))
-        self.assertFalse(checker._is_newer("0.3.9", "0.4.3"))
+        self.checker = UpdateChecker()
 
     @patch('urllib.request.urlopen')
     def test_update_check_found(self, mock_urlopen):
@@ -69,18 +33,20 @@ class TestUpdateChecker(unittest.TestCase):
         mock_response.read.return_value = b'{"tag_name": "v9.9.9"}'
         mock_urlopen.return_value.__enter__.return_value = mock_response
 
-        checker = self.UpdateChecker()
-        checker.update_available.emit.reset_mock()
+        # Connect a mock slot to the signal
+        mock_slot = MagicMock()
+        self.checker.update_available.connect(mock_slot)
 
         # Run synchronous for testing
-        checker.run()
+        self.checker.run()
 
         # Verify URL usage
         args, _ = mock_urlopen.call_args
         request_obj = args[0]
         self.assertEqual(request_obj.full_url, UPDATE_CHECK_URL)
 
-        checker.update_available.emit.assert_called_with("v9.9.9")
+        # Verify signal emission
+        mock_slot.assert_called_once_with("v9.9.9")
 
     @patch('urllib.request.urlopen')
     def test_update_check_not_found(self, mock_urlopen):
@@ -90,25 +56,24 @@ class TestUpdateChecker(unittest.TestCase):
         mock_response.read.return_value = b'{"tag_name": "v0.0.1"}'
         mock_urlopen.return_value.__enter__.return_value = mock_response
 
-        checker = self.UpdateChecker()
-        checker.update_available.emit.reset_mock()
+        mock_slot = MagicMock()
+        self.checker.update_available.connect(mock_slot)
 
-        checker.run()
+        self.checker.run()
 
-        checker.update_available.emit.assert_not_called()
+        mock_slot.assert_not_called()
 
     @patch('urllib.request.urlopen')
     def test_update_check_failure_logs_error(self, mock_urlopen):
         # Mock side effect to raise exception
         mock_urlopen.side_effect = Exception("Network error")
 
-        checker = self.UpdateChecker()
-
         # Verify logging
         with self.assertLogs('UpdateChecker', level='ERROR') as cm:
-            checker.run()
+            self.checker.run()
 
         self.assertTrue(any("Network error" in log for log in cm.output))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Refactored `UpdateChecker` and its tests to improve stability and maintainability.

**Changes:**
*   **`src/core/update_checker.py`**: Extracted `is_newer_version` as a standalone function.
*   **`tests/logic_verification/core/test_update_checker.py`**:
    *   Removed `sys.modules` patching and `importlib.reload`.
    *   Added `TestVersionComparison` for isolated logic testing.
    *   Updated `TestUpdateChecker` to use `unittest.mock.patch` for `urllib` and test `QThread` integration naturally.

**Verification:**
*   `pytest tests/logic_verification/core/test_update_checker.py` passes all 6 tests.

---
*PR created automatically by Jules for task [10285523949069609320](https://jules.google.com/task/10285523949069609320) started by @youtube-at-vach*