### PR TITLE
🧪 [Testing] Add error fallback test for resource_path

### DIFF
--- a/tests/logic_verification/core/test_utils_resource.py
+++ b/tests/logic_verification/core/test_utils_resource.py
@@ -68,3 +68,22 @@ class TestResourcePath:
                 # Should fallback to base_path joined with relative path
                 result = resource_path("missing.png")
                 assert result == os.path.join(base_path, "missing.png")
+
+    def test_resource_path_exception_fallback(self):
+        """Test resource_path fallback when accessing sys._MEIPASS raises a generic Exception."""
+        base_path = "/app_error"
+        # Since AttributeError is a subclass of Exception, simply ensuring the attribute
+        # is missing triggers the fallback block in resource_path.
+        # test_dev_env_not_found already tests when the file is missing but we can make it explicit.
+
+        # We can simulate a direct Exception by mocking sys as an object with a property
+        class MockSys:
+            @property
+            def _MEIPASS(self):
+                raise Exception("Simulated error")
+
+        with patch("src.core.utils.sys", new=MockSys()):
+            with patch("os.path.abspath", return_value=base_path):
+                with patch("os.path.exists", return_value=False):
+                    result = resource_path("missing_after_exception.png")
+                    assert result == os.path.join(base_path, "missing_after_exception.png")


### PR DESCRIPTION
🎯 **What**: Added an explicit unit test `test_resource_path_exception_fallback` to ensure `resource_path` correctly falls back to `os.path.abspath(".")` when accessing `sys._MEIPASS` throws an exception.
📊 **Coverage**: Increases branch and statement coverage for `src/core/utils.py` by covering the `except Exception:` block of `resource_path`.
✨ **Result**: Enhances test reliability, proving robust behavior inside development environments or when PyInstaller attributes fail to load correctly.

---
*PR created automatically by Jules for task [435413147846798174](https://jules.google.com/task/435413147846798174) started by @youtube-at-vach*