### PR TITLE
🧪 [Add missing error path tests for SPL calibration]

### DIFF
--- a/tests/logic_verification/core/test_calibration_manager.py
+++ b/tests/logic_verification/core/test_calibration_manager.py
@@ -123,6 +123,12 @@ def test_spl_invalid_input(cal_manager):
     """Test invalid input for SPL calibration."""
     with pytest.raises(ValueError, match="Invalid SPL calibration values"):
         cal_manager.set_spl_calibration("invalid", 80.0)
+    with pytest.raises(ValueError, match="Invalid SPL calibration values"):
+        cal_manager.set_spl_calibration(-20.0, "invalid")
+    with pytest.raises(ValueError, match="Invalid SPL calibration values"):
+        cal_manager.set_spl_calibration(None, 80.0)
+    with pytest.raises(ValueError, match="Invalid SPL calibration values"):
+        cal_manager.set_spl_calibration(-20.0, None)
 
 def test_profile_management(cal_manager):
     """Test creating, loading, and deleting profiles."""


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
Added missing test cases in `tests/logic_verification/core/test_calibration_manager.py` to cover all invalid input error paths for the `CalibrationManager.set_spl_calibration()` method. The method expects two convertible float arguments and catches any exceptions during the conversion, raising a `ValueError`.

📊 **Coverage:** What scenarios are now tested
Previously, the test suite only validated `cal_manager.set_spl_calibration("invalid", 80.0)`. The test has been expanded to cover:
- Invalid second parameter: `cal_manager.set_spl_calibration(-20.0, "invalid")`
- Null first parameter: `cal_manager.set_spl_calibration(None, 80.0)`
- Null second parameter: `cal_manager.set_spl_calibration(-20.0, None)`

✨ **Result:** The improvement in test coverage
The `except Exception` block inside `set_spl_calibration` is now fully exercised for all relevant invalid argument states, guaranteeing the `ValueError("Invalid SPL calibration values")` contract is always honored. Regression testing passed successfully.

---
*PR created automatically by Jules for task [7902634429734500509](https://jules.google.com/task/7902634429734500509) started by @youtube-at-vach*