### PR TITLE
⚡ Vectorize frequency2scale computation in Transient Analyzer

### DIFF
--- a/src/gui/widgets/transient_analyzer.py
+++ b/src/gui/widgets/transient_analyzer.py
@@ -218,12 +218,7 @@ class TransientAnalyzer(MeasurementModule):
         # Linear space for frequencies to match linear Y-axis of plot
         freqs = np.linspace(min_freq, max_freq, num_scales)
 
-        scales = []
-        for f in freqs:
-            s = pywt.frequency2scale(self.wavelet_name, f / self.fs)
-            scales.append(s)
-
-        scales = np.array(scales)
+        scales = pywt.frequency2scale(self.wavelet_name, freqs / self.fs)
 
         # Run CWT
         cwtmatr, frequencies = pywt.cwt(self.final_data, scales, self.wavelet_name, sampling_period=1.0 / self.fs)


### PR DESCRIPTION
### 💡 What
Replaced the Python loop and intermediate list used for converting frequencies to scales with a single vectorized call to `pywt.frequency2scale`.

### 🎯 Why
The `freqs` variable is already a NumPy array. `pywt.frequency2scale` can take array-like structures directly and perform the calculation much more efficiently at the C-level (within NumPy/SciPy), completely avoiding Python list overhead and an unneeded conversion back to `np.array()`. While the problem rationale suggested a list comprehension (`[pywt.frequency2scale(...) for f in freqs]`), native array vectorization is significantly faster and cleaner.

### 📊 Measured Improvement
I wrote a microbenchmark (`benchmark_scale2.py`) with `freqs = np.linspace(1, 20000, 1000)`, `wavelet_name = 'cmor'`, and `fs = 48000` executing the conversion 1000 times.
- **Original method (for-loop):** ~116.57 s
- **New method (vectorized):** ~0.12 s
- **Speedup:** ~970x faster for an array of size 1000. 

A list comprehension was also benchmarked but was only ~1.02x faster than the original loop, making the vectorized implementation vastly superior.

---
*PR created automatically by Jules for task [9097754444908230268](https://jules.google.com/task/9097754444908230268) started by @youtube-at-vach*