### PR TITLE
🧪 [testing improvement] Add tests for invalid version formats in update_checker

### DIFF
--- a/tests/logic_verification/core/test_update_checker.py
+++ b/tests/logic_verification/core/test_update_checker.py
@@ -19,6 +19,8 @@ class TestVersionComparison(unittest.TestCase):
         # Should return False on ValueError
         self.assertFalse(is_newer_version("invalid", "0.4.3"))
         self.assertFalse(is_newer_version("0.4.3", "invalid"))
+        self.assertFalse(is_newer_version("not.a.version", "0.4.3"))
+        self.assertFalse(is_newer_version("v1.a.b", "0.4.3"))
 
 
 class TestUpdateChecker(unittest.TestCase):
@@ -73,6 +75,12 @@ class TestUpdateChecker(unittest.TestCase):
             self.checker.run()
 
         self.assertTrue(any("Network error" in log for log in cm.output))
+
+    def test_deprecated_is_newer(self):
+        # Test the deprecated wrapper method to ensure it calls is_newer_version correctly
+        self.assertTrue(self.checker._is_newer("0.4.4", "0.4.3"))
+        self.assertFalse(self.checker._is_newer("0.4.3", "0.4.4"))
+        self.assertFalse(self.checker._is_newer("not.a.version", "0.4.3"))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
🎯 **What:** Added tests to cover invalid version formats like 'not.a.version' and 'v1.a.b' in `is_newer_version`, handling the `ValueError` exception block. Added coverage for the deprecated `_is_newer` method.

📊 **Coverage:** Test coverage for `src/core/update_checker.py` was increased to 100%.

✨ **Result:** Improved test reliability and ensured that version string comparison functions gracefully handle unexpected formats without crashing.

---
*PR created automatically by Jules for task [3786186149153813196](https://jules.google.com/task/3786186149153813196) started by @youtube-at-vach*