### PR TITLE
🧪 [Enhance SPL calibration error testing]

### DIFF
--- a/tests/logic_verification/core/test_calibration_manager.py
+++ b/tests/logic_verification/core/test_calibration_manager.py
@@ -121,8 +121,21 @@ def test_spl_calibration(cal_manager):
 
 def test_spl_invalid_input(cal_manager):
     """Test invalid input for SPL calibration."""
+    # Test invalid type for measured_dbfs_c
     with pytest.raises(ValueError, match="Invalid SPL calibration values"):
         cal_manager.set_spl_calibration("invalid", 80.0)
+    with pytest.raises(ValueError, match="Invalid SPL calibration values"):
+        cal_manager.set_spl_calibration(None, 80.0)
+
+    # Test invalid type for measured_spl_db
+    with pytest.raises(ValueError, match="Invalid SPL calibration values"):
+        cal_manager.set_spl_calibration(-20.0, "invalid")
+    with pytest.raises(ValueError, match="Invalid SPL calibration values"):
+        cal_manager.set_spl_calibration(-20.0, [80.0])
+
+    # Test invalid type for both
+    with pytest.raises(ValueError, match="Invalid SPL calibration values"):
+        cal_manager.set_spl_calibration("abc", "def")
 
 def test_profile_management(cal_manager):
     """Test creating, loading, and deleting profiles."""


### PR DESCRIPTION
🎯 **What:** The existing test for `set_spl_calibration`'s error handling (`test_spl_invalid_input`) only verified that passing an invalid string for the first argument (`measured_dbfs_c`) raised a `ValueError`. It did not test the second argument (`measured_spl_db`) or unconvertible types like `None` or lists.

📊 **Coverage:** The test has been expanded to assert that `ValueError` with the specific message "Invalid SPL calibration values" is correctly raised when passing invalid types (strings, `None`, lists) to either the first argument, the second argument, or both arguments.

✨ **Result:** Test coverage for the error handling path of `set_spl_calibration` is now comprehensive and ensures robust input validation.

---
*PR created automatically by Jules for task [14376141344673843414](https://jules.google.com/task/14376141344673843414) started by @youtube-at-vach*