### PR TITLE
🧪 [Test Coverage] Add tests for frequency calibration methods in CalibrationManager

### DIFF
--- a/tests/logic_verification/core/test_calibration_manager.py
+++ b/tests/logic_verification/core/test_calibration_manager.py
@@ -231,6 +231,43 @@ def test_set_lockin_gain_offset(cal_manager):
             cal_manager.set_lockin_gain_offset("invalid")
         mock_save.assert_not_called()
 
+def test_set_frequency_calibration(cal_manager):
+    """Test setting frequency calibration updates value and calls save."""
+    from unittest.mock import patch
+    with patch.object(cal_manager, 'save') as mock_save:
+        cal_manager.set_frequency_calibration(1.0001)
+        assert cal_manager.frequency_calibration == 1.0001
+        mock_save.assert_called_once()
+
+def test_set_frequency_calibration_1pps(cal_manager):
+    """Test setting 1PPS frequency calibration updates value and calls save."""
+    from unittest.mock import patch
+    with patch.object(cal_manager, 'save') as mock_save:
+        cal_manager.set_frequency_calibration_1pps(0.9999)
+        assert cal_manager.frequency_calibration_1pps == 0.9999
+        mock_save.assert_called_once()
+
+def test_set_frequency_calibration_source(cal_manager):
+    """Test setting frequency calibration source updates value and calls save for valid inputs."""
+    from unittest.mock import patch
+    with patch.object(cal_manager, 'save') as mock_save:
+        # Valid source '1pps'
+        cal_manager.set_frequency_calibration_source("1pps")
+        assert cal_manager.frequency_calibration_source == "1pps"
+        mock_save.assert_called_once()
+        mock_save.reset_mock()
+
+        # Valid source 'basic'
+        cal_manager.set_frequency_calibration_source("basic")
+        assert cal_manager.frequency_calibration_source == "basic"
+        mock_save.assert_called_once()
+        mock_save.reset_mock()
+
+        # Invalid source (should ignore and not save)
+        cal_manager.set_frequency_calibration_source("invalid")
+        assert cal_manager.frequency_calibration_source == "basic" # Remains unchanged
+        mock_save.assert_not_called()
+
 def test_frequency_map_persistence(cal_manager, tmp_path):
     """Test saving and loading frequency map."""
     map_path = tmp_path / "freq_map.json"


### PR DESCRIPTION
🎯 **What:** The `set_frequency_calibration`, `set_frequency_calibration_1pps`, and `set_frequency_calibration_source` methods in `CalibrationManager` lacked test coverage, creating a minor testing gap for calibration functionality.

📊 **Coverage:** The following scenarios are now tested using `unittest.mock.patch` to prevent unintended disk I/O:
- `set_frequency_calibration`: Verifies the calibration factor is correctly updated and `save()` is called.
- `set_frequency_calibration_1pps`: Verifies the 1PPS calibration factor is correctly updated and `save()` is called.
- `set_frequency_calibration_source`: Verifies that valid sources ("basic", "1pps") update the configuration and trigger a `save()`, while invalid sources are safely ignored without triggering a `save()`.

✨ **Result:** Test coverage for `CalibrationManager` is improved, ensuring the persistence behavior of frequency calibration methods remains intact.

---
*PR created automatically by Jules for task [6753440109257591554](https://jules.google.com/task/6753440109257591554) started by @youtube-at-vach*