### PR TITLE
[codex] Add subtle sidebar indicators for active modules

### DIFF
--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -4,6 +4,7 @@ import time
 from typing import Optional
 
 from PyQt6.QtCore import QTimer
+from PyQt6.QtGui import QPalette
 from PyQt6.QtWidgets import (
     QApplication,
     QComboBox,
@@ -133,6 +134,17 @@ def _load_welcome_widget_class():
 
 
 class MainWindow(QMainWindow):
+    _ACTIVE_STATE_ATTRS = (
+        "is_running",
+        "is_playing",
+        "is_recording",
+        "rotation_active",
+        "analysis_active",
+        "capture_active",
+        "_play_active",
+        "_cal_active",
+    )
+
     def __init__(self, enable_experimental: bool = False):
         super().__init__()
         self.enable_experimental = enable_experimental
@@ -279,6 +291,7 @@ class MainWindow(QMainWindow):
 
         self.sidebar.currentRowChanged.connect(self.on_tool_selected)
         layout.addWidget(self.sidebar)
+        self._refresh_sidebar_activity_indicators()
 
     def _init_content_area(self, layout):
         """Initialize the central stacked widget content area."""
@@ -530,12 +543,56 @@ class MainWindow(QMainWindow):
 
         # Clients
         self.clients_label.setText(tr("Clients: {0}").format(status["active_clients"]))
+        self._refresh_sidebar_activity_indicators()
 
         # Check for Offline Mode change
         is_offline = status["offline_mode"]
         if is_offline != self._last_offline_mode:
             self._update_output_destination_ui_for_mode(is_offline)
             self._last_offline_mode = is_offline
+
+    def _module_is_active(self, module) -> bool:
+        if module is None:
+            return False
+
+        for attr_name in self._ACTIVE_STATE_ATTRS:
+            if bool(getattr(module, attr_name, False)):
+                return True
+
+        return False
+
+    def _build_module_activity_tooltip(self, module_index: int) -> str:
+        key = self._module_keys[module_index]
+        parts = [tr(key)]
+
+        if self._module_is_active(self.modules[module_index]):
+            parts.append(tr("ACTIVE"))
+
+        wrapper = self.module_widgets[module_index]
+        if wrapper is not None and getattr(wrapper, "is_detached", False):
+            parts.append(tr("Widget is detached in a separate window."))
+
+        return "\n".join(parts)
+
+    def _refresh_sidebar_activity_indicators(self):
+        if not hasattr(self, "sidebar"):
+            return
+
+        default_brush = self.sidebar.palette().brush(QPalette.ColorRole.Text)
+        active_brush = self.sidebar.palette().brush(QPalette.ColorRole.Highlight)
+
+        for module_index, key in enumerate(self._module_keys):
+            item = self.sidebar.item(module_index + 2)
+            if item is None:
+                continue
+
+            is_active = self._module_is_active(self.modules[module_index])
+            font = item.font()
+            font.setBold(is_active)
+            item.setFont(font)
+            item.setForeground(active_brush if is_active else default_brush)
+            item.setToolTip(self._build_module_activity_tooltip(module_index))
+            item.setText(tr(key))
 
     def _get_engine_output_destination(self):
         if self.audio_engine.loopback:

--- a/tests/logic_verification/gui/test_main_window_activity.py
+++ b/tests/logic_verification/gui/test_main_window_activity.py
@@ -1,0 +1,71 @@
+from PyQt6.QtGui import QPalette
+from PyQt6.QtWidgets import QListWidget
+
+from src.gui.main_window import MainWindow
+
+
+class _DummyModule:
+    def __init__(self, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+class _DummyWrapper:
+    def __init__(self, is_detached=False):
+        self.is_detached = is_detached
+
+
+def _build_window_stub(qtbot):
+    window = MainWindow.__new__(MainWindow)
+    window._module_keys = ["Signal Generator", "Recorder / Player"]
+    window.modules = [None, None]
+    window.module_widgets = [None, None]
+    window.sidebar = QListWidget()
+    window.sidebar.addItem("Welcome")
+    window.sidebar.addItem("Settings")
+    window.sidebar.addItem("Signal Generator")
+    window.sidebar.addItem("Recorder / Player")
+    qtbot.addWidget(window.sidebar)
+    return window
+
+
+def test_module_is_active_supports_nonstandard_flags(qtbot):
+    window = _build_window_stub(qtbot)
+
+    assert window._module_is_active(_DummyModule(is_playing=True))
+    assert window._module_is_active(_DummyModule(is_recording=True))
+    assert window._module_is_active(_DummyModule(rotation_active=True))
+    assert not window._module_is_active(_DummyModule())
+
+
+def test_refresh_sidebar_activity_indicators_updates_visuals_and_tooltips(qtbot):
+    window = _build_window_stub(qtbot)
+    window.modules[0] = _DummyModule(is_playing=True)
+    window.modules[1] = _DummyModule(is_recording=True)
+    window.module_widgets[1] = _DummyWrapper(is_detached=True)
+
+    window._refresh_sidebar_activity_indicators()
+
+    active_item = window.sidebar.item(2)
+    detached_item = window.sidebar.item(3)
+    default_brush = window.sidebar.palette().brush(QPalette.ColorRole.Text)
+    active_brush = window.sidebar.palette().brush(QPalette.ColorRole.Highlight)
+
+    assert active_item.font().bold()
+    assert active_item.foreground().color() == active_brush.color()
+    assert "ACTIVE" in active_item.toolTip()
+
+    assert detached_item.font().bold()
+    assert detached_item.foreground().color() == active_brush.color()
+    assert "ACTIVE" in detached_item.toolTip()
+    assert "detached" in detached_item.toolTip().lower()
+
+    window.modules[0] = _DummyModule()
+    window.modules[1] = _DummyModule()
+    window.module_widgets[1] = _DummyWrapper(is_detached=False)
+
+    window._refresh_sidebar_activity_indicators()
+
+    inactive_item = window.sidebar.item(2)
+    assert not inactive_item.font().bold()
+    assert inactive_item.foreground().color() == default_brush.color()


### PR DESCRIPTION
## Summary
- add subtle sidebar activity indicators for modules with active runtime state
- detect activity across existing module-specific state flags such as `is_running`, `is_playing`, and `is_recording`
- add GUI coverage for sidebar styling and tooltip updates

## Why
The main window already showed the number of active clients, but it was hard to tell which module was currently active. This change keeps the sidebar visually quiet while still making active modules easy to spot.

## User Impact
Active modules are now highlighted in the sidebar with accent-colored bold text. Hovering a module also shows whether it is active and whether its widget is detached into a separate window.

## Validation
- `./.venv/bin/python -m pytest -q tests/logic_verification/gui/test_main_window_activity.py`
- `./.venv/bin/python -m pytest -q tests/logic_verification/gui/widgets/test_welcome.py`
- `./.venv/bin/ruff check src/gui/main_window.py tests/logic_verification/gui/test_main_window_activity.py`