### PR TITLE
🧹 [remove unused on_point_clicked method in HRTFPlayerWidget]

### DIFF
--- a/src/gui/widgets/hrtf_player.py
+++ b/src/gui/widgets/hrtf_player.py
@@ -774,10 +774,6 @@ class HRTFPlayerWidget(QWidget):
             if hasattr(self, "pos_indicator"):
                 self.pos_indicator.setData(x=[az], y=[el])
 
-    def on_point_clicked(self, plot, points):
-        # Legacy/Scatter click
-        pass
-
     def on_load_music(self):
         fname, _ = QFileDialog.getOpenFileName(
             self, tr("Open Music File"), "", "Audio Files (*.wav *.mp3 *.flac *.ogg);;All Files (*)"


### PR DESCRIPTION
🎯 **What:** Removed the empty and unused `on_point_clicked` stub method from the `HRTFPlayerWidget` class in `src/gui/widgets/hrtf_player.py`.
💡 **Why:** The function was entirely dead code—it contained only a `pass` statement, was flagged as "Legacy/Scatter click" in comments, and wasn't referenced anywhere in the class or bound to any UI events. Removing it reduces noise and improves overall readability and maintainability.
✅ **Verification:** Verified safe removal by searching the entire codebase via `grep` to ensure no hidden references existed. Successfully ran related HRTF tests (`tests/logic_verification/gui/test_hrtf_player_resample.py` and `test_hrtf_dos.py`), as well as the entire pytest suite containing 604 tests without failure.
✨ **Result:** A cleaner widget class with obsolete legacy stubs removed, leaving no behavioral impact.

---
*PR created automatically by Jules for task [9518162705668331654](https://jules.google.com/task/9518162705668331654) started by @youtube-at-vach*