### PR TITLE
Allow signal generator frequencies up to Nyquist

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -151,6 +151,6 @@ Linux ではそのまま **PortAudio** バックエンドでも通常利用で�
 
 ### 🤖 AI パートナー
 
-- OpenAI: GPT-4.1, GPT-5, GPT-5.1 Codex Max, GPT-5.2, GPT-5.2 Codex, GPT-5.3-Codex, GPT-5.4
+- OpenAI: GPT-4.1, GPT-5, GPT-5.1 Codex Max, GPT-5.2, GPT-5.2 Codex, GPT-5.3-Codex, GPT-5.4, GPT-5.5
 - Google: Gemini 2.5 Pro, Gemini 3 Pro, Gemini 3 Flash, Gemini 3.1 Pro
 - Anthropic: Claude 4.5 Sonnet

--- a/README.md
+++ b/README.md
@@ -151,6 +151,6 @@ You are free to copy, modify, distribute, and use it for any commercial or non-c
 
 ### 🤖 AI Models
 
-- OpenAI: GPT-4.1, GPT-5, GPT-5.1 Codex Max, GPT-5.2, GPT-5.2 Codex, GPT-5.3-Codex, GPT-5.4
+- OpenAI: GPT-4.1, GPT-5, GPT-5.1 Codex Max, GPT-5.2, GPT-5.2 Codex, GPT-5.3-Codex, GPT-5.4, GPT-5.5
 - Google: Gemini 2.5 Pro, Gemini 3 Pro, Gemini 3 Flash, Gemini 3.1 Pro
 - Anthropic: Claude 4.5 Sonnet

--- a/src/gui/widgets/signal_generator.py
+++ b/src/gui/widgets/signal_generator.py
@@ -1346,7 +1346,7 @@ class SignalGeneratorWidget(QWidget):
     def _init_frequency_controls(self, layout):
         freq_layout = QHBoxLayout()
         self.freq_spin = QDoubleSpinBox()
-        self.freq_spin.setRange(20, 20000)
+        self.freq_spin.setRange(1, 20000)
         self.freq_spin.setValue(1000)
         self.freq_spin.valueChanged.connect(self.on_freq_spin_changed)
 
@@ -1502,7 +1502,7 @@ class SignalGeneratorWidget(QWidget):
         form_layout = QFormLayout()
 
         freq_spin = QDoubleSpinBox()
-        freq_spin.setRange(20, 20000)
+        freq_spin.setRange(1, 20000)
         freq_spin.setValue(default_freq)
         freq_spin.setGroupSeparatorShown(True)
         freq_spin.valueChanged.connect(lambda v, p=prefix: self.update_param(f"{p}_freq", v))
@@ -1542,7 +1542,7 @@ class SignalGeneratorWidget(QWidget):
         form_layout = QFormLayout()
 
         freq_spin = QDoubleSpinBox()
-        freq_spin.setRange(20, 20000)
+        freq_spin.setRange(1, 20000)
         freq_spin.setValue(1000.0)
         freq_spin.setGroupSeparatorShown(True)
         freq_spin.valueChanged.connect(lambda v: self.update_param("notch_freq", v))
@@ -1573,12 +1573,12 @@ class SignalGeneratorWidget(QWidget):
         sweep_layout = QFormLayout()
 
         self.start_freq_spin = QDoubleSpinBox()
-        self.start_freq_spin.setRange(20, 20000)
+        self.start_freq_spin.setRange(1, 20000)
         self.start_freq_spin.valueChanged.connect(lambda v: self.update_param("start_freq", v))
         sweep_layout.addRow(tr("Start Freq:"), self.start_freq_spin)
 
         self.end_freq_spin = QDoubleSpinBox()
-        self.end_freq_spin.setRange(20, 20000)
+        self.end_freq_spin.setRange(1, 20000)
         self.end_freq_spin.valueChanged.connect(lambda v: self.update_param("end_freq", v))
         sweep_layout.addRow(tr("End Freq:"), self.end_freq_spin)
 
