### PR TITLE
Fix oscilloscope trigger sync for long timebases

### DIFF
--- a/src/gui/widgets/oscilloscope.py
+++ b/src/gui/widgets/oscilloscope.py
@@ -188,21 +188,22 @@ class Oscilloscope(MeasurementModule):
         old_data = self.input_data
         old_write_index = self.write_index
 
-        # Reallocate only on the UI thread. Keep chronological samples so trigger
-        # state does not jump when the user selects a longer timebase.
+        # Reallocate only on the UI thread. Keep the ring-buffer invariant that
+        # write_index is the logical origin (oldest sample) for _get_data_slice().
         self.buffer_size = required_size
         self.input_data = np.zeros((self.buffer_size * 2, 2), dtype=old_data.dtype)
         old_available = min(old_buffer_size, self.buffer_size)
         old_start = (old_write_index - old_available) % old_buffer_size
+        new_start = self.buffer_size - old_available
         if old_start + old_available <= old_buffer_size:
-            preserved = old_data[old_start : old_start + old_available]
+            self.input_data[new_start : new_start + old_available] = old_data[old_start : old_start + old_available]
         else:
             split = old_buffer_size - old_start
-            preserved = np.vstack((old_data[old_start:old_buffer_size], old_data[: old_available - split]))
+            self.input_data[new_start : new_start + split] = old_data[old_start:old_buffer_size]
+            self.input_data[new_start + split : new_start + old_available] = old_data[: old_available - split]
 
-        self.input_data[:old_available] = preserved
-        self.input_data[self.buffer_size : self.buffer_size + old_available] = preserved
-        self.write_index = old_available % self.buffer_size
+        self.input_data[self.buffer_size :] = self.input_data[: self.buffer_size]
+        self.write_index = 0
 
     def start_analysis(self):
         if self.is_running:
@@ -306,7 +307,7 @@ class Oscilloscope(MeasurementModule):
                 self.callback_id = None
             self.is_running = False
 
-    def _get_data_slice(self, start_offset, length, step=1):
+    def _get_data_slice(self, start_offset, length):
         """Returns a contiguous array of length samples starting at logical offset start_offset (0 = oldest)."""
         if length <= 0:
             return np.empty((0, 2))
@@ -314,7 +315,7 @@ class Oscilloscope(MeasurementModule):
         idx = (self.write_index + start_offset) % self.buffer_size
         end_idx = idx + length
 
