### PR TITLE
Add download requirements summary to the site

### DIFF
--- a/download-site/index.html
+++ b/download-site/index.html
@@ -60,6 +60,12 @@
               </button>
             </div>
           </div>
+
+          <section class="requirements" aria-labelledby="requirements-title">
+            <h3 id="requirements-title">ダウンロード前に確認</h3>
+            <p class="requirements-lead" id="requirements-lead"></p>
+            <ul class="requirements-list" id="requirements-list"></ul>
+          </section>
         </section>
       </main>
 

--- a/download-site/main.js
+++ b/download-site/main.js
@@ -3,6 +3,30 @@ const RELEASE_BASE_URL = 'https://github.com/youtube-at-vach/MeasureLab/releases
 let currentVersion = FALLBACK_VERSION;
 let currentVariantKey = null;
 
+const requirementData = {
+  macOS: {
+    lead: 'macOS 13以降が必要です。お使いのMacに合うDMGを選んでください。',
+    items: [
+      'Apple Silicon は arm64、Intel Mac は x64 を選択してください。',
+      '未署名アプリのため、初回起動時は右クリックの「開く」または「システム設定 > プライバシーとセキュリティ」から許可が必要な場合があります。'
+    ]
+  },
+  Windows: {
+    lead: 'Windows 10 / 11 向けのZIP版です。',
+    items: [
+      'ZIP を展開して MeasureLab.exe を実行してください。',
+      '通常版 (onedir) と単一EXE版 (onefile) を選べます。'
+    ]
+  },
+  Linux: {
+    lead: 'Linux 版は x86_64 向け AppImage です。',
+    items: [
+      '初回起動前に chmod +x で実行権限を付与してください。',
+      '位相連続性が重要な測定では、環境に応じて JACK / PipeWire の利用が推奨されます。'
+    ]
+  }
+};
+
 // OSに応じた情報
 const osData = {
   macOS: {
@@ -139,6 +163,24 @@ function renderVariantPicker(osName) {
   picker.hidden = false;
 }
 
+function renderRequirements(osName) {
+  const requirement = requirementData[osName];
+  if (!requirement) {
+    return;
+  }
+
+  const lead = document.getElementById('requirements-lead');
+  const list = document.getElementById('requirements-list');
+  lead.textContent = requirement.lead;
+  list.innerHTML = '';
+
+  requirement.items.forEach((item) => {
+    const li = document.createElement('li');
+    li.textContent = item;
+    list.appendChild(li);
+  });
+}
+
 // ユーザーのOSを判定
 function detectOS() {
   const userAgent = window.navigator.userAgent;
@@ -167,6 +209,7 @@ function updateMainDisplay(osName, requestedVariantKey = null) {
   document.getElementById('main-variant').textContent = variant.label;
   document.getElementById('main-size').textContent = variant.size;
   renderVariantPicker(osName);
+  renderRequirements(osName);
   
   // メインボタンのリンク設定
   const mainBtn = document.getElementById('main-download-btn');

--- a/download-site/style.css
+++ b/download-site/style.css
@@ -319,6 +319,42 @@ main {
   border-color: rgba(255, 255, 255, 0.2);
 }
 
+.requirements {
+  width: 100%;
+  margin-top: 2rem;
+  padding-top: 2rem;
+  border-top: 1px solid var(--glass-border);
+}
+
+.requirements h3 {
+  font-size: 1rem;
+  color: var(--text-muted);
+  margin-bottom: 0.75rem;
+  font-weight: 500;
+}
+
+.requirements-lead {
+  color: #e2e8f0;
+  font-size: 0.95rem;
+  margin-bottom: 0.9rem;
+}
+
+.requirements-list {
+  list-style: none;
+  display: grid;
+  gap: 0.7rem;
+}
+
+.requirements-list li {
+  color: #cbd5e1;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  padding: 0.85rem 1rem;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
 /* Footer */
 footer {
   margin-top: 4rem;
@@ -356,6 +392,10 @@ footer {
 
   .variant-picker {
     width: 100%;
+  }
+
+  .requirements-list li {
+    font-size: 0.92rem;
   }
   
   .os-buttons {


### PR DESCRIPTION
## Summary
- Add a compact pre-download requirements section to the download page
- Show OS-specific notes for macOS, Windows, and Linux based on the selected download
- Keep the page lightweight while surfacing macOS 13+ and Linux AppImage requirements before download

## Testing
- Not run (not requested)