### PR TITLE
🧪 [testing improvement] Add tests for set_screenshot_output_dir

### DIFF
--- a/tests/logic_verification/core/test_config_manager_logic.py
+++ b/tests/logic_verification/core/test_config_manager_logic.py
@@ -405,6 +405,47 @@ class TestConfigManagerLogic(unittest.TestCase):
 
         cm.shutdown()
 
+    @patch('src.core.config_manager.ConfigManager.save_config')
+    @patch('src.core.config_manager.ConfigManager._ensure_screenshot_dir')
+    def test_set_screenshot_output_dir(self, mock_ensure, mock_save):
+        """Test setting the screenshot output directory updates the config."""
+        cm = self.ConfigManager(config_filename=self.config_path)
+
+        # Ensure starting state
+        self.assertIn("screenshot", cm.config)
+
+        # Test setting a new directory
+        cm.set_screenshot_output_dir("/new/screenshot/path")
+        self.assertEqual(cm.config["screenshot"]["output_dir"], "/new/screenshot/path")
+        mock_ensure.assert_called_with(cm.config)
+        mock_save.assert_called()
+
+        # Test with missing 'screenshot' section
+        del cm.config["screenshot"]
+
+        mock_ensure.reset_mock()
+        mock_save.reset_mock()
+
+        cm.set_screenshot_output_dir("another/path")
+        self.assertIn("screenshot", cm.config)
+        self.assertEqual(cm.config["screenshot"]["output_dir"], "another/path")
+        mock_ensure.assert_called_with(cm.config)
+        mock_save.assert_called()
+
+        # Test with invalid 'screenshot' section (not a dict)
+        cm.config["screenshot"] = "invalid_string"
+
+        mock_ensure.reset_mock()
+        mock_save.reset_mock()
+
+        cm.set_screenshot_output_dir("fallback/path")
+        self.assertIsInstance(cm.config["screenshot"], dict)
+        self.assertEqual(cm.config["screenshot"]["output_dir"], "fallback/path")
+        mock_ensure.assert_called_with(cm.config)
+        mock_save.assert_called()
+
+        cm.shutdown()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
🎯 **What:** 
Added unit tests for the previously untested `set_screenshot_output_dir` method in `ConfigManager`.

📊 **Coverage:**
The new test (`test_set_screenshot_output_dir` in `tests/logic_verification/core/test_config_manager_logic.py`) covers:
- The happy path where an existing valid string is provided and replaces the default output directory.
- The edge case where the `"screenshot"` section is missing from the configuration.
- The edge case where the `"screenshot"` section exists but is not a dictionary.
- Verifying that internal helper methods (`_ensure_screenshot_dir` and `save_config`) are correctly called.

✨ **Result:** 
Increased test coverage and confidence when refactoring or modifying screenshot-related config functionality.

---
*PR created automatically by Jules for task [17198757788641690059](https://jules.google.com/task/17198757788641690059) started by @youtube-at-vach*