### PR TITLE
🧹 Remove unused ConfigManager import from detachable_wrapper

### DIFF
--- a/src/gui/widgets/detachable_wrapper.py
+++ b/src/gui/widgets/detachable_wrapper.py
@@ -16,11 +16,6 @@ from PyQt6.QtWidgets import (
 
 from src.core.localization import tr
 
-try:
-    from src.core.config_manager import ConfigManager
-except Exception:  # pragma: no cover
-    ConfigManager = None
-
 
 class IndependentWindow(QMainWindow):
     """


### PR DESCRIPTION
🎯 **What:** Removed the unused `ConfigManager` import from `src/gui/widgets/detachable_wrapper.py`.

💡 **Why:** The `ConfigManager` was imported but never utilized within the module. Removing it cleans up the module's namespace and removes unnecessary try/except blocks, improving code readability and maintainability.

✅ **Verification:**
- Ran `ruff format --check src/gui/widgets/detachable_wrapper.py` (Passed)
- Ran `ruff check src/gui/widgets/detachable_wrapper.py` (Passed)
- Executed the full test suite via `pytest tests` (All 591 tests passed successfully)

✨ **Result:** A cleaner `detachable_wrapper.py` file with no unused imports, contributing to a healthier codebase without altering any functionality.

---
*PR created automatically by Jules for task [18203876419860414566](https://jules.google.com/task/18203876419860414566) started by @youtube-at-vach*