### PR TITLE
⚡ Replace slow Python sum() with in-place NumPy accumulation

### DIFF
--- a/src/core/analysis.py
+++ b/src/core/analysis.py
@@ -420,7 +420,9 @@ class AudioCalc:
             E_chunk = E_base if current_len == chunk_size else E_base[:, :current_len]
             return (E_chunk @ sig_chunk) * np.exp(1j * omega * t[i])
 
-        acc_v_complex = sum((_compute_chunk(i) for i in range(0, N, chunk_size)), np.zeros(K, dtype=np.complex128))
+        acc_v_complex = np.zeros(K, dtype=np.complex128)
+        for i in range(0, N, chunk_size):
+            acc_v_complex += _compute_chunk(i)
 
         sig_s = acc_v_complex.imag
         sig_c = acc_v_complex.real

--- a/tests/benchmarks/benchmark_coarse_search.py
+++ b/tests/benchmarks/benchmark_coarse_search.py
@@ -1,0 +1,41 @@
+import time
+import numpy as np
+import sys
+import os
+
+# Adjust path to find src
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../")))
+
+from src.core.analysis import AudioCalc
+
+def benchmark_coarse_search():
+    sample_rate = 48000
+    duration = 1.0 # 1 second
+    N = int(sample_rate * duration)
+    t = np.arange(N) / sample_rate
+
+    # Generate test signal
+    true_freq = 1000.0
+    amplitude = 1.0
+    signal = amplitude * np.sin(2 * np.pi * true_freq * t)
+
+    # Grid search parameters
+    grid = np.linspace(900.0, 1100.0, 200) # 200 frequencies
+
+    # Warm up
+    print("Warming up...")
+    AudioCalc._perform_coarse_search(signal, t, grid)
+
+    iterations = 50
+    start_time = time.perf_counter()
+
+    for _ in range(iterations):
+        AudioCalc._perform_coarse_search(signal, t, grid)
+
+    end_time = time.perf_counter()
+    avg_time = (end_time - start_time) / iterations
+
+    print(f"Average execution time for _perform_coarse_search: {avg_time * 1000:.2f} ms")
+
+if __name__ == "__main__":
+    benchmark_coarse_search()

--- a/tests/benchmarks/benchmark_sum.py
+++ b/tests/benchmarks/benchmark_sum.py
@@ -1,0 +1,26 @@
+import time
+import numpy as np
+
+def test_sum():
+    K = 100
+    N_chunks = 1000
+
+    def get_chunk():
+        return np.ones(K, dtype=np.complex128)
+
+    start = time.perf_counter()
+    for _ in range(100):
+        sum((get_chunk() for _ in range(N_chunks)), np.zeros(K, dtype=np.complex128))
+    t1 = time.perf_counter() - start
+
+    start = time.perf_counter()
+    for _ in range(100):
+        res2 = np.zeros(K, dtype=np.complex128)
+        for _ in range(N_chunks):
+            res2 += get_chunk()
+    t2 = time.perf_counter() - start
+
+    print(f"sum(): {t1:.4f}s")
+    print(f"+= loop: {t2:.4f}s")
+
+test_sum()


### PR DESCRIPTION
💡 **What:** Replaced the Python generator expression inside `sum()` with a standard `for` loop and in-place addition (`+=`) for `acc_v_complex` in `src/core/analysis.py`.
🎯 **Why:** Python's built-in `sum()` function is famously slow for accumulating NumPy arrays because it performs O(N) memory allocations, creating a new intermediate NumPy array on every single iteration. Using a pre-allocated array and in-place addition correctly uses NumPy memory optimizations and prevents this overhead.
📊 **Measured Improvement:** Measured by the newly added benchmark `tests/benchmarks/benchmark_coarse_search.py`. The time for `_perform_coarse_search` improved slightly from ~163ms to ~161ms. In isolated synthetic benchmarks (`tests/benchmarks/benchmark_sum.py`), replacing `sum()` with `+=` accumulation provides roughly a ~10% performance gain over many loops.

---
*PR created automatically by Jules for task [8830766008175554642](https://jules.google.com/task/8830766008175554642) started by @youtube-at-vach*