### PR TITLE
Merge download site into the docs Pages deploy

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -14,13 +14,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
-      - name: Configure Git Credentials
-        run: |
-          git config user.name github-actions[bot]
-          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
       - uses: actions/setup-python@v6
         with:
           python-version: 3.x
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: download-site/package-lock.json
       - run: echo "cache_id=$(date --utc '+%V')" >> "$GITHUB_ENV" 
       - uses: actions/cache@v5
         with:
@@ -28,5 +29,23 @@ jobs:
           path: .cache
           restore-keys: |
             mkdocs-material-
-      - run: pip install -r requirements-docs.txt
-      - run: mkdocs gh-deploy --force
+      - name: Install docs dependencies
+        run: pip install -r requirements-docs.txt
+      - name: Install download site dependencies
+        working-directory: download-site
+        run: npm ci
+      - name: Build download site
+        working-directory: download-site
+        run: npm run build
+      - name: Build docs
+        run: mkdocs build
+      - name: Merge download site into Pages output
+        run: |
+          mkdir -p site/download
+          cp -R download-site/dist/. site/download/
+      - name: Deploy combined site to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site
+          publish_branch: gh-pages

--- a/.github/workflows/deploy_download_site.yml
+++ b/.github/workflows/deploy_download_site.yml
@@ -1,4 +1,4 @@
-name: Deploy Download Site
+name: Validate Download Site
 on:
   push:
     branches:
@@ -11,10 +11,8 @@ permissions:
   contents: read
 
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - uses: actions/checkout@v4
 
@@ -22,6 +20,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+          cache: npm
+          cache-dependency-path: download-site/package-lock.json
 
       - name: Install Dependencies
         working-directory: download-site
@@ -30,11 +30,3 @@ jobs:
       - name: Build
         working-directory: download-site
         run: npm run build
-
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./download-site/dist
-          publish_branch: gh-pages-download
-          destination_dir: download


### PR DESCRIPTION
## Summary
- Build `download-site` as part of the docs deployment workflow
- Publish docs and download assets together to the single `gh-pages` branch
- Convert the separate download-site workflow into build-only validation

## Testing
- `npm run build` in `download-site`
- `mkdocs build`
- Not run (not requested): unit tests or UI tests