### PR TITLE
Add download variant selectors for macOS and Windows

### DIFF
--- a/download-site/index.html
+++ b/download-site/index.html
@@ -35,12 +35,14 @@
               <div class="btn-text">
                 <span class="btn-title">Download for <span id="main-os-name">macOS</span></span>
                 <span class="btn-version" id="main-version">Loading...</span>
+                <span class="btn-variant" id="main-variant"></span>
               </div>
             </button>
             <div class="aux-info">
               <span class="file-size" id="main-size"></span>
               <p class="desc">高精度なオーディオ分析と測定を、あなたのPCで。</p>
             </div>
+            <div class="variant-picker" id="variant-picker" hidden></div>
           </div>
 
           <!-- Other OS Options -->

--- a/download-site/main.js
+++ b/download-site/main.js
@@ -1,26 +1,55 @@
 const FALLBACK_VERSION = 'v0.6.3';
 const RELEASE_BASE_URL = 'https://github.com/youtube-at-vach/MeasureLab/releases/download';
 let currentVersion = FALLBACK_VERSION;
+let currentVariantKey = null;
 
 // OSに応じた情報
 const osData = {
   macOS: {
     name: 'macOS',
     icon: '🍎',
-    size: '約 90 MB',
-    assetName: 'MeasureLab-{tag}-macos-arm64.dmg'
+    defaultVariant: 'arm64',
+    variants: {
+      arm64: {
+        label: 'Apple Silicon',
+        size: '約 90 MB',
+        assetName: 'MeasureLab-{tag}-macos-arm64.dmg'
+      },
+      x64: {
+        label: 'Intel',
+        size: '約 90 MB',
+        assetName: 'MeasureLab-{tag}-macos-x64.dmg'
+      }
+    }
   },
   Windows: {
     name: 'Windows',
     icon: '🪟',
-    size: '約 120 MB',
-    assetName: 'MeasureLab-{tag}-windows-x64-onefile.zip'
+    defaultVariant: 'onedir',
+    variants: {
+      onedir: {
+        label: '通常版 (onedir)',
+        size: '約 120 MB',
+        assetName: 'MeasureLab-{tag}-windows-x64-onedir.zip'
+      },
+      onefile: {
+        label: '単一EXE版 (onefile)',
+        size: '約 120 MB',
+        assetName: 'MeasureLab-{tag}-windows-x64-onefile.zip'
+      }
+    }
   },
   Linux: {
     name: 'Linux',
     icon: '🐧',
-    size: '約 150 MB',
-    assetName: 'MeasureLab-{tag}-linux-x86_64.AppImage'
+    defaultVariant: 'appimage',
+    variants: {
+      appimage: {
+        label: 'AppImage',
+        size: '約 150 MB',
+        assetName: 'MeasureLab-{tag}-linux-x86_64.AppImage'
+      }
+    }
   }
 };
 
@@ -57,6 +86,59 @@ function buildReleaseUrl(versionTag, assetNameTemplate) {
   return `${RELEASE_BASE_URL}/${versionTag}/${assetName}`;
 }
 
+function getVariantEntries(osName) {
+  const data = osData[osName];
+  if (!data) {
+    return [];
+  }
+
+  return Object.entries(data.variants);
+}
+
+function selectVariant(osName, requestedVariantKey) {
+  const data = osData[osName];
+  if (!data) {
+    return null;
+  }
+
+  if (requestedVariantKey && data.variants[requestedVariantKey]) {
+    return requestedVariantKey;
+  }
+
+  return data.defaultVariant;
+}
+
+function renderVariantPicker(osName) {
+  const picker = document.getElementById('variant-picker');
+  const variantEntries = getVariantEntries(osName);
+  picker.innerHTML = '';
+
+  if (variantEntries.length <= 1) {
+    picker.hidden = true;
+    return;
+  }
+
+  variantEntries.forEach(([variantKey, variant]) => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'variant-btn';
+    button.textContent = variant.label;
+    button.dataset.variant = variantKey;
+
+    if (variantKey === currentVariantKey) {
+      button.classList.add('is-active');
+    }
+
+    button.addEventListener('click', () => {
+      updateMainDisplay(osName, variantKey);
+    });
+
+    picker.appendChild(button);
+  });
+
+  picker.hidden = false;
+}
+
 // ユーザーのOSを判定
 function detectOS() {
   const userAgent = window.navigator.userAgent;
@@ -72,15 +154,19 @@ function detectOS() {
 }
 
 // 画面の情報を更新
-function updateMainDisplay(osName) {
+function updateMainDisplay(osName, requestedVariantKey = null) {
   const data = osData[osName];
   if (!data) return;
-  const downloadUrl = buildReleaseUrl(currentVersion, data.assetName);
+  currentVariantKey = selectVariant(osName, requestedVariantKey);
+  const variant = data.variants[currentVariantKey];
+  const downloadUrl = buildReleaseUrl(currentVersion, variant.assetName);
 
   document.getElementById('main-os-icon').textContent = data.icon;
   document.getElementById('main-os-name').textContent = data.name;
   document.getElementById('main-version').textContent = currentVersion;
-  document.getElementById('main-size').textContent = data.size;
+  document.getElementById('main-variant').textContent = variant.label;
+  document.getElementById('main-size').textContent = variant.size;
+  renderVariantPicker(osName);
   
   // メインボタンのリンク設定
   const mainBtn = document.getElementById('main-download-btn');

--- a/download-site/style.css
+++ b/download-site/style.css
@@ -213,6 +213,11 @@ main {
   opacity: 0.8;
 }
 
+.btn-variant {
+  font-size: 0.85rem;
+  opacity: 0.75;
+}
+
 .pulse {
   animation: pulse-shadow 2s infinite;
 }
@@ -233,6 +238,37 @@ main {
 .aux-info .desc {
   margin-top: 0.5rem;
   color: #cbd5e1;
+}
+
+.variant-picker {
+  margin-top: 1rem;
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.variant-btn {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--glass-border);
+  color: var(--text-main);
+  padding: 0.65rem 1rem;
+  border-radius: 999px;
+  font-family: inherit;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.variant-btn:hover {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.variant-btn.is-active {
+  background: rgba(129, 140, 248, 0.2);
+  border-color: rgba(165, 180, 252, 0.7);
+  color: #ffffff;
 }
 
 /* Secondary Buttons */
@@ -316,6 +352,10 @@ footer {
   
   .btn-large {
     padding: 1rem 1.5rem;
+  }
+
+  .variant-picker {
+    width: 100%;
   }
   
   .os-buttons {


### PR DESCRIPTION
## Summary
- Add macOS architecture selection for Apple Silicon and Intel builds
- Make Windows default to the onedir package, with onefile still selectable
- Update download links and styling to reflect the active variant

## Testing
- Not run (not requested)