### PR TITLE
🧪 Add tests for ConfigManager.set_language

### DIFF
--- a/tests/logic_verification/core/test_config_manager_logic.py
+++ b/tests/logic_verification/core/test_config_manager_logic.py
@@ -146,6 +146,21 @@ class TestConfigManagerLogic(unittest.TestCase):
     # Language Detection (from test_config_manager_language.py)
     # -------------------------------------------------------------------------
 
+    @patch('src.core.config_manager.ConfigManager.save_config')
+    def test_set_language(self, mock_save_config):
+        """Test setting the language updates the config and calls save_config."""
+        cm = self.ConfigManager(config_filename=self.config_path)
+
+        mock_save_config.reset_mock()
+
+        cm.set_language('fr')
+
+        self.assertEqual(cm.config['language'], 'fr')
+        self.assertEqual(cm.get_language(), 'fr')
+        mock_save_config.assert_called_once()
+
+        cm.shutdown()
+
     @patch('src.core.config_manager.QLocale')
     @patch('src.core.config_manager.resource_path')
     @patch('src.core.config_manager.os.path.exists')


### PR DESCRIPTION
🎯 **What:** The `ConfigManager.set_language` method lacked explicit test coverage, leaving a gap where changes to configuration dictionary setting and the subsequent save trigger could go untested.
📊 **Coverage:** A new unit test `test_set_language` was added under the language detection section of `test_config_manager_logic.py`. This test mocks the `save_config` method, resets it after initialization, invokes the setter, and verifies both state update and function delegation.
✨ **Result:** Improved test coverage and reliability for configuration updates. Changes are safe and introduce no regressions.

---
*PR created automatically by Jules for task [8264889627271752854](https://jules.google.com/task/8264889627271752854) started by @youtube-at-vach*