### PR TITLE
Dynamic buffer resizing for OnePPSMonitor

### DIFF
--- a/src/gui/widgets/one_pps_monitor.py
+++ b/src/gui/widgets/one_pps_monitor.py
@@ -216,17 +216,23 @@ class OnePPSMonitor(MeasurementModule):
                 # Since we want a rolling view, we just write to the ring buffer.
                 # If frames > buffer size, we just take the last part.
 
+                # Dynamic buffer resize check
+                # Ensure buffer holds at least 2 seconds of data
+                target_size = int(self.nominal_rate * 2.0)
+                if self.vis_buffer_size != target_size:
+                    with self._lock:
+                        self.vis_buffer_size = target_size
+                        self.vis_buffer = np.zeros(self.vis_buffer_size, dtype=np.float32)
+                        self.vis_write_pos = 0
+                        self.last_trig_waveform = None
+                        self._capture_trigger_index = -1
+
                 write_len = min(frames, self.vis_buffer_size)
                 src_data = sig[-write_len:].astype(np.float32)
 
-                # Check for buffer resize if rate changed drastically?
-                # For now assume fixed size enough for ~1s at 48k. 
-                # If 192k, it will be 0.25s, which might be too short for 1PPS.
-                # Let's dynamically resize if needed in future, but for now fixed is okay or we check nominal.
-
                 # Logic for ring buffer write
                 with self._lock:
-                     # Calculate split
+                    # Calculate split
                     remain = self.vis_buffer_size - self.vis_write_pos
                     if write_len <= remain:
                         self.vis_buffer[self.vis_write_pos : self.vis_write_pos + write_len] = src_data


### PR DESCRIPTION
This change addresses the issue where the fixed visualization buffer size in `OnePPSMonitor` was insufficient for high sample rates (e.g., 192kHz). By implementing dynamic resizing, the buffer now adapts to the `nominal_rate`, ensuring it always holds at least 2 seconds of data. This allows for correct 1PPS signal capture and visualization across different audio configurations.

---
*PR created automatically by Jules for task [2245893534430576424](https://jules.google.com/task/2245893534430576424) started by @youtube-at-vach*