### PR TITLE
Fix Analysis module S_geom calculation division by zero

### DIFF
--- a/src/core/analysis.py
+++ b/src/core/analysis.py
@@ -472,9 +472,15 @@ class AudioCalc:
 
         # Safety for denom close to 0
         epsilon = 1e-15
-        denom[np.abs(denom) < epsilon] = epsilon # Hack to avoid NaN, though results will be huge
+        mask = np.abs(denom) < epsilon
+        safe_denom = np.where(mask, 1.0, denom)
 
-        S_geom = (1 - np.exp(1j * N * phi)) / denom
+        S_geom = (1 - np.exp(1j * N * phi)) / safe_denom
+
+        # Apply limit: lim_{phi->0} (1 - exp(j*N*phi)) / (1 - exp(j*phi)) = N * exp(j*(N-1)*phi/2)
+        if np.any(mask):
+            limit_val = N * np.exp(1j * (N - 1) * phi / 2)
+            S_geom = np.where(mask, limit_val, S_geom)
 
         # Apply t[0] phase shift
         S_exp = S_geom * np.exp(1j * omega * t[0])
@@ -490,9 +496,15 @@ class AudioCalc:
         # We need sum of exp(j * 2w * t)
         phi2 = 2 * phi
         denom2 = 1 - np.exp(1j * phi2)
-        denom2[np.abs(denom2) < epsilon] = epsilon
+        mask2 = np.abs(denom2) < epsilon
+        safe_denom2 = np.where(mask2, 1.0, denom2)
 
-        S_geom2 = (1 - np.exp(1j * N * phi2)) / denom2
+        S_geom2 = (1 - np.exp(1j * N * phi2)) / safe_denom2
+
+        # Apply limit for small phi2
+        if np.any(mask2):
+            limit_val2 = N * np.exp(1j * (N - 1) * phi2 / 2)
+            S_geom2 = np.where(mask2, limit_val2, S_geom2)
         S_exp2 = S_geom2 * np.exp(1j * 2 * omega * t[0])
 
         sum_cos_2wt = S_exp2.real


### PR DESCRIPTION
Replaces the hacky division-by-zero mitigation in `_perform_coarse_search` with a proper mathematical limit.

**Changes:**
- Replaced `denom[np.abs(denom) < epsilon] = epsilon` with `np.where`.
- Implemented `safe_denom = np.where(mask, 1.0, denom)` to compute a warning-free nominal division.
- Applied the strict limit using L'Hôpital's rule: `lim_{\phi \to 0} (1 - e^{jN\phi}) / (1 - e^{j\phi}) = N e^{j(N-1)\phi/2}`.
- Refactored identical logic for `S_geom2` calculation using `phi2` limits.
- Tested and verified tests continue to pass gracefully without generating NaNs or massive values.

---
*PR created automatically by Jules for task [12022520845557482122](https://jules.google.com/task/12022520845557482122) started by @youtube-at-vach*