### PR TITLE
Shift+ドラッグで波形ループ範囲を指定できるようにする

### DIFF
--- a/src/assets/lang/de.json
+++ b/src/assets/lang/de.json
@@ -1442,7 +1442,7 @@
     "{0:.1f} kHz": "{0:.1f} kHz",
     "{0:g} Hz": "{0:g} Hz",
     "{0:g} kHz": "{0:g} kHz",
-    "Click waveform to seek. Drag the highlighted region edges to set the loop.": "Click waveform to seek. Drag the highlighted region edges to set the loop.",
+    "Click waveform to seek. Shift-drag waveform to set the loop range; drag highlighted edges for fine adjustment.": "Click waveform to seek. Shift-drag waveform to set the loop range; drag highlighted edges for fine adjustment.",
     "End (s):": "End (s):",
     "Fit All": "Fit All",
     "Length: {0:.3f} s": "Length: {0:.3f} s",

--- a/src/assets/lang/en.json
+++ b/src/assets/lang/en.json
@@ -1442,7 +1442,7 @@
     "{0:.1f} kHz": "{0:.1f} kHz",
     "{0:g} Hz": "{0:g} Hz",
     "{0:g} kHz": "{0:g} kHz",
-    "Click waveform to seek. Drag the highlighted region edges to set the loop.": "Click waveform to seek. Drag the highlighted region edges to set the loop.",
+    "Click waveform to seek. Shift-drag waveform to set the loop range; drag highlighted edges for fine adjustment.": "Click waveform to seek. Shift-drag waveform to set the loop range; drag highlighted edges for fine adjustment.",
     "End (s):": "End (s):",
     "Fit All": "Fit All",
     "Length: {0:.3f} s": "Length: {0:.3f} s",

--- a/src/assets/lang/es.json
+++ b/src/assets/lang/es.json
@@ -1442,7 +1442,7 @@
     "{0:.1f} kHz": "{0:.1f} kHz",
     "{0:g} Hz": "{0:g} Hz",
     "{0:g} kHz": "{0:g} kHz",
-    "Click waveform to seek. Drag the highlighted region edges to set the loop.": "Click waveform to seek. Drag the highlighted region edges to set the loop.",
+    "Click waveform to seek. Shift-drag waveform to set the loop range; drag highlighted edges for fine adjustment.": "Click waveform to seek. Shift-drag waveform to set the loop range; drag highlighted edges for fine adjustment.",
     "End (s):": "End (s):",
     "Fit All": "Fit All",
     "Length: {0:.3f} s": "Length: {0:.3f} s",

--- a/src/assets/lang/fr.json
+++ b/src/assets/lang/fr.json
@@ -1442,7 +1442,7 @@
     "{0:.1f} kHz": "{0:.1f} kHz",
     "{0:g} Hz": "{0:g} Hz",
     "{0:g} kHz": "{0:g} kHz",
-    "Click waveform to seek. Drag the highlighted region edges to set the loop.": "Click waveform to seek. Drag the highlighted region edges to set the loop.",
+    "Click waveform to seek. Shift-drag waveform to set the loop range; drag highlighted edges for fine adjustment.": "Click waveform to seek. Shift-drag waveform to set the loop range; drag highlighted edges for fine adjustment.",
     "End (s):": "End (s):",
     "Fit All": "Fit All",
     "Length: {0:.3f} s": "Length: {0:.3f} s",

--- a/src/assets/lang/ja.json
+++ b/src/assets/lang/ja.json
@@ -1442,7 +1442,7 @@
     "{0:.1f} kHz": "{0:.1f} kHz",
     "{0:g} Hz": "{0:g} Hz",
     "{0:g} kHz": "{0:g} kHz",
-    "Click waveform to seek. Drag the highlighted region edges to set the loop.": "波形をクリックしてシーク。ハイライト範囲の端をドラッグしてループを設定します。",
+    "Click waveform to seek. Shift-drag waveform to set the loop range; drag highlighted edges for fine adjustment.": "波形をクリックしてシーク。Shift + ドラッグでループ範囲指定、微調整はハイライト範囲の端をドラッグします。",
     "End (s):": "終了 (秒):",
     "Fit All": "全体表示",
     "Length: {0:.3f} s": "長さ: {0:.3f} 秒",

--- a/src/assets/lang/ko.json
+++ b/src/assets/lang/ko.json
@@ -1442,7 +1442,7 @@
     "{0:.1f} kHz": "{0:.1f} kHz",
     "{0:g} Hz": "{0:g} Hz",
     "{0:g} kHz": "{0:g} kHz",