@@ -1950,10 +1950,10 @@ class SignalGeneratorWidget(QWidget):
 
     # --- Frequency Helpers ---
     def _freq_to_slider(self, freq):
-        return int(1000 * (np.log10(freq) - np.log10(20)) / (np.log10(20000) - np.log10(20)))
+        return int(1000 * (np.log10(freq) - np.log10(1)) / (np.log10(20000) - np.log10(1)))
 
     def _slider_to_freq(self, val):
-        log_freq = np.log10(20) + (val / 1000) * (np.log10(20000) - np.log10(20))
+        log_freq = np.log10(1) + (val / 1000) * (np.log10(20000) - np.log10(1))
         return 10**log_freq
 
     def _get_snapped_frequency(self, freq):
@@ -1997,7 +1997,7 @@ class SignalGeneratorWidget(QWidget):
         if snapped_val != val:
             self.freq_spin.setValue(snapped_val)
 
-        self.freq_slider.setValue(self._freq_to_slider(snapped_val if snapped_val > 0 else 20))
+        self.freq_slider.setValue(self._freq_to_slider(snapped_val if snapped_val > 0 else 1))
 
         self.freq_spin.blockSignals(False)
         self.freq_slider.blockSignals(False)
@@ -2021,7 +2021,7 @@ class SignalGeneratorWidget(QWidget):
         # Actually, if we don't update slider, it might be out of sync.
         # Let's update it.
         if snapped_freq != freq:
-            self.freq_slider.setValue(self._freq_to_slider(snapped_freq if snapped_freq > 0 else 20))
+            self.freq_slider.setValue(self._freq_to_slider(snapped_freq if snapped_freq > 0 else 1))
 
         self.freq_spin.blockSignals(False)
         self.freq_slider.blockSignals(False)

--- a/src/gui/widgets/signal_generator.py
+++ b/src/gui/widgets/signal_generator.py
@@ -1012,6 +1012,7 @@ class SignalGeneratorWidget(QWidget):
         "fm_frequency",
         "pm_frequency",
     )
+    FILTER_FREQUENCY_PARAM_NAMES = ("lpf_freq", "hpf_freq", "notch_freq")
 
     def __init__(self, module: SignalGenerator):
         super().__init__()
@@ -1384,6 +1385,11 @@ class SignalGeneratorWidget(QWidget):
             sample_rate = 48000.0
         return max(1.000001, sample_rate / 2.0)
 