-        return self.input_data[idx:end_idx:step].copy()
+        return self.input_data[idx:end_idx].copy()
 
     def get_display_data(self, window_duration):
         """
@@ -339,8 +340,7 @@ class Oscilloscope(MeasurementModule):
         if search_end <= 0:
             # Buffer too small for requested window, just return what we have (the last required_samples)
             start_offset = max(0, self.buffer_size - required_samples)
-            step = max(1, int(np.ceil(required_samples / self.MAX_DISPLAY_SAMPLES)))
-            return self._get_data_slice(start_offset, required_samples, step=step)
+            return self._get_data_slice(start_offset, required_samples)
 
         # Limit search to recent history to be responsive (e.g. last 50% of possible range)
         # But we need enough pre-trigger data?
@@ -375,16 +375,14 @@ class Oscilloscope(MeasurementModule):
                 self.single_shot_fired = True
                 self.single_shot_armed = False
 
-            step = max(1, int(np.ceil(required_samples / self.MAX_DISPLAY_SAMPLES)))
-            return self._get_data_slice(trigger_idx, required_samples, step=step)
+            return self._get_data_slice(trigger_idx, required_samples)
         else:
             # No trigger found
             if self.trigger_mode == "Auto":
                 # Return latest data
                 # Corresponds to last required_samples
                 start_offset = self.buffer_size - required_samples
-                step = max(1, int(np.ceil(required_samples / self.MAX_DISPLAY_SAMPLES)))
-                return self._get_data_slice(start_offset, required_samples, step=step)
+                return self._get_data_slice(start_offset, required_samples)
             else:
                 # Normal mode: return None (keep last frame)
                 return None
@@ -1245,6 +1243,8 @@ class OscilloscopeWidget(QWidget):
                 self._time_array_cache = t
                 self._time_array_cache_params = (window_duration, current_len)
 
+            display_step = max(1, int(np.ceil(current_len / self.module.MAX_DISPLAY_SAMPLES)))
+
             # Apply Filter if enabled
             sr = self.module.audio_engine.sample_rate
             if self.module.filter_type != "None":
@@ -1304,8 +1304,10 @@ class OscilloscopeWidget(QWidget):
             self.latest_data = data
             self.latest_t = t
 
-            scaled_l = data[:, 0] * float(getattr(self.module, "vscale_left", 1.0))
-            scaled_r = data[:, 1] * float(getattr(self.module, "vscale_right", 1.0))
+            plot_t = t[::display_step]
+            plot_data = data[::display_step]
+            scaled_l = plot_data[:, 0] * float(getattr(self.module, "vscale_left", 1.0))
+            scaled_r = plot_data[:, 1] * float(getattr(self.module, "vscale_right", 1.0))
 
             if self.module.persistence_mode:
                 # Update Persistence
@@ -1325,10 +1327,10 @@ class OscilloscopeWidget(QWidget):
                 rng = [[0, window_duration], [self.VIEW_Y_MIN, self.VIEW_Y_MAX]]
 
                 if self.module.show_left:
-                    self.module._accumulate_heatmap(t, scaled_l, self.module.heatmap_l, [w, h], rng, intensity)
+                    self.module._accumulate_heatmap(plot_t, scaled_l, self.module.heatmap_l, [w, h], rng, intensity)
 
                 if self.module.show_right:
-                    self.module._accumulate_heatmap(t, scaled_r, self.module.heatmap_r, [w, h], rng, intensity)
+                    self.module._accumulate_heatmap(plot_t, scaled_r, self.module.heatmap_r, [w, h], rng, intensity)
 
                 # Compose Image
                 # L = Green, R = Red
@@ -1397,13 +1399,13 @@ class OscilloscopeWidget(QWidget):
             else:
                 # Normal Mode
                 if self.module.show_left:
-                    self.curve_l.setData(t, scaled_l)
+                    self.curve_l.setData(plot_t, scaled_l)
                     self.curve_l.setVisible(True)
                 else:
                     self.curve_l.setVisible(False)
 
                 if self.module.show_right:
-                    self.curve_r.setData(t, scaled_r)
+                    self.curve_r.setData(plot_t, scaled_r)
                     self.curve_r.setVisible(True)
                 else:
                     self.curve_r.setVisible(False)
@@ -1440,7 +1442,7 @@ class OscilloscopeWidget(QWidget):
                     math_data = math_data - np.mean(math_data)
 
                 if math_data is not None and math_data.size > 0:
-                    self.curve_math.setData(t, math_data)
+                    self.curve_math.setData(plot_t, math_data[::display_step])
                     # Auto-scale Math View
                     mn, mx = np.min(math_data), np.max(math_data)
                     if mn == mx:

--- a/src/gui/widgets/oscilloscope.py
+++ b/src/gui/widgets/oscilloscope.py
@@ -43,19 +43,23 @@ logger = logging.getLogger(__name__)
 
 
 class Oscilloscope(MeasurementModule):
+    MIN_BUFFER_SIZE = 8192
+    MAX_DISPLAY_SAMPLES = 8192
     TRIGGER_SEARCH_WINDOW_SIZE = 2048
+    TRIGGER_SEARCH_FRACTION = 0.25
+    MAX_TRIGGER_SEARCH_WINDOW_SIZE = 8192
 
     def __init__(self, audio_engine: AudioEngine):
         self.audio_engine = audio_engine
         self.is_running = False
+        # Settings
+        self.timebase = 0.01  # Seconds per division (approx) -> Total view window
         # Buffer enough for low frequency analysis, but we'll display a subset
-        self.buffer_size = 8192
+        self.buffer_size = self._recommended_buffer_size(self.timebase)
         # Double the buffer size to avoid wrap-around concatenation
         self.input_data = np.zeros((self.buffer_size * 2, 2))
         self.write_index = 0
 
-        # Settings
-        self.timebase = 0.01  # Seconds per division (approx) -> Total view window
         self.gain = 1.0
         self.trigger_source = 0  # 0: Left, 1: Right
         self.trigger_mode = "Auto"  # 'Auto', 'Normal', 'Single'
@@ -150,11 +154,62 @@ class Oscilloscope(MeasurementModule):
         self.heatmap_l = np.zeros((w, h))
         self.heatmap_r = np.zeros((w, h))
 
+    def _recommended_trigger_search_window(self, required_samples):
+        adaptive_window = int(required_samples * self.TRIGGER_SEARCH_FRACTION)
+        return min(
+            max(self.TRIGGER_SEARCH_WINDOW_SIZE, adaptive_window),
+            self.MAX_TRIGGER_SEARCH_WINDOW_SIZE,
+        )
+
+    def _sample_rate_hz(self):
+        try:
+            sample_rate = int(getattr(self.audio_engine, "sample_rate", 48000))
+        except (TypeError, ValueError):
+            sample_rate = 48000
+        return max(1, sample_rate)
+
+    def _recommended_buffer_size(self, window_duration):
+        sample_rate = self._sample_rate_hz()
+        required_samples = max(1, int(window_duration * sample_rate))
+        search_window = self._recommended_trigger_search_window(required_samples)
+        return max(self.MIN_BUFFER_SIZE, required_samples + search_window)
+
+    def _ensure_buffer_capacity(self, window_duration):
+        sample_rate = self._sample_rate_hz()
+        required_samples = max(1, int(window_duration * sample_rate))
+        if self.buffer_size < self.MIN_BUFFER_SIZE and required_samples <= self.buffer_size:
+            return
+
+        required_size = self._recommended_buffer_size(window_duration)
+        if required_size <= self.buffer_size:
+            return
+
+        old_buffer_size = self.buffer_size
+        old_data = self.input_data
+        old_write_index = self.write_index
+
+        # Reallocate only on the UI thread. Keep chronological samples so trigger
+        # state does not jump when the user selects a longer timebase.
+        self.buffer_size = required_size
+        self.input_data = np.zeros((self.buffer_size * 2, 2), dtype=old_data.dtype)
+        old_available = min(old_buffer_size, self.buffer_size)
+        old_start = (old_write_index - old_available) % old_buffer_size
+        if old_start + old_available <= old_buffer_size:
+            preserved = old_data[old_start : old_start + old_available]
+        else:
+            split = old_buffer_size - old_start
+            preserved = np.vstack((old_data[old_start:old_buffer_size], old_data[: old_available - split]))
+
+        self.input_data[:old_available] = preserved
+        self.input_data[self.buffer_size : self.buffer_size + old_available] = preserved
+        self.write_index = old_available % self.buffer_size
+
     def start_analysis(self):
         if self.is_running:
             return
 
         self.is_running = True
+        self._ensure_buffer_capacity(self.timebase)
         self.input_data = np.zeros((self.buffer_size * 2, 2))
         self.write_index = 0
 
@@ -251,7 +306,7 @@ class Oscilloscope(MeasurementModule):
                 self.callback_id = None
             self.is_running = False
 
-    def _get_data_slice(self, start_offset, length):
+    def _get_data_slice(self, start_offset, length, step=1):
         """Returns a contiguous array of length samples starting at logical offset start_offset (0 = oldest)."""
         if length <= 0:
             return np.empty((0, 2))
@@ -259,14 +314,15 @@ class Oscilloscope(MeasurementModule):
         idx = (self.write_index + start_offset) % self.buffer_size
         end_idx = idx + length
 
-        return self.input_data[idx:end_idx].copy()
+        return self.input_data[idx:end_idx:step].copy()
 
     def get_display_data(self, window_duration):
         """
         Get triggered data for display.
         window_duration: float, seconds of data to display
         """
-        sample_rate = self.audio_engine.sample_rate
+        self._ensure_buffer_capacity(window_duration)
+        sample_rate = self._sample_rate_hz()
         required_samples = int(window_duration * sample_rate)
 
         if required_samples > self.buffer_size:
@@ -283,7 +339,8 @@ class Oscilloscope(MeasurementModule):
         if search_end <= 0:
             # Buffer too small for requested window, just return what we have (the last required_samples)
             start_offset = max(0, self.buffer_size - required_samples)
-            return self._get_data_slice(start_offset, required_samples)
+            step = max(1, int(np.ceil(required_samples / self.MAX_DISPLAY_SAMPLES)))
+            return self._get_data_slice(start_offset, required_samples, step=step)
 
         # Limit search to recent history to be responsive (e.g. last 50% of possible range)
         # But we need enough pre-trigger data?
@@ -292,7 +349,7 @@ class Oscilloscope(MeasurementModule):
         # We search backwards from the end-required_samples to find the most recent trigger event
         # Or search forwards?
         # Let's search in the last 'search_window' samples
-        search_window = self.TRIGGER_SEARCH_WINDOW_SIZE  # Limit search to avoid high CPU
+        search_window = self._recommended_trigger_search_window(required_samples)  # Limit search to avoid high CPU
         start_idx = max(0, search_end - search_window)
 
         # Extract only the search window subset
@@ -318,14 +375,16 @@ class Oscilloscope(MeasurementModule):
                 self.single_shot_fired = True
                 self.single_shot_armed = False
 
-            return self._get_data_slice(trigger_idx, required_samples)
+            step = max(1, int(np.ceil(required_samples / self.MAX_DISPLAY_SAMPLES)))
+            return self._get_data_slice(trigger_idx, required_samples, step=step)
         else:
             # No trigger found
             if self.trigger_mode == "Auto":
                 # Return latest data
                 # Corresponds to last required_samples
                 start_offset = self.buffer_size - required_samples
-                return self._get_data_slice(start_offset, required_samples)
+                step = max(1, int(np.ceil(required_samples / self.MAX_DISPLAY_SAMPLES)))
+                return self._get_data_slice(start_offset, required_samples, step=step)
             else:
                 # Normal mode: return None (keep last frame)
                 return None

--- a/tests/logic_verification/instruments/test_oscilloscope_logic.py
+++ b/tests/logic_verification/instruments/test_oscilloscope_logic.py
@@ -258,6 +258,35 @@ class TestOscilloscopeLogic(unittest.TestCase):
         data2 = self.scope.get_display_data(window_duration)
         self.assertIsNone(data2, "Should not capture after firing in Single mode")
 
+    def test_long_timebase_keeps_trigger_with_bounded_display_points(self):
+        self.engine.sample_rate = 48000
+        window_duration = 1.0
+
+        self.scope._ensure_buffer_capacity(window_duration)
+        self.assertGreater(self.scope.buffer_size, 8192)
+
+        self.scope.input_data[:] = -1.0
+        self.scope.write_index = 0
+        crossing_prev = 4095
+        crossing_now = 4096
+        self.scope.input_data[crossing_prev, 0] = -0.5
+        self.scope.input_data[crossing_now : self.scope.buffer_size, 0] = 0.5
+        self.scope.input_data[
+            self.scope.buffer_size + crossing_now : self.scope.buffer_size * 2,
+            0,
+        ] = 0.5
+
+        self.scope.trigger_source = 0
+        self.scope.trigger_mode = "Normal"
+        self.scope.trigger_level = 0.0
+        self.scope.trigger_slope = "Rising"
+
+        data = self.scope.get_display_data(window_duration)
+
+        self.assertIsNotNone(data)
+        self.assertLessEqual(len(data), self.scope.MAX_DISPLAY_SAMPLES)
+        self.assertEqual(data[0, 0], 0.5)
+
     def test_measurements_apply_calibration(self):
         # 1. Test with default sensitivity (1.0)
         t = np.linspace(0, 1, 1000)

--- a/tests/logic_verification/instruments/test_oscilloscope_logic.py
+++ b/tests/logic_verification/instruments/test_oscilloscope_logic.py
@@ -258,7 +258,24 @@ class TestOscilloscopeLogic(unittest.TestCase):
         data2 = self.scope.get_display_data(window_duration)
         self.assertIsNone(data2, "Should not capture after firing in Single mode")
 
-    def test_long_timebase_keeps_trigger_with_bounded_display_points(self):
+    def test_buffer_expansion_preserves_history_as_latest_samples(self):
+        self.engine.sample_rate = 100
+        self.scope.buffer_size = 8
+        self.scope.input_data = np.zeros((self.scope.buffer_size * 2, 2))
+        self.scope.write_index = 3
+
+        physical = np.arange(self.scope.buffer_size, dtype=float)
+        self.scope.input_data[: self.scope.buffer_size, 0] = physical
+        self.scope.input_data[self.scope.buffer_size :, 0] = physical
+
+        self.scope._ensure_buffer_capacity(0.2)
+
+        data = self.scope._get_data_slice(0, self.scope.buffer_size)
+        self.assertEqual(self.scope.write_index, 0)
+        self.assertTrue(np.all(data[: self.scope.buffer_size - 8, 0] == 0.0))
+        self.assertTrue(np.array_equal(data[-8:, 0], np.array([3, 4, 5, 6, 7, 0, 1, 2], dtype=float)))
+
+    def test_long_timebase_keeps_trigger_at_full_resolution(self):
         self.engine.sample_rate = 48000
         window_duration = 1.0
 
@@ -284,7 +301,7 @@ class TestOscilloscopeLogic(unittest.TestCase):
         data = self.scope.get_display_data(window_duration)
 
         self.assertIsNotNone(data)
-        self.assertLessEqual(len(data), self.scope.MAX_DISPLAY_SAMPLES)
+        self.assertEqual(len(data), 48000)
         self.assertEqual(data[0, 0], 0.5)
 
     def test_measurements_apply_calibration(self):
@@ -513,6 +530,35 @@ class TestOscilloscopeWidgetLogic(unittest.TestCase):
         # args: x, y, w, h. y=-1.1, h=2.2 (from VIEW_Y_MIN/MAX in widget code)
         # We expect (0, -1.1, 0.01, 2.2)
         widget.persistence_img.setRect.assert_called_with((0, -1.1, 0.01, 2.2))
+
+    def test_update_plot_measures_full_resolution_but_plots_decimated_data(self):
+        from src.gui.widgets.oscilloscope import Oscilloscope, OscilloscopeWidget
+
+        mock_audio_engine = MagicMock()
+        mock_audio_engine.sample_rate = 48000
+        mock_audio_engine.calibration.input_sensitivity = 1.0
+
+        oscilloscope = Oscilloscope(mock_audio_engine)
+        widget = OscilloscopeWidget(oscilloscope)
+        widget.chk_wave_meas.isChecked.return_value = False
+        widget.chk_cursors.isChecked.return_value = False
+
+        data = np.zeros((48000, 2))
+        data[12345, 0] = 1.0
+        oscilloscope.is_running = True
+        oscilloscope.timebase = 1.0
+        oscilloscope.get_display_data = MagicMock(return_value=data)
+        oscilloscope.process_queue = MagicMock()
+        oscilloscope.get_measurements = MagicMock(return_value={"l_rms": 0.0, "l_vpp": 1.0, "r_rms": 0.0, "r_vpp": 0.0})
+
+        widget.update_plot()
+
+        measured_data = oscilloscope.get_measurements.call_args.args[0]
+        self.assertEqual(len(measured_data), 48000)
+
+        plot_t, plot_l = widget.curve_l.setData.call_args.args
+        self.assertLessEqual(len(plot_t), oscilloscope.MAX_DISPLAY_SAMPLES)
+        self.assertLessEqual(len(plot_l), oscilloscope.MAX_DISPLAY_SAMPLES)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Grow the oscilloscope history buffer only when a longer timebase needs it
- Adapt trigger search depth to the requested window while capping display samples to keep rendering bounded
- Add a regression test covering long timebase trigger capture

## Testing
- `pytest -q tests/logic_verification/instruments/test_oscilloscope_logic.py`
- `pytest -q tests/logic_verification/core/test_utils.py tests/logic_verification/instruments/test_oscilloscope_logic.py`
- `ruff check src/gui/widgets/oscilloscope.py tests/logic_verification/instruments/test_oscilloscope_logic.py`