### PR TITLE
Update download site with English localization

### DIFF
--- a/download-site/index.html
+++ b/download-site/index.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/MeasureLab/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>MeasureLab - オーディオ測定ツール</title>
+    <title>MeasureLab - Audio Measurement Tool</title>
     <!-- SEO Meta Tags -->
-    <meta name="description" content="MeasureLabは高精度なオーディオ分析と測定を行うためのオープンソースツールです。macOS、Windows、Linuxに対応。" />
+    <meta name="description" content="MeasureLab is an open-source tool for high-precision audio analysis and measurement on macOS, Windows, and Linux." />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;800&family=Noto+Sans+JP:wght@400;500;700;900&display=swap" rel="stylesheet">
@@ -22,8 +22,12 @@
     
     <div class="container">
       <header>
+        <div class="lang-switch" aria-label="Language selector">
+          <button type="button" class="lang-btn" data-lang="ja">JA</button>
+          <button type="button" class="lang-btn" data-lang="en">EN</button>
+        </div>
         <h1 class="logo">MeasureLab</h1>
-        <p class="subtitle">オーディオ測定ツール</p>
+        <p class="subtitle" data-i18n="subtitle">オーディオ測定ツール</p>
       </header>
       
       <main>
@@ -33,21 +37,21 @@
             <button id="main-download-btn" class="btn-large pulse">
               <span class="os-icon" id="main-os-icon">🍎</span>
               <div class="btn-text">
-                <span class="btn-title">Download for <span id="main-os-name">macOS</span></span>
+                <span class="btn-title"><span data-i18n="downloadFor">Download for</span> <span id="main-os-name">macOS</span></span>
                 <span class="btn-version" id="main-version">Loading...</span>
                 <span class="btn-variant" id="main-variant"></span>
               </div>
             </button>
             <div class="aux-info">
               <span class="file-size" id="main-size"></span>
-              <p class="desc">高精度なオーディオ分析と測定を、あなたのPCで。</p>
+              <p class="desc" data-i18n="heroDescription">高精度なオーディオ分析と測定を、あなたのPCで。</p>
             </div>
             <div class="variant-picker" id="variant-picker" hidden></div>
           </div>
 
           <!-- Other OS Options -->
           <div class="other-os">
-            <h3>その他のプラットフォーム</h3>
+            <h3 data-i18n="otherPlatforms">その他のプラットフォーム</h3>
             <div class="os-buttons">
               <button class="btn-small" data-os="macOS">
                 <span class="os-icon">🍎</span> macOS
@@ -62,7 +66,7 @@
           </div>
 
           <section class="requirements" aria-labelledby="requirements-title">
-            <h3 id="requirements-title">ダウンロード前に確認</h3>
+            <h3 id="requirements-title" data-i18n="requirementsTitle">ダウンロード前に確認</h3>
             <p class="requirements-lead" id="requirements-lead"></p>
             <ul class="requirements-list" id="requirements-list"></ul>
           </section>
@@ -70,7 +74,7 @@
       </main>
 
       <footer>
-        <a href="/MeasureLab/" class="footer-link">📖 ドキュメント (Docs)</a>
+        <a href="/MeasureLab/" class="footer-link">📖 <span data-i18n="docsLink">ドキュメント</span></a>
         <a href="https://github.com/youtube-at-vach/MeasureLab" class="footer-link">🐙 GitHub</a>
       </footer>
     </div>

--- a/download-site/main.js
+++ b/download-site/main.js
@@ -1,81 +1,191 @@
 const FALLBACK_VERSION = 'v0.6.3';
 const RELEASE_BASE_URL = 'https://github.com/youtube-at-vach/MeasureLab/releases/download';
+const SUPPORTED_LANGS = ['ja', 'en'];
+
 let currentVersion = FALLBACK_VERSION;
 let currentVariantKey = null;
+let currentLang = 'ja';
+let currentOsName = 'macOS';
+let versionLoaded = false;
 
