### PR TITLE
Link Bode plot X axes between magnitude and phase views

### DIFF
--- a/src/gui/widgets/network_analyzer.py
+++ b/src/gui/widgets/network_analyzer.py
@@ -872,6 +872,7 @@ class NetworkAnalyzerWidget(QWidget):
         self.phase_plot.setLabel("bottom", tr("Frequency"), units="Hz")
         self.phase_plot.setLogMode(x=True, y=False)
         self.phase_plot.showGrid(x=True, y=True)
+        self.phase_plot.setXLink(self.mag_plot)
         self.phase_curve = self.phase_plot.plot(pen="y")
 
         # Group Delay Axis (Right)


### PR DESCRIPTION
## Summary
- Link the phase plot X axis to the magnitude plot in the Network Analyzer Bode tab
- Keep frequency zoom and pan synchronized across gain, phase, and group delay views

## Testing
- Not run (not requested)
- Verified the change is limited to the plot setup in `src/gui/widgets/network_analyzer.py`