+    def _get_filter_frequency_max(self) -> float:
+        nyquist_freq = self._get_nyquist_frequency()
+        epsilon = max(0.01, nyquist_freq * 1e-9)
+        return max(1.0, nyquist_freq - epsilon)
+
     def _refresh_frequency_limits(self, force: bool = False):
         nyquist_freq = self._get_nyquist_frequency()
         if (
@@ -1399,9 +1405,6 @@ class SignalGeneratorWidget(QWidget):
             "freq_spin",
             "start_freq_spin",
             "end_freq_spin",
-            "lpf_freq_spin",
-            "hpf_freq_spin",
-            "notch_freq_spin",
             "am_freq_spin",
             "fm_freq_spin",
             "pm_freq_spin",
@@ -1410,11 +1413,20 @@ class SignalGeneratorWidget(QWidget):
             if spin is not None:
                 spin.setMaximum(nyquist_freq)
 
+        filter_max = self._get_filter_frequency_max()
+        for spin_name in ("lpf_freq_spin", "hpf_freq_spin", "notch_freq_spin"):
+            spin = getattr(self, spin_name, None)
+            if spin is not None:
+                spin.setMaximum(filter_max)
+
         for params in (self.module.params_L, self.module.params_R):
             for name in self.FREQUENCY_PARAM_NAMES:
                 value = getattr(params, name, None)
-                if value is not None and value > nyquist_freq:
-                    self.module.update_param(params, name, nyquist_freq)
+                if value is None:
+                    continue
+                max_value = filter_max if name in self.FILTER_FREQUENCY_PARAM_NAMES else nyquist_freq
+                if value > max_value:
+                    self.module.update_param(params, name, max_value)
 
         params_list = self.get_active_params_list()
         if params_list and hasattr(self, "freq_slider"):
@@ -1566,7 +1578,7 @@ class SignalGeneratorWidget(QWidget):
         form_layout = QFormLayout()
 
         freq_spin = QDoubleSpinBox()
-        freq_spin.setRange(1, self._get_nyquist_frequency())
+        freq_spin.setRange(1, self._get_filter_frequency_max())
         freq_spin.setValue(default_freq)
         freq_spin.setGroupSeparatorShown(True)
         freq_spin.valueChanged.connect(lambda v, p=prefix: self.update_param(f"{p}_freq", v))
@@ -1606,7 +1618,7 @@ class SignalGeneratorWidget(QWidget):
         form_layout = QFormLayout()
 
         freq_spin = QDoubleSpinBox()
-        freq_spin.setRange(1, self._get_nyquist_frequency())
+        freq_spin.setRange(1, self._get_filter_frequency_max())
         freq_spin.setValue(1000.0)
         freq_spin.setGroupSeparatorShown(True)
         freq_spin.valueChanged.connect(lambda v: self.update_param("notch_freq", v))
@@ -1748,6 +1760,11 @@ class SignalGeneratorWidget(QWidget):
         return []
 
     def update_param(self, name, value):
+        if name in self.FILTER_FREQUENCY_PARAM_NAMES:
+            value = min(float(value), self._get_filter_frequency_max())
+        elif name in self.FREQUENCY_PARAM_NAMES:
+            value = min(float(value), self._get_nyquist_frequency())
+
         for p in self.get_active_params_list():
             self.module.update_param(p, name, value)
 

--- a/src/gui/widgets/signal_generator.py
+++ b/src/gui/widgets/signal_generator.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from typing import Any, Optional, Tuple
 
 import numpy as np
-from PyQt6.QtCore import Qt
+from PyQt6.QtCore import Qt, QTimer
 from PyQt6.QtWidgets import (
     QButtonGroup,
     QCheckBox,
@@ -1001,11 +1001,29 @@ class SignalGenerator(MeasurementModule):
 
 
 class SignalGeneratorWidget(QWidget):
+    FREQUENCY_PARAM_NAMES = (
+        "frequency",
+        "start_freq",
+        "end_freq",
+        "lpf_freq",
+        "hpf_freq",
+        "notch_freq",
+        "am_frequency",
+        "fm_frequency",
+        "pm_frequency",
+    )
+
     def __init__(self, module: SignalGenerator):
         super().__init__()
         self.module = module
         self.current_target = "L"  # 'L', 'R', 'LINK'
+        self._last_nyquist_freq: float | None = None
         self.init_ui()
+
+        self.frequency_limit_timer = QTimer(self)
+        self.frequency_limit_timer.setInterval(1000)
+        self.frequency_limit_timer.timeout.connect(self._refresh_frequency_limits)
+        self.frequency_limit_timer.start()
 
     def _set_wave_combo_key(self, key: str):
         idx = self.wave_combo.findData(key)
@@ -1105,6 +1123,7 @@ class SignalGeneratorWidget(QWidget):
         self.setLayout(layout)
 
         # Initialize UI with current target (L)
+        self._refresh_frequency_limits(force=True)
         self.load_params_to_ui(self.module.params_L)
 
     def _create_top_control_bar(self):
@@ -1346,7 +1365,7 @@ class SignalGeneratorWidget(QWidget):
     def _init_frequency_controls(self, layout):
         freq_layout = QHBoxLayout()
         self.freq_spin = QDoubleSpinBox()
-        self.freq_spin.setRange(1, 20000)
+        self.freq_spin.setRange(1, self._get_nyquist_frequency())
         self.freq_spin.setValue(1000)
         self.freq_spin.valueChanged.connect(self.on_freq_spin_changed)
 
@@ -1357,6 +1376,51 @@ class SignalGeneratorWidget(QWidget):
         freq_layout.addWidget(self.freq_spin)
         freq_layout.addWidget(self.freq_slider)
         layout.addRow(tr("Frequency (Hz):"), freq_layout)
+
+    def _get_nyquist_frequency(self) -> float:
+        try:
+            sample_rate = float(getattr(self.module.audio_engine, "sample_rate", 48000) or 48000)
+        except Exception:
+            sample_rate = 48000.0
+        return max(1.000001, sample_rate / 2.0)
+
+    def _refresh_frequency_limits(self, force: bool = False):
+        nyquist_freq = self._get_nyquist_frequency()
+        if (
+            not force
+            and self._last_nyquist_freq is not None
+            and abs(nyquist_freq - self._last_nyquist_freq) <= 1e-9
+        ):
+            return
+
+        self._last_nyquist_freq = nyquist_freq
+
+        for spin_name in (
+            "freq_spin",
+            "start_freq_spin",
+            "end_freq_spin",
+            "lpf_freq_spin",
+            "hpf_freq_spin",
+            "notch_freq_spin",
+            "am_freq_spin",
+            "fm_freq_spin",
+            "pm_freq_spin",
+        ):
+            spin = getattr(self, spin_name, None)
+            if spin is not None:
+                spin.setMaximum(nyquist_freq)
+
+        for params in (self.module.params_L, self.module.params_R):
+            for name in self.FREQUENCY_PARAM_NAMES:
+                value = getattr(params, name, None)
+                if value is not None and value > nyquist_freq:
+                    self.module.update_param(params, name, nyquist_freq)
+
+        params_list = self.get_active_params_list()
+        if params_list and hasattr(self, "freq_slider"):
+            self.freq_slider.blockSignals(True)
+            self.freq_slider.setValue(self._freq_to_slider(params_list[0].frequency))
+            self.freq_slider.blockSignals(False)
 
     def _init_phase_controls(self, layout):
         phase_layout = QHBoxLayout()
@@ -1502,7 +1566,7 @@ class SignalGeneratorWidget(QWidget):
         form_layout = QFormLayout()
 
         freq_spin = QDoubleSpinBox()
-        freq_spin.setRange(1, 20000)
+        freq_spin.setRange(1, self._get_nyquist_frequency())
         freq_spin.setValue(default_freq)
         freq_spin.setGroupSeparatorShown(True)
         freq_spin.valueChanged.connect(lambda v, p=prefix: self.update_param(f"{p}_freq", v))
@@ -1542,7 +1606,7 @@ class SignalGeneratorWidget(QWidget):
         form_layout = QFormLayout()
 
         freq_spin = QDoubleSpinBox()
-        freq_spin.setRange(1, 20000)
+        freq_spin.setRange(1, self._get_nyquist_frequency())
         freq_spin.setValue(1000.0)
         freq_spin.setGroupSeparatorShown(True)
         freq_spin.valueChanged.connect(lambda v: self.update_param("notch_freq", v))
@@ -1573,12 +1637,12 @@ class SignalGeneratorWidget(QWidget):
         sweep_layout = QFormLayout()
 
         self.start_freq_spin = QDoubleSpinBox()
-        self.start_freq_spin.setRange(1, 20000)
+        self.start_freq_spin.setRange(1, self._get_nyquist_frequency())
         self.start_freq_spin.valueChanged.connect(lambda v: self.update_param("start_freq", v))
         sweep_layout.addRow(tr("Start Freq:"), self.start_freq_spin)
 
         self.end_freq_spin = QDoubleSpinBox()
-        self.end_freq_spin.setRange(1, 20000)
+        self.end_freq_spin.setRange(1, self._get_nyquist_frequency())
         self.end_freq_spin.valueChanged.connect(lambda v: self.update_param("end_freq", v))
         sweep_layout.addRow(tr("End Freq:"), self.end_freq_spin)
 
@@ -1604,7 +1668,7 @@ class SignalGeneratorWidget(QWidget):
         am_layout = QFormLayout()
 
         self.am_freq_spin = QDoubleSpinBox()
-        self.am_freq_spin.setRange(0.01, 20000.0)
+        self.am_freq_spin.setRange(0.01, self._get_nyquist_frequency())
         self.am_freq_spin.setDecimals(3)
         self.am_freq_spin.setValue(5.0)
         self.am_freq_spin.valueChanged.connect(lambda v: self.update_param("am_frequency", v))
@@ -1632,7 +1696,7 @@ class SignalGeneratorWidget(QWidget):
         fm_layout = QFormLayout()
 
         self.fm_freq_spin = QDoubleSpinBox()
-        self.fm_freq_spin.setRange(0.01, 20000.0)
+        self.fm_freq_spin.setRange(0.01, self._get_nyquist_frequency())
         self.fm_freq_spin.setDecimals(3)
         self.fm_freq_spin.setValue(5.0)
         self.fm_freq_spin.valueChanged.connect(lambda v: self.update_param("fm_frequency", v))
@@ -1658,7 +1722,7 @@ class SignalGeneratorWidget(QWidget):
         pm_layout = QFormLayout()
 
         self.pm_freq_spin = QDoubleSpinBox()
-        self.pm_freq_spin.setRange(0.01, 20000.0)
+        self.pm_freq_spin.setRange(0.01, self._get_nyquist_frequency())
         self.pm_freq_spin.setDecimals(3)
         self.pm_freq_spin.setValue(5.0)
         self.pm_freq_spin.valueChanged.connect(lambda v: self.update_param("pm_frequency", v))
@@ -1691,6 +1755,8 @@ class SignalGeneratorWidget(QWidget):
         # No, UI reflects the state. If linked, we assume they are now same.
 
     def load_params_to_ui(self, params: SignalParameters):
+        self._refresh_frequency_limits()
+
         # Block signals to prevent feedback loops
         self.block_all_signals(True)
 
@@ -1920,6 +1986,7 @@ class SignalGeneratorWidget(QWidget):
             self.cal_freq_label.setText("")
 
     def on_snap_toggled(self, checked):
+        self._refresh_frequency_limits()
         self.update_param("bin_center_snap", checked)
         self.fft_size_combo.setEnabled(checked)
         # Re-apply frequency to snap it if enabled
@@ -1927,6 +1994,7 @@ class SignalGeneratorWidget(QWidget):
         self.on_freq_spin_changed(current_freq)
 
     def on_fft_size_changed(self, text):
+        self._refresh_frequency_limits()
         try:
             val = int(text)
             if val > 0:
@@ -1938,6 +2006,7 @@ class SignalGeneratorWidget(QWidget):
             logger.warning(f"Invalid FFT size provided: {text}")
 
     def on_wave_changed(self, _index):
+        self._refresh_frequency_limits()
         key = self.wave_combo.currentData() or self.wave_combo.currentText()
         self._apply_waveform_key(str(key), update_params=True)
 
@@ -1950,10 +2019,13 @@ class SignalGeneratorWidget(QWidget):
 
     # --- Frequency Helpers ---
     def _freq_to_slider(self, freq):
-        return int(1000 * (np.log10(freq) - np.log10(1)) / (np.log10(20000) - np.log10(1)))
+        max_freq = self._get_nyquist_frequency()
+        freq = float(np.clip(freq, 1.0, max_freq))
+        return int(1000 * (np.log10(freq) - np.log10(1)) / (np.log10(max_freq) - np.log10(1)))
 
     def _slider_to_freq(self, val):
-        log_freq = np.log10(1) + (val / 1000) * (np.log10(20000) - np.log10(1))
+        max_freq = self._get_nyquist_frequency()
+        log_freq = np.log10(1) + (val / 1000) * (np.log10(max_freq) - np.log10(1))
         return 10**log_freq
 
     def _get_snapped_frequency(self, freq):
@@ -1985,6 +2057,7 @@ class SignalGeneratorWidget(QWidget):
         return snapped_freq
 
     def on_freq_spin_changed(self, val):
+        self._refresh_frequency_limits()
         snapped_val = self._get_snapped_frequency(val)
 
         self.update_param("frequency", snapped_val)
@@ -2003,6 +2076,7 @@ class SignalGeneratorWidget(QWidget):
         self.freq_slider.blockSignals(False)
 
     def on_freq_slider_changed(self, val):
+        self._refresh_frequency_limits()
         freq = self._slider_to_freq(val)
         snapped_freq = self._get_snapped_frequency(freq)
 

--- a/src/gui/widgets/signal_generator.py
+++ b/src/gui/widgets/signal_generator.py
@@ -2067,11 +2067,8 @@ class SignalGeneratorWidget(QWidget):
         k = round(freq / bin_width)
         snapped_freq = k * bin_width
 
-        # Ensure we don't snap to 0 if the user didn't intend to (though 0 is a valid bin center DC)
-        # But for audio signal generator, usually we want > 0.
-        # But let's respect the math. If freq is close to 0, it snaps to DC.
-
-        return snapped_freq
+        # Keep DSP state aligned with the visible spin box range.
+        return float(np.clip(snapped_freq, self.freq_spin.minimum(), self.freq_spin.maximum()))
 
     def on_freq_spin_changed(self, val):
         self._refresh_frequency_limits()
@@ -2084,8 +2081,7 @@ class SignalGeneratorWidget(QWidget):
         self.freq_spin.blockSignals(True)
         self.freq_slider.blockSignals(True)
 
-        if snapped_val != val:
-            self.freq_spin.setValue(snapped_val)
+        self.freq_spin.setValue(snapped_val)
 
         self.freq_slider.setValue(self._freq_to_slider(snapped_val if snapped_val > 0 else 1))
 

--- a/tests/logic_verification/gui/widgets/test_signal_generator.py
+++ b/tests/logic_verification/gui/widgets/test_signal_generator.py
@@ -67,3 +67,17 @@ def test_frequency_slider_maps_to_nyquist(signal_generator_widget):
 
     assert widget._slider_to_freq(1000) == pytest.approx(48000.0)
     assert widget._freq_to_slider(48000.0) == 1000
+
+
+def test_bin_snap_respects_frequency_lower_bound(signal_generator_widget):
+    widget, module, engine = signal_generator_widget
+
+    engine.sample_rate = 48000
+    widget._refresh_frequency_limits(force=True)
+    module.params_L.bin_center_snap = True
+    module.params_L.fft_size = 16384
+
+    widget.on_freq_spin_changed(1.0)
+
+    assert widget.freq_spin.value() == pytest.approx(1.0)
+    assert module.params_L.frequency == pytest.approx(1.0)

--- a/tests/logic_verification/gui/widgets/test_signal_generator.py
+++ b/tests/logic_verification/gui/widgets/test_signal_generator.py
@@ -1,0 +1,52 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.gui.widgets.signal_generator import SignalGenerator
+
+
+@pytest.fixture
+def signal_generator_widget(qtbot):
+    engine = MagicMock()
+    engine.sample_rate = 96000
+    engine.calibration.output_gain = 1.0
+
+    module = SignalGenerator(engine)
+    widget = module.get_widget()
+    qtbot.addWidget(widget)
+    return widget, module, engine
+
+
+def test_frequency_controls_allow_nyquist(signal_generator_widget):
+    widget, _module, _engine = signal_generator_widget
+
+    assert widget.freq_spin.maximum() == pytest.approx(48000.0)
+    assert widget.start_freq_spin.maximum() == pytest.approx(48000.0)
+    assert widget.end_freq_spin.maximum() == pytest.approx(48000.0)
+    assert widget.lpf_freq_spin.maximum() == pytest.approx(48000.0)
+    assert widget.hpf_freq_spin.maximum() == pytest.approx(48000.0)
+    assert widget.notch_freq_spin.maximum() == pytest.approx(48000.0)
+    assert widget.am_freq_spin.maximum() == pytest.approx(48000.0)
+    assert widget.fm_freq_spin.maximum() == pytest.approx(48000.0)
+    assert widget.pm_freq_spin.maximum() == pytest.approx(48000.0)
+
+
+def test_frequency_limits_follow_sample_rate_changes(signal_generator_widget):
+    widget, module, engine = signal_generator_widget
+
+    module.params_L.frequency = 50000.0
+    module.params_R.frequency = 50000.0
+
+    engine.sample_rate = 44100
+    widget._refresh_frequency_limits()
+
+    assert widget.freq_spin.maximum() == pytest.approx(22050.0)
+    assert module.params_L.frequency == pytest.approx(22050.0)
+    assert module.params_R.frequency == pytest.approx(22050.0)
+
+
+def test_frequency_slider_maps_to_nyquist(signal_generator_widget):
+    widget, _module, _engine = signal_generator_widget
+
+    assert widget._slider_to_freq(1000) == pytest.approx(48000.0)
+    assert widget._freq_to_slider(48000.0) == 1000

--- a/tests/logic_verification/gui/widgets/test_signal_generator.py
+++ b/tests/logic_verification/gui/widgets/test_signal_generator.py
@@ -36,6 +36,8 @@ def test_frequency_limits_follow_sample_rate_changes(signal_generator_widget):
 
     module.params_L.frequency = 50000.0
     module.params_R.frequency = 50000.0
+    module.params_L.lpf_freq = 50000.0
+    module.params_R.notch_freq = 50000.0
 
     engine.sample_rate = 44100
     widget._refresh_frequency_limits()
@@ -43,6 +45,21 @@ def test_frequency_limits_follow_sample_rate_changes(signal_generator_widget):
     assert widget.freq_spin.maximum() == pytest.approx(22050.0)
     assert module.params_L.frequency == pytest.approx(22050.0)
     assert module.params_R.frequency == pytest.approx(22050.0)
+    assert module.params_L.lpf_freq < 22050.0
+    assert module.params_R.notch_freq < 22050.0
+
+
+def test_filter_cutoffs_are_clamped_below_nyquist(signal_generator_widget):
+    widget, module, _engine = signal_generator_widget
+
+    widget.update_param("lpf_freq", 48000.0)
+    widget.update_param("hpf_freq", 48000.0)
+    widget.update_param("notch_freq", 48000.0)
+
+    assert widget.lpf_freq_spin.maximum() < 48000.0
+    assert module.params_L.lpf_freq < 48000.0
+    assert module.params_L.hpf_freq < 48000.0
+    assert module.params_L.notch_freq < 48000.0
 
 
 def test_frequency_slider_maps_to_nyquist(signal_generator_widget):


### PR DESCRIPTION
## Summary
- Raise Signal Generator frequency controls to the current Nyquist limit instead of a fixed 20 kHz ceiling
- Keep the slider mapping and parameter clamping aligned with sample-rate changes
- Add GUI regression coverage for Nyquist-range behavior and sample-rate updates

## Testing
- Added unit/UI tests for frequency control limits, slider mapping, and sample-rate-driven limit refresh
- Existing Signal Generator logic regression tests passed