### PR TITLE
🔒 Security: Fix insecure file permissions for calibration config

### DIFF
--- a/src/core/calibration.py
+++ b/src/core/calibration.py
@@ -127,7 +127,16 @@ class CalibrationManager:
             "last_profile": self.last_profile,
         }
         try:
-            with open(self.config_path, "w") as f:
+            # Use os.open to ensure secure permissions (600) on creation
+            fd = os.open(self.config_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+
+            # Ensure permissions on existing files (best effort)
+            try:
+                os.chmod(self.config_path, 0o600)
+            except Exception as e:
+                self.logger.warning("Failed to set secure permissions for calibration file: %s", e)
+
+            with os.fdopen(fd, "w") as f:
                 json.dump(data, f, indent=4)
         except Exception as e:
             self.logger.error("Failed to save calibration: %s", e)

--- a/tests/security/test_calibration_permissions.py
+++ b/tests/security/test_calibration_permissions.py
@@ -1,0 +1,44 @@
+import unittest
+import os
+import stat
+import tempfile
+import shutil
+from src.core.calibration import CalibrationManager
+
+class TestCalibrationPermissions(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+        self.config_path = os.path.join(self.test_dir, "test_calibration.json")
+        self.cm = CalibrationManager(config_filename=self.config_path)
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def test_calibration_file_permissions(self):
+        # Save calibration
+        self.cm.save()
+
+        # Verify file exists
+        self.assertTrue(os.path.exists(self.config_path))
+
+        # Check permissions
+        st = os.stat(self.config_path)
+        mode = st.st_mode
+
+        if os.name == 'posix':
+            # Check for 0o600 (or stricter)
+            # This test expects failure if the fix is not applied yet
+            # because the current implementation uses default open() permissions
+            # which are typically 0o644 or 0o664 depending on umask
+
+            # For reproduction, we can assert that it IS insecure (has group/other read perms)
+            # But the goal is to write a test that fails now and passes later.
+            # So I will assert the DESIRED state (secure) and expect it to fail.
+
+            self.assertEqual(mode & 0o077, 0, f"File has permissions for group or other: {oct(mode)}")
+            # Ensure owner has rw
+            self.assertTrue(mode & stat.S_IRUSR, "Owner cannot read")
+            self.assertTrue(mode & stat.S_IWUSR, "Owner cannot write")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR fixes a security vulnerability where the calibration configuration file was created with default insecure permissions (e.g., world-readable).

**Changes:**
- Modified `src/core/calibration.py`:
  - Replaced `open(..., 'w')` with `os.open(..., os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)` and `os.fdopen`.
  - Added an `os.chmod` call immediately after `os.open` to handle cases where the file already exists with insecure permissions, reducing the window of exposure.
- Added `tests/security/test_calibration_permissions.py` to verify that the file is created with restricted permissions.

**Risk:**
- Without this fix, sensitive calibration data could be read by other users on the system.

**Verification:**
- Verified with `tests/security/test_calibration_permissions.py` (passed).
- Verified regression with existing tests (passed).

---
*PR created automatically by Jules for task [11775270777100409865](https://jules.google.com/task/11775270777100409865) started by @youtube-at-vach*