### PR TITLE
Fix thread leaks in OnePPSMonitor tests and clarify fixture comments

### DIFF
--- a/tests/logic_verification/gui/test_one_pps_monitor.py
+++ b/tests/logic_verification/gui/test_one_pps_monitor.py
@@ -52,6 +52,7 @@ class TestOnePPSMonitorLogic(unittest.TestCase):
     def test_one_pps_logic(self):
         engine = MockAudioEngine()
         monitor = OnePPSMonitor(engine)
+        self.addCleanup(monitor.stop_analysis)
 
         # Configure
         monitor.threshold_fs = 0.5
@@ -107,6 +108,7 @@ class TestOnePPSMonitorLogic(unittest.TestCase):
     def test_hysteresis(self):
         engine = MockAudioEngine()
         monitor = OnePPSMonitor(engine)
+        self.addCleanup(monitor.stop_analysis)
         monitor.threshold_fs = 0.5
         monitor.hysteresis_fs = 0.1 # High: 0.5, Low: 0.4
         monitor.start_analysis()
@@ -147,6 +149,7 @@ class TestOnePPSMonitorLogic(unittest.TestCase):
         """Test that outliers are truly ignored and don't skew regression or history."""
         engine = MockAudioEngine()
         monitor = OnePPSMonitor(engine)
+        self.addCleanup(monitor.stop_analysis)
         monitor.threshold_fs = 0.5
         monitor.nominal_rate = 1000.0
 
@@ -186,6 +189,7 @@ class TestOnePPSMonitorLogic(unittest.TestCase):
     def test_cumulative_precision(self):
         engine = MockAudioEngine()
         monitor = OnePPSMonitor(engine)
+        self.addCleanup(monitor.stop_analysis)
         monitor.nominal_rate = 1000.0
         monitor.start_analysis()
         monitor.warmup_count = 0
@@ -218,6 +222,7 @@ class TestOnePPSMonitorLogic(unittest.TestCase):
     def test_mad_death_spiral(self):
         engine = MockAudioEngine()
         monitor = OnePPSMonitor(engine)
+        self.addCleanup(monitor.stop_analysis)
         monitor.threshold_fs = 0.5
         monitor.nominal_rate = 1000.0
 
@@ -348,12 +353,8 @@ def test_visualization_buffer(monitor):
 
     for i in range(0, frames, chunk_size):
         chunk = data[i:i+chunk_size]
-        # Need to handle queue put manually since we don't have callback registered in this test setup easily
-        # Actually OnePPSMonitor uses `process_buffer` internally from callback, or `data_queue` if threaded.
-        # But wait, `monitor` fixture uses `OnePPSMonitor` which spawns thread?
-        # `OnePPSMonitor` starts thread in `start_analysis`.
-        # Here `start_analysis` is NOT called.
-        # But `test_visualization_buffer` manually puts to queue.
+        # We manually feed the queue and run `_process_loop` synchronously in the main thread.
+        # `start_analysis()` is not called, so no background thread is spawned.
         monitor.data_queue.put((chunk, len(chunk)))
 
     monitor.data_queue.put(None) # Signal termination


### PR DESCRIPTION
This PR addresses a concern raised in `tests/logic_verification/gui/test_one_pps_monitor.py` regarding potential thread leaks and race conditions in the `OnePPSMonitor` test fixture.

Changes:
1.  **Refactored `TestOnePPSMonitorLogic`**: Added `self.addCleanup(monitor.stop_analysis)` to all test methods in this class. This ensures that any thread spawned by `monitor.start_analysis()` is properly stopped after the test completes, even if the test fails.
2.  **Clarified Comments**: Updated a confusing comment in `test_visualization_buffer` to explicitly state that the test manually feeds the queue and runs the processing loop synchronously, confirming that no background thread is spawned in that scenario.

These changes improve the robustness and reliability of the test suite by preventing thread leaks and clarifying the intended execution model.

---
*PR created automatically by Jules for task [3135444998814125337](https://jules.google.com/task/3135444998814125337) started by @youtube-at-vach*