### PR TITLE
🧪 [Test] Add coverage for ConfigManager.set_dithering_enabled

### DIFF
--- a/tests/logic_verification/core/test_config_manager_logic.py
+++ b/tests/logic_verification/core/test_config_manager_logic.py
@@ -335,5 +335,27 @@ class TestConfigManagerLogic(unittest.TestCase):
         finally:
             os.chdir(original_cwd)
 
+    def test_set_dithering_enabled(self):
+        """Test enabling and disabling dithering updates the config."""
+        cm = self.ConfigManager(config_filename=self.config_path)
+
+        # Test setting True
+        cm.set_dithering_enabled(True)
+        self.assertTrue(cm.config["audio"]["dithering_enabled"])
+
+        # Test setting False
+        cm.set_dithering_enabled(False)
+        self.assertFalse(cm.config["audio"]["dithering_enabled"])
+
+        # Test with missing 'audio' section
+        if "audio" in cm.config:
+            del cm.config["audio"]
+
+        cm.set_dithering_enabled(True)
+        self.assertTrue(cm.config["audio"]["dithering_enabled"])
+
+        cm.shutdown()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
🎯 **What:** Added a unit test for `ConfigManager.set_dithering_enabled`.
📊 **Coverage:** The new test covers enabling and disabling dithering, as well as the edge case where the "audio" section is entirely missing from the initial configuration dictionary.
✨ **Result:** Improved test coverage for `ConfigManager`, ensuring proper configuration mutations for the dithering setting.

---
*PR created automatically by Jules for task [14999794710342068107](https://jules.google.com/task/14999794710342068107) started by @youtube-at-vach*