### PR TITLE
📝 [docs improvement] Update Dithering Bit Depth options to include 8-bit

### DIFF
--- a/docs/widgets/settings.en.md
+++ b/docs/widgets/settings.en.md
@@ -56,7 +56,7 @@ Selects the input and output devices. Previous settings have been split into tab
 * **Buffer Size**: Actual size of the audio buffer.
 * **Input/Output Channels**: Selects the channel mode (Stereo, Left, Right).
 * **Enable Dithering (TPDF)**: Adds dither to the output signal to reduce quantization distortion.
-* **Dithering Bit Depth**: Selects the bit depth for dithering application.
+* **Dithering Bit Depth**: Selects the bit depth for dithering application (8-bit, 16-bit, 24-bit).
 
 ## Calibration
 

--- a/docs/widgets/settings.md
+++ b/docs/widgets/settings.md
@@ -56,7 +56,7 @@ FFT（高速フーリエ変換）の処理速度を向上させるための最�
 * **Buffer Size**: 実際のオーディオバッファのサイズです。
 * **Input/Output Channels**: チャンネルモードを選択します（Stereo, Left, Right）。
 * **Enable Dithering (TPDF)**: 出力信号に量子化歪み軽減のためのディザを付加します。
-* **Dithering Bit Depth**: ディザリングを適用するビット深度を選択します。
+* **Dithering Bit Depth**: ディザリングを適用するビット深度（8-bit, 16-bit, 24-bit）を選択します。
 
 ## Calibration (キャリブレーション)
 


### PR DESCRIPTION
🎯 **What:**
Updated `docs/widgets/settings.md` and `docs/widgets/settings.en.md` to mention that the "Dithering Bit Depth" setting now supports 8-bit, 16-bit, and 24-bit options.

💡 **Why:**
A recent PR added 8-bit dithering support to the application, but the documentation for the settings widget lacked the specific options. This update ensures that the documentation accurately reflects the application's functionality.

---
*PR created automatically by Jules for task [17419480251596991112](https://jules.google.com/task/17419480251596991112) started by @youtube-at-vach*