### PR TITLE
🧪 [test] add unit tests for ConfigManager audio engine 64-bit settings

### DIFF
--- a/tests/logic_verification/core/test_config_manager_logic.py
+++ b/tests/logic_verification/core/test_config_manager_logic.py
@@ -142,6 +142,40 @@ class TestConfigManagerLogic(unittest.TestCase):
 
         cm.shutdown()
 
+    def test_audio_engine_64bit_settings(self):
+        """Test getting and setting the 64-bit audio engine configuration."""
+        cm = self.ConfigManager(config_filename=self.config_path)
+
+        # Mock save_config so we don't write to disk repeatedly
+        cm.save_config = MagicMock()
+
+        # Check default value (should be False unless DEFAULT_CONFIG changes)
+        self.assertFalse(cm.is_audio_engine_64bit())
+
+        # Enable 64-bit engine
+        cm.set_audio_engine_64bit(True)
+        self.assertTrue(cm.is_audio_engine_64bit())
+        self.assertTrue(cm.config["audio"]["audio_engine_64bit"])
+        cm.save_config.assert_called_once()
+
+        # Disable 64-bit engine
+        cm.save_config.reset_mock()
+        cm.set_audio_engine_64bit(False)
+        self.assertFalse(cm.is_audio_engine_64bit())
+        self.assertFalse(cm.config["audio"]["audio_engine_64bit"])
+        cm.save_config.assert_called_once()
+
+        # Edge case: "audio" key is missing
+        cm.save_config.reset_mock()
+        del cm.config["audio"]
+        cm.set_audio_engine_64bit(True)
+        self.assertIn("audio", cm.config)
+        self.assertTrue(cm.config["audio"]["audio_engine_64bit"])
+        self.assertTrue(cm.is_audio_engine_64bit())
+        cm.save_config.assert_called_once()
+
+        cm.shutdown()
+
     # -------------------------------------------------------------------------
     # Language Detection (from test_config_manager_language.py)
     # -------------------------------------------------------------------------


### PR DESCRIPTION
🎯 **What:** Added tests for `ConfigManager.set_audio_engine_64bit` and `ConfigManager.is_audio_engine_64bit` methods.
📊 **Coverage:** Covered default value retrieval, setting the value to True/False, ensuring `save_config` is called, and the edge case where the "audio" key is missing from the configuration.
✨ **Result:** Improved test coverage for `ConfigManager` and ensured safety for future refactoring of audio configuration saving logic.

---
*PR created automatically by Jules for task [14032095076635597928](https://jules.google.com/task/14032095076635597928) started by @youtube-at-vach*