### PR TITLE
🧪 [Add tests for resource_path Exception fallback]

### DIFF
--- a/tests/logic_verification/core/test_utils.py
+++ b/tests/logic_verification/core/test_utils.py
@@ -141,6 +141,52 @@ class TestUtils(unittest.TestCase):
         # Vpeak
         self.assertTrue(np.isclose(utils.linear_to_amplitude(1.0, "Vpeak", gain=1.0), 1.0))
 
+    def test_resource_path_meipass(self):
+        from unittest.mock import patch
+        from src.core.utils import resource_path
+        with patch("sys._MEIPASS", "/tmp/_MEI123456", create=True):
+            self.assertEqual(resource_path("test.png"), os.path.join("/tmp/_MEI123456", "test.png"))
+
+    def test_resource_path_exception_fallback_root(self):
+        from unittest.mock import patch
+        from src.core.utils import resource_path
+
+        if hasattr(sys, '_MEIPASS'):
+            del sys._MEIPASS
+
+        with patch("os.path.abspath", return_value="/fake/root"):
+            with patch("os.path.exists", side_effect=lambda p: p == os.path.join("/fake/root", "test.png")):
+                self.assertEqual(resource_path("test.png"), os.path.join("/fake/root", "test.png"))
+
+    def test_resource_path_exception_fallback_src(self):
+        from unittest.mock import patch
+        from src.core.utils import resource_path
+
+        if hasattr(sys, '_MEIPASS'):
+            del sys._MEIPASS
+
+        with patch("os.path.abspath", return_value="/fake/root"):
+            def mock_exists(p):
+                if p == os.path.join("/fake/root", "test.png"):
+                    return False
+                if p == os.path.join("/fake/root", "src", "test.png"):
+                    return True
+                return False
+
+            with patch("os.path.exists", side_effect=mock_exists):
+                self.assertEqual(resource_path("test.png"), os.path.join("/fake/root", "src", "test.png"))
+
+    def test_resource_path_exception_fallback_not_found(self):
+        from unittest.mock import patch
+        from src.core.utils import resource_path
+
+        if hasattr(sys, '_MEIPASS'):
+            del sys._MEIPASS
+
+        with patch("os.path.abspath", return_value="/fake/root"):
+            with patch("os.path.exists", return_value=False):
+                self.assertEqual(resource_path("test.png"), os.path.join("/fake/root", "test.png"))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of test coverage for the `resource_path` function in `src/core/utils.py`, specifically the fallback logic when `sys._MEIPASS` is missing or throws an exception.
📊 **Coverage:** The tests now cover scenarios where `sys._MEIPASS` is present, absent but file exists in root, absent but file exists in `src`, and absent with file not found.
✨ **Result:** Increased test coverage and confidence in resource path resolution across development and PyInstaller environments.

---
*PR created automatically by Jules for task [8687021372613941997](https://jules.google.com/task/8687021372613941997) started by @youtube-at-vach*