### PR TITLE
🧹 [code health] Remove unused `jam_capture_auto` method in TimecodeMonitor

### DIFF
--- a/src/gui/widgets/timecode_monitor.py
+++ b/src/gui/widgets/timecode_monitor.py
@@ -835,24 +835,6 @@ class TimecodeMonitor(MeasurementModule):
         self.jam_memories[s] = mem
         return True
 
-    def jam_capture_auto(self, key: str) -> int:
-        if key not in self.channels:
-            return -1
-
-        free_idx = None
-        oldest_idx = 0
-        oldest_ts = float("inf")
-        for i, m in enumerate(self.jam_memories):
-            if not m.valid and free_idx is None:
-                free_idx = i
-            if m.valid and float(m.captured_at) < oldest_ts:
-                oldest_ts = float(m.captured_at)
-                oldest_idx = i
-
-        idx = int(free_idx) if free_idx is not None else int(oldest_idx)
-        ok = self.jam_capture(key, idx)
-        return idx if ok else -1
-
     def jam_capture_precise(self, key: str, slot: int, window_seconds: float = 0.8, min_samples: int = 12) -> bool:
         if key not in self.channels:
             return False


### PR DESCRIPTION
🎯 **What:** Removed the unused `jam_capture_auto` method from `src/gui/widgets/timecode_monitor.py`.
💡 **Why:** This improves maintainability by removing dead code. The function `jam_capture_auto_precise` duplicates the core logic and is used by the UI instead. Removing unused methods cleans up the codebase and avoids confusion for future maintainers.
✅ **Verification:** Ran the full `pytest` suite locally and confirmed all 604 tests pass successfully with no regressions introduced.
✨ **Result:** A cleaner `timecode_monitor.py` file without unused functions, preserving exact functionality.

---
*PR created automatically by Jules for task [8322830641763371588](https://jules.google.com/task/8322830641763371588) started by @youtube-at-vach*