-const requirementData = {
-  macOS: {
-    lead: 'macOS 13以降が必要です。お使いのMacに合うDMGを選んでください。',
-    items: [
-      'Apple Silicon は arm64、Intel Mac は x64 を選択してください。',
-      '未署名アプリのため、初回起動時は右クリックの「開く」または「システム設定 > プライバシーとセキュリティ」から許可が必要な場合があります。'
-    ]
+const translations = {
+  ja: {
+    htmlLang: 'ja',
+    title: 'MeasureLab - オーディオ測定ツール',
+    metaDescription:
+      'MeasureLabは高精度なオーディオ分析と測定を行うためのオープンソースツールです。macOS、Windows、Linuxに対応。',
+    subtitle: 'オーディオ測定ツール',
+    downloadFor: 'Download for',
+    heroDescription: '高精度なオーディオ分析と測定を、あなたのPCで。',
+    otherPlatforms: 'その他のプラットフォーム',
+    requirementsTitle: 'ダウンロード前に確認',
+    docsLink: 'ドキュメント',
+    loading: '読み込み中...',
+    requirementData: {
+      macOS: {
+        lead: 'macOS 13以降が必要です。お使いのMacに合うDMGを選んでください。',
+        items: [
+          'Apple Silicon は arm64、Intel Mac は x64 を選択してください。',
+          '未署名アプリのため、初回起動時は右クリックの「開く」または「システム設定 > プライバシーとセキュリティ」から許可が必要な場合があります。'
+        ]
+      },
+      Windows: {
+        lead: 'Windows 10 / 11 向けのZIP版です。',
+        items: [
+          'ZIP を展開して MeasureLab.exe を実行してください。',
+          '通常版 (onedir) と単一EXE版 (onefile) を選べます。'
+        ]
+      },
+      Linux: {
+        lead: 'Linux 版は x86_64 向け AppImage です。',
+        items: [
+          '初回起動前に chmod +x で実行権限を付与してください。',
+          '位相連続性が重要な測定では、環境に応じて JACK / PipeWire の利用が推奨されます。'
+        ]
+      }
+    },
+    osData: {
+      macOS: {
+        name: 'macOS',
+        icon: '🍎',
+        defaultVariant: 'arm64',
+        variants: {
+          arm64: {
+            label: 'Apple Silicon',
+            size: '約 90 MB',
+            assetName: 'MeasureLab-{tag}-macos-arm64.dmg'
+          },
+          x64: {
+            label: 'Intel',
+            size: '約 90 MB',
+            assetName: 'MeasureLab-{tag}-macos-x64.dmg'
+          }
+        }
+      },
+      Windows: {
+        name: 'Windows',
+        icon: '🪟',
+        defaultVariant: 'onedir',
+        variants: {
+          onedir: {
+            label: '通常版 (onedir)',
+            size: '約 120 MB',
+            assetName: 'MeasureLab-{tag}-windows-x64-onedir.zip'
+          },
+          onefile: {
+            label: '単一EXE版 (onefile)',
+            size: '約 120 MB',
+            assetName: 'MeasureLab-{tag}-windows-x64-onefile.zip'
+          }
+        }
+      },
+      Linux: {
+        name: 'Linux',
+        icon: '🐧',
+        defaultVariant: 'appimage',
+        variants: {
+          appimage: {
+            label: 'AppImage',
+            size: '約 150 MB',
+            assetName: 'MeasureLab-{tag}-linux-x86_64.AppImage'
+          }
+        }
+      }
+    }
   },
-  Windows: {
-    lead: 'Windows 10 / 11 向けのZIP版です。',
-    items: [
-      'ZIP を展開して MeasureLab.exe を実行してください。',
-      '通常版 (onedir) と単一EXE版 (onefile) を選べます。'
-    ]
-  },
-  Linux: {
-    lead: 'Linux 版は x86_64 向け AppImage です。',
-    items: [
-      '初回起動前に chmod +x で実行権限を付与してください。',
-      '位相連続性が重要な測定では、環境に応じて JACK / PipeWire の利用が推奨されます。'
-    ]
+  en: {
+    htmlLang: 'en',
+    title: 'MeasureLab - Audio Measurement Tool',
+    metaDescription:
+      'MeasureLab is an open-source tool for high-precision audio analysis and measurement on macOS, Windows, and Linux.',
+    subtitle: 'Audio Measurement Tool',
+    downloadFor: 'Download for',
+    heroDescription: 'High-precision audio analysis and measurement on your computer.',
+    otherPlatforms: 'Other platforms',
+    requirementsTitle: 'Before you download',
+    docsLink: 'Documentation',
+    loading: 'Loading...',
+    requirementData: {
+      macOS: {
+        lead: 'Requires macOS 13 or later. Choose the DMG that matches your Mac.',
+        items: [
+          'Select arm64 for Apple Silicon and x64 for Intel Macs.',
+          'Because the app is unsigned, first launch may require using "Open" from the context menu or allowing it in System Settings > Privacy & Security.'
+        ]
+      },
+      Windows: {
+        lead: 'ZIP package for Windows 10 / 11.',
+        items: [
+          'Extract the ZIP archive and run MeasureLab.exe.',
+          'You can choose between the standard build (onedir) and the single EXE build (onefile).'
+        ]
+      },
+      Linux: {
+        lead: 'The Linux build is an x86_64 AppImage.',
+        items: [
+          'Run chmod +x before the first launch to make it executable.',
+          'For measurements where phase continuity matters, JACK / PipeWire may be recommended depending on your environment.'
+        ]
+      }
+    },
+    osData: {
+      macOS: {
+        name: 'macOS',
+        icon: '🍎',
+        defaultVariant: 'arm64',
+        variants: {
+          arm64: {
+            label: 'Apple Silicon',
+            size: '~90 MB',
+            assetName: 'MeasureLab-{tag}-macos-arm64.dmg'
+          },
+          x64: {
+            label: 'Intel',
+            size: '~90 MB',
+            assetName: 'MeasureLab-{tag}-macos-x64.dmg'
+          }
+        }
+      },
+      Windows: {
+        name: 'Windows',
+        icon: '🪟',
+        defaultVariant: 'onedir',
+        variants: {
+          onedir: {
+            label: 'Standard (onedir)',
+            size: '~120 MB',
+            assetName: 'MeasureLab-{tag}-windows-x64-onedir.zip'
+          },
+          onefile: {
+            label: 'Single EXE (onefile)',
+            size: '~120 MB',
+            assetName: 'MeasureLab-{tag}-windows-x64-onefile.zip'
+          }
+        }
+      },
+      Linux: {
+        name: 'Linux',
+        icon: '🐧',
+        defaultVariant: 'appimage',
+        variants: {
+          appimage: {
+            label: 'AppImage',
+            size: '~150 MB',
+            assetName: 'MeasureLab-{tag}-linux-x86_64.AppImage'
+          }
+        }
+      }
+    }
   }
 };
 
-// OSに応じた情報
-const osData = {
-  macOS: {
-    name: 'macOS',
-    icon: '🍎',
-    defaultVariant: 'arm64',
-    variants: {
-      arm64: {
-        label: 'Apple Silicon',
-        size: '約 90 MB',
-        assetName: 'MeasureLab-{tag}-macos-arm64.dmg'
-      },
-      x64: {
-        label: 'Intel',
-        size: '約 90 MB',
-        assetName: 'MeasureLab-{tag}-macos-x64.dmg'
-      }
-    }
-  },
-  Windows: {
-    name: 'Windows',
-    icon: '🪟',
-    defaultVariant: 'onedir',
-    variants: {
-      onedir: {
-        label: '通常版 (onedir)',
-        size: '約 120 MB',
-        assetName: 'MeasureLab-{tag}-windows-x64-onedir.zip'
-      },
-      onefile: {
-        label: '単一EXE版 (onefile)',
-        size: '約 120 MB',
-        assetName: 'MeasureLab-{tag}-windows-x64-onefile.zip'
-      }
-    }
-  },
-  Linux: {
-    name: 'Linux',
-    icon: '🐧',
-    defaultVariant: 'appimage',
-    variants: {
-      appimage: {
-        label: 'AppImage',
-        size: '約 150 MB',
-        assetName: 'MeasureLab-{tag}-linux-x86_64.AppImage'
-      }
-    }
-  }
-};
+function getMessages() {
+  return translations[currentLang];
+}
+
+function getOsData() {
+  return getMessages().osData;
+}
 
 function normalizeVersionTag(version) {
   const trimmed = String(version ?? '').trim();
@@ -111,7 +221,7 @@ function buildReleaseUrl(versionTag, assetNameTemplate) {
 }
 
 function getVariantEntries(osName) {
-  const data = osData[osName];
+  const data = getOsData()[osName];
   if (!data) {
     return [];
   }
@@ -120,7 +230,7 @@ function getVariantEntries(osName) {
 }
 
 function selectVariant(osName, requestedVariantKey) {
-  const data = osData[osName];
+  const data = getOsData()[osName];
   if (!data) {
     return null;
   }
@@ -130,6 +240,58 @@ function selectVariant(osName, requestedVariantKey) {
   }
 
   return data.defaultVariant;
+}
+
+function getLanguageFromQuery() {
+  const params = new URLSearchParams(window.location.search);
+  const lang = params.get('lang');
+  return SUPPORTED_LANGS.includes(lang) ? lang : null;
+}
+
+function detectLanguage() {
+  const queryLang = getLanguageFromQuery();
+  if (queryLang) {
+    return queryLang;
+  }
+
+  const browserLang = String(window.navigator.language || '').toLowerCase();
+  return browserLang.startsWith('ja') ? 'ja' : 'en';
+}
+
+function syncLanguageQuery(lang) {
+  const url = new URL(window.location.href);
+  url.searchParams.set('lang', lang);
+  window.history.replaceState({}, '', url);
+}
+
+function applyStaticTranslations() {
+  const messages = getMessages();
+
+  document.documentElement.lang = messages.htmlLang;
+  document.title = messages.title;
+
+  const metaDescription = document.querySelector('meta[name="description"]');
+  if (metaDescription) {
+    metaDescription.setAttribute('content', messages.metaDescription);
+  }
+
+  document.querySelectorAll('[data-i18n]').forEach((element) => {
+    const key = element.dataset.i18n;
+    if (key && messages[key]) {
+      element.textContent = messages[key];
+    }
+  });
+
+  const versionElement = document.getElementById('main-version');
+  if (versionElement && !versionLoaded) {
+    versionElement.textContent = messages.loading;
+  }
+
+  document.querySelectorAll('.lang-btn').forEach((button) => {
+    const isActive = button.dataset.lang === currentLang;
+    button.classList.toggle('is-active', isActive);
+    button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+  });
 }
 
 function renderVariantPicker(osName) {
@@ -164,7 +326,7 @@ function renderVariantPicker(osName) {
 }
 
 function renderRequirements(osName) {
-  const requirement = requirementData[osName];
+  const requirement = getMessages().requirementData[osName];
   if (!requirement) {
     return;
   }
@@ -181,24 +343,26 @@ function renderRequirements(osName) {
   });
 }
 
-// ユーザーのOSを判定
 function detectOS() {
   const userAgent = window.navigator.userAgent;
-  let os = 'Windows'; // デフォルト
+  let os = 'Windows';
 
   if (userAgent.indexOf('Mac') !== -1) {
     os = 'macOS';
   } else if (userAgent.indexOf('Linux') !== -1 || userAgent.indexOf('X11') !== -1) {
     os = 'Linux';
   }
-  
+
   return os;
 }
 
-// 画面の情報を更新
 function updateMainDisplay(osName, requestedVariantKey = null) {
-  const data = osData[osName];
-  if (!data) return;
+  const data = getOsData()[osName];
+  if (!data) {
+    return;
+  }
+
+  currentOsName = osName;
   currentVariantKey = selectVariant(osName, requestedVariantKey);
   const variant = data.variants[currentVariantKey];
   const downloadUrl = buildReleaseUrl(currentVersion, variant.assetName);
@@ -210,34 +374,45 @@ function updateMainDisplay(osName, requestedVariantKey = null) {
   document.getElementById('main-size').textContent = variant.size;
   renderVariantPicker(osName);
   renderRequirements(osName);
-  
-  // メインボタンのリンク設定
+
   const mainBtn = document.getElementById('main-download-btn');
   mainBtn.onclick = () => {
     window.location.href = downloadUrl;
   };
 }
 
-// 初期化
-document.addEventListener('DOMContentLoaded', async () => {
-  currentVersion = await loadVersionTag();
+function setLanguage(lang, osName, requestedVariantKey = null) {
+  currentLang = SUPPORTED_LANGS.includes(lang) ? lang : 'en';
+  syncLanguageQuery(currentLang);
+  applyStaticTranslations();
+  updateMainDisplay(osName, requestedVariantKey ?? currentVariantKey);
+}
 
-  // 自動判定して表示
+document.addEventListener('DOMContentLoaded', async () => {
+  currentLang = detectLanguage();
+  applyStaticTranslations();
+
+  currentVersion = await loadVersionTag();
+  versionLoaded = true;
+
   const detectedOS = detectOS();
   updateMainDisplay(detectedOS);
 
-  // その他のOSボタンのイベントリスナー
-  const smallBtns = document.querySelectorAll('.btn-small');
-  smallBtns.forEach(btn => {
-    btn.addEventListener('click', (e) => {
-      const selectedOS = e.currentTarget.getAttribute('data-os');
+  document.querySelectorAll('.btn-small').forEach((button) => {
+    button.addEventListener('click', (event) => {
+      const selectedOS = event.currentTarget.getAttribute('data-os');
       updateMainDisplay(selectedOS);
-      
-      // クリック後、少しアニメーションをリセットして目立たせる
+
       const mainBtn = document.getElementById('main-download-btn');
       mainBtn.classList.remove('pulse');
-      void mainBtn.offsetWidth; // リフローを強制
+      void mainBtn.offsetWidth;
       mainBtn.classList.add('pulse');
+    });
+  });
+
+  document.querySelectorAll('.lang-btn').forEach((button) => {
+    button.addEventListener('click', () => {
+      setLanguage(button.dataset.lang, currentOsName, currentVariantKey);
     });
   });
 });

--- a/download-site/style.css
+++ b/download-site/style.css
@@ -96,6 +96,45 @@ body {
 header {
   text-align: center;
   margin-bottom: 4rem;
+  width: 100%;
+  position: relative;
+}
+
+.lang-switch {
+  position: absolute;
+  top: -1rem;
+  right: 0;
+  display: inline-flex;
+  gap: 0.5rem;
+  padding: 0.35rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
+.lang-btn {
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-muted);
+  font: inherit;
+  font-size: 0.9rem;
+  font-weight: 700;
+  padding: 0.45rem 0.8rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.lang-btn:hover {
+  color: var(--text-main);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.lang-btn.is-active {
+  color: #ffffff;
+  background: rgba(129, 140, 248, 0.28);
 }
 
 .logo {
@@ -378,6 +417,17 @@ footer {
 
 /* Responsive */
 @media (max-width: 600px) {
+  header {
+    margin-bottom: 3rem;
+    padding-top: 3.25rem;
+  }
+
+  .lang-switch {
+    top: 0;
+    right: 50%;
+    transform: translateX(50%);
+  }
+
   .logo {
     font-size: 3rem;
   }


### PR DESCRIPTION
## Summary
- Added EN support to the download site with browser-language detection and `?lang=` overrides.
- Localized the page title, meta description, headings, hero copy, requirements, and footer text.
- Added a simple JA/EN language toggle while preserving the selected OS and variant state.

## Testing
- Ran `npm run build` in `download-site` and confirmed the Vite production build succeeds.