-    "Click waveform to seek. Drag the highlighted region edges to set the loop.": "Click waveform to seek. Drag the highlighted region edges to set the loop.",
+    "Click waveform to seek. Shift-drag waveform to set the loop range; drag highlighted edges for fine adjustment.": "Click waveform to seek. Shift-drag waveform to set the loop range; drag highlighted edges for fine adjustment.",
     "End (s):": "End (s):",
     "Fit All": "Fit All",
     "Length: {0:.3f} s": "Length: {0:.3f} s",

--- a/src/assets/lang/pt.json
+++ b/src/assets/lang/pt.json
@@ -1442,7 +1442,7 @@
     "{0:.1f} kHz": "{0:.1f} kHz",
     "{0:g} Hz": "{0:g} Hz",
     "{0:g} kHz": "{0:g} kHz",
-    "Click waveform to seek. Drag the highlighted region edges to set the loop.": "Click waveform to seek. Drag the highlighted region edges to set the loop.",
+    "Click waveform to seek. Shift-drag waveform to set the loop range; drag highlighted edges for fine adjustment.": "Click waveform to seek. Shift-drag waveform to set the loop range; drag highlighted edges for fine adjustment.",
     "End (s):": "End (s):",
     "Fit All": "Fit All",
     "Length: {0:.3f} s": "Length: {0:.3f} s",

--- a/src/assets/lang/ru.json
+++ b/src/assets/lang/ru.json
@@ -1442,7 +1442,7 @@
     "{0:.1f} kHz": "{0:.1f} кГц",
     "{0:g} Hz": "{0:g} Гц",
     "{0:g} kHz": "{0:g} кГц",
-    "Click waveform to seek. Drag the highlighted region edges to set the loop.": "Click waveform to seek. Drag the highlighted region edges to set the loop.",
+    "Click waveform to seek. Shift-drag waveform to set the loop range; drag highlighted edges for fine adjustment.": "Click waveform to seek. Shift-drag waveform to set the loop range; drag highlighted edges for fine adjustment.",
     "End (s):": "End (s):",
     "Fit All": "Fit All",
     "Length: {0:.3f} s": "Length: {0:.3f} s",

--- a/src/assets/lang/zh.json
+++ b/src/assets/lang/zh.json
@@ -1442,7 +1442,7 @@
     "{0:.1f} kHz": "{0:.1f} kHz",
     "{0:g} Hz": "{0:g} Hz",
     "{0:g} kHz": "{0:g} kHz",
-    "Click waveform to seek. Drag the highlighted region edges to set the loop.": "Click waveform to seek. Drag the highlighted region edges to set the loop.",
+    "Click waveform to seek. Shift-drag waveform to set the loop range; drag highlighted edges for fine adjustment.": "Click waveform to seek. Shift-drag waveform to set the loop range; drag highlighted edges for fine adjustment.",
     "End (s):": "End (s):",
     "Fit All": "Fit All",
     "Length: {0:.3f} s": "Length: {0:.3f} s",

--- a/src/gui/widgets/waveform_loop_player.py
+++ b/src/gui/widgets/waveform_loop_player.py
@@ -4,7 +4,7 @@ import os
 import numpy as np
 import pyqtgraph as pg
 import soundfile as sf
-from PyQt6.QtCore import Qt, QThread, QTimer, pyqtSignal
+from PyQt6.QtCore import QEvent, Qt, QThread, QTimer, pyqtSignal
 from PyQt6.QtWidgets import (
     QCheckBox,
     QComboBox,
@@ -267,6 +267,8 @@ class WaveformLoopPlayerWidget(QWidget):
         self._updating_region = False
         self._updating_spinboxes = False
         self._pending_waveform_range: tuple[float, float] | None = None
+        self._range_drag_active = False
+        self._range_drag_start_s: float | None = None
 
         self.init_ui()
 
@@ -300,12 +302,18 @@ class WaveformLoopPlayerWidget(QWidget):
         self.region.sigRegionChangeFinished.connect(self.on_region_changed)
         self.plot_widget.addItem(self.region)
         self.plot_widget.addItem(self.cursor_line)
+        self.plot_widget.viewport().installEventFilter(self)
         self.plot_widget.scene().sigMouseClicked.connect(self.on_plot_clicked)
         layout.addWidget(self.plot_widget, stretch=1)
 
-        hint = QLabel(tr("Click waveform to seek. Drag the highlighted region edges to set the loop."))
-        hint.setWordWrap(True)
-        layout.addWidget(hint)
+        self.hint_label = QLabel()
+        self.hint_label.setText(
+            tr(
+                "Click waveform to seek. Shift-drag waveform to set the loop range; drag highlighted edges for fine adjustment."
+            )
+        )
+        self.hint_label.setWordWrap(True)
+        layout.addWidget(self.hint_label)
 
         controls = QGroupBox(tr("Playback"))
         controls_layout = QVBoxLayout()
@@ -394,6 +402,68 @@ class WaveformLoopPlayerWidget(QWidget):
         self.end_spin.setEnabled(enabled)
         self.out_mode_combo.setEnabled(enabled)
         self.gain_slider.setEnabled(enabled)
+
+    def eventFilter(self, watched, event):
+        if watched is self.plot_widget.viewport() and self.module.playback_buffer is not None:
+            event_type = event.type()
+            if event_type == QEvent.Type.MouseButtonPress and event.button() == Qt.MouseButton.LeftButton:
+                if self._should_start_range_drag(event):
+                    start_s = self._time_from_mouse_event(event)
+                    if start_s is not None:
+                        self._range_drag_active = True
+                        self._range_drag_start_s = start_s
+                        self._update_region_ui(start_s, start_s)
+                        self.plot_widget.viewport().setCursor(Qt.CursorShape.CrossCursor)
+                        event.accept()
+                        return True
+
+            if event_type == QEvent.Type.MouseMove and self._range_drag_active:
+                if event.buttons() & Qt.MouseButton.LeftButton:
+                    current_s = self._time_from_mouse_event(event)
+                    if current_s is not None and self._range_drag_start_s is not None:
+                        self._update_region_ui(
+                            min(self._range_drag_start_s, current_s), max(self._range_drag_start_s, current_s)
+                        )
+                    event.accept()
+                    return True
+                self._finish_range_drag()
+
+            if event_type == QEvent.Type.MouseButtonRelease and event.button() == Qt.MouseButton.LeftButton:
+                if self._range_drag_active:
+                    current_s = self._time_from_mouse_event(event)
+                    if current_s is not None and self._range_drag_start_s is not None:
+                        self._update_region_ui(
+                            min(self._range_drag_start_s, current_s), max(self._range_drag_start_s, current_s)
+                        )
+                    self._finish_range_drag()
+                    event.accept()
+                    return True
+
+        return super().eventFilter(watched, event)
+
+    def _should_start_range_drag(self, event) -> bool:
+        if not self._event_is_inside_plot(event):
+            return False
+        return bool(event.modifiers() & Qt.KeyboardModifier.ShiftModifier)
+
+    def _event_is_inside_plot(self, event) -> bool:
+        scene_pos = self.plot_widget.mapToScene(event.position().toPoint())
+        return self.plot_widget.plotItem.sceneBoundingRect().contains(scene_pos)
+
+    def _time_from_mouse_event(self, event) -> float | None:
+        if not self._event_is_inside_plot(event):
+            return None
+        scene_pos = self.plot_widget.mapToScene(event.position().toPoint())
+        point = self.plot_widget.plotItem.vb.mapSceneToView(scene_pos)
+        return self._clamp_time(point.x())
+
+    def _clamp_time(self, seconds: float) -> float:
+        return max(0.0, min(float(seconds), self.module.duration_seconds))
+
+    def _finish_range_drag(self):
+        self._range_drag_active = False
+        self._range_drag_start_s = None
+        self.plot_widget.viewport().unsetCursor()
 
     def on_load(self):
         file_path, _ = QFileDialog.getOpenFileName(
@@ -535,6 +605,9 @@ class WaveformLoopPlayerWidget(QWidget):
 
     def on_plot_clicked(self, event):
         if self.module.playback_buffer is None or event.button() != Qt.MouseButton.LeftButton:
+            return
+        modifiers = event.modifiers() if hasattr(event, "modifiers") else Qt.KeyboardModifier.NoModifier
+        if modifiers & Qt.KeyboardModifier.ShiftModifier:
             return
         if self.plot_widget.plotItem.sceneBoundingRect().contains(event.scenePos()):
             point = self.plot_widget.plotItem.vb.mapSceneToView(event.scenePos())


### PR DESCRIPTION
## Summary
- 波形の範囲指定をマウスモード切り替えから削除し、通常はクリックでシーク、`Shift + 左ドラッグ` でループ範囲指定に統一
- 範囲指定中はドラッグで開始・終了を更新し、既存のリージョン端ドラッグによる微調整は維持
- ヒント文を新しい操作体系に合わせて更新
- 翻訳キーを整理し、不要になった文言を削除

## Testing
- `ruff` による対象ファイルの静的チェックを実施
- `scripts/check_trn_keys.py` で翻訳キー整合を確認
- `tests/logic_verification/gui/test_waveform_loop_player.py` を実行し、関連ユニットテストが通過することを確認