### PR TITLE
🧪 [Add test coverage for set_input_sensitivity]

### DIFF
--- a/tests/logic_verification/core/test_calibration_manager.py
+++ b/tests/logic_verification/core/test_calibration_manager.py
@@ -175,6 +175,23 @@ def test_conversions(cal_manager):
     # Check input offset helper
     assert np.isclose(cal_manager.get_input_offset_db(), expected_dbv)
 
+def test_set_input_sensitivity(cal_manager):
+    """Test setting input sensitivity updates value and calls save."""
+    from unittest.mock import patch
+    with patch.object(cal_manager, 'save') as mock_save:
+        # Test valid float
+        cal_manager.set_input_sensitivity(5.5)
+        assert cal_manager.input_sensitivity == 5.5
+        mock_save.assert_called_once()
+        mock_save.reset_mock()
+
+        # Test valid int
+        cal_manager.set_input_sensitivity(10)
+        assert cal_manager.input_sensitivity == 10
+        mock_save.assert_called_once()
+        mock_save.reset_mock()
+
+
 def test_output_gain_validation(cal_manager):
     """Test validation for output gain setting."""
     cal_manager.set_output_gain(2.0)


### PR DESCRIPTION
🎯 **What:** The `set_input_sensitivity` method in `CalibrationManager` lacked test coverage, creating a minor testing gap for this basic setter function.
📊 **Coverage:** A new test case `test_set_input_sensitivity` was added to verify that setting both float and integer values correctly updates the internal `input_sensitivity` state and properly invokes the `save()` method. The `save()` method was mocked to prevent unnecessary disk I/O.
✨ **Result:** Test coverage is improved, ensuring the persistence behavior of `input_sensitivity` is correctly verified in the regression suite.

---
*PR created automatically by Jules for task [14024178123208227321](https://jules.google.com/task/14024178123208227321) started by @youtube-at-vach*