### PR TITLE
🧹 [Replace unused drawContents with paintEvent in splash screen]

### DIFF
--- a/src/gui/startup.py
+++ b/src/gui/startup.py
@@ -80,15 +80,18 @@ class WrappingSplashScreen(QSplashScreen):
         self._message = message
         self._alignment = alignment
         self._color = color
-        # Call super to trigger repaint, but we'll override drawContents
-        super().showMessage(message, alignment, color)
+        # Trigger a repaint so paintEvent uses the updated message
+        self.repaint()
 
-    def drawContents(self, painter: QPainter | None):
-        if painter is None:
-            return
+    def paintEvent(self, event):
+        painter = QPainter(self)
+        # Draw the original pixmap as background
+        painter.drawPixmap(0, 0, self.pixmap())
+
         painter.setPen(self._color)
         # Add padding around the edges
         margin = 20
         rect = self.rect().adjusted(margin, margin, -margin, -margin)
         # Draw text with word wrap
         painter.drawText(rect, self._alignment | Qt.TextFlag.TextWordWrap, self._message)
+        painter.end()


### PR DESCRIPTION
🎯 **What:** The code health issue addressed is the dead-code `drawContents` method in `WrappingSplashScreen` in `src/gui/startup.py`. In PyQt6, `QSplashScreen` natively renders via `paintEvent` rather than delegating custom painting to `drawContents`.

💡 **Why:** Overriding `drawContents` has no effect natively and leaves dead code. To properly handle custom text drawing like word-wrapping and padding, the code needs to override `paintEvent(self, event)`, draw the original pixmap manually, and then draw the wrapped text on top. Furthermore, using `super().showMessage` causes the underlying Qt code to draw the un-wrapped string, so `showMessage` should just call `self.repaint()`. This refactoring improves the cleanliness and accuracy of our custom `QSplashScreen` subclass.

✅ **Verification:** Verified by temporarily instantiating the class offscreen, confirming `paintEvent` correctly draws the custom wrapper text with no double-drawing issues. Verified logic integrity by running `/home/jules/.local/bin/pytest tests/logic_verification/gui/test_main_gui_exception.py` (Passed). Checked syntax with `/home/jules/.local/bin/ruff check`. Removed all dummy files used during verification.

✨ **Result:** Removed unused dead code and correctly positioned custom painting logic within the standard PyQt6 `paintEvent` pipeline.

---
*PR created automatically by Jules for task [11020967786861902801](https://jules.google.com/task/11020967786861902801) started by @youtube-at-vach*