### PR TITLE
🧪 [testing improvement test_get_cached_window]

### DIFF
--- a/src/core/analysis.py
+++ b/src/core/analysis.py
@@ -32,7 +32,7 @@ RAYLEIGH_RMS_FACTOR = 1.2011
 
 @functools.lru_cache(maxsize=16)
 def get_cached_window(window_name, nx, dtype=np.float64, fftbins=True):
-    win = get_window(window_name, nx, fftbins=fftbins).astype(dtype)
+    win = get_window(window_name, nx, fftbins=fftbins).astype(dtype, copy=True)
     win.flags.writeable = False
     return win
 

--- a/tests/logic_verification/core/test_analysis.py
+++ b/tests/logic_verification/core/test_analysis.py
@@ -117,3 +117,6 @@ class TestAudioCalc:
         win3 = get_cached_window("hann", 100, dtype=np.float32)
         assert win3.dtype == np.float32
         assert not win3.flags.writeable
+
+        # Clear cache to prevent lingering objects from causing segfaults in subsequent qt tests
+        get_cached_window.cache_clear()

--- a/tests/logic_verification/core/test_analysis.py
+++ b/tests/logic_verification/core/test_analysis.py
@@ -100,3 +100,20 @@ class TestAudioCalc:
             mock_lstsq.assert_called_once()
             assert isinstance(mse, float)
             assert not np.isnan(mse)
+
+    def test_get_cached_window(self):
+        from src.core.analysis import get_cached_window
+        # Test default float64
+        win1 = get_cached_window("hann", 100)
+        assert len(win1) == 100
+        assert win1.dtype == np.float64
+        assert not win1.flags.writeable
+
+        # Test caching
+        win2 = get_cached_window("hann", 100)
+        assert win1 is win2
+
+        # Test dtype float32
+        win3 = get_cached_window("hann", 100, dtype=np.float32)
+        assert win3.dtype == np.float32
+        assert not win3.flags.writeable


### PR DESCRIPTION
🎯 **What:** Missing unit tests for the `get_cached_window` function in `src/core/analysis.py`.
📊 **Coverage:** Covered array length validation, default dtype, non-default dtype (e.g., `np.float32`), array mutability (read-only verification), and object identity caching behavior.
✨ **Result:** Improved codebase testing reliability by safely verifying properties of core pure functions.

---
*PR created automatically by Jules for task [7979611905177786825](https://jules.google.com/task/7979611905177786825) started by @youtube-at-vach*