### PR TITLE
🔒 [security fix TOCTOU vulnerability in configuration saving]

### DIFF
--- a/src/core/analysis.py
+++ b/src/core/analysis.py
@@ -32,7 +32,7 @@ RAYLEIGH_RMS_FACTOR = 1.2011
 
 @functools.lru_cache(maxsize=16)
 def get_cached_window(window_name, nx, dtype=np.float64, fftbins=True):
-    win = get_window(window_name, nx, fftbins=fftbins).astype(dtype)
+    win = get_window(window_name, nx, fftbins=fftbins).astype(dtype, copy=True)
     win.flags.writeable = False
     return win
 

--- a/src/core/calibration.py
+++ b/src/core/calibration.py
@@ -132,7 +132,10 @@ class CalibrationManager:
 
             # Ensure permissions on existing files (best effort)
             try:
-                os.chmod(self.config_path, 0o600)
+                if hasattr(os, "fchmod"):
+                    os.fchmod(fd, 0o600)
+                else:
+                    os.chmod(self.config_path, 0o600)
             except Exception as e:
                 self.logger.warning("Failed to set secure permissions for calibration file: %s", e)
 
@@ -306,6 +309,16 @@ class CalibrationManager:
         """
         try:
             fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+
+            # Ensure permissions on existing files (best effort)
+            try:
+                if hasattr(os, "fchmod"):
+                    os.fchmod(fd, 0o600)
+                else:
+                    os.chmod(path, 0o600)
+            except Exception as e:
+                self.logger.warning("Failed to set secure permissions for calibration map: %s", e)
+
             with os.fdopen(fd, "w") as f:
                 json.dump(data, f, indent=4)
             self.frequency_map = sorted(data, key=lambda x: x[0])

--- a/src/core/config_manager.py
+++ b/src/core/config_manager.py
@@ -195,14 +195,17 @@ class ConfigManager:
             try:
                 # Use os.open to ensure secure permissions (600) on creation
                 fd = os.open(self.config_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-                with os.fdopen(fd, "w") as f:
-                    json.dump(self.config, f, indent=4)
-
                 # Ensure permissions on existing files (best effort)
                 try:
-                    os.chmod(self.config_path, 0o600)
+                    if hasattr(os, "fchmod"):
+                        os.fchmod(fd, 0o600)
+                    else:
+                        os.chmod(self.config_path, 0o600)
                 except Exception as e:
                     self.logger.warning(f"Failed to set secure permissions for config file: {e}")
+
+                with os.fdopen(fd, "w") as f:
+                    json.dump(self.config, f, indent=4)
 
                 self.logger.debug("Config saved.")
                 self._save_timer = None

--- a/tests/logic_verification/core/test_config_manager.py
+++ b/tests/logic_verification/core/test_config_manager.py
@@ -164,7 +164,8 @@ class TestConfigManager(unittest.TestCase):
     def test_flush_config_chmod_error(self):
         cm = self.ConfigManager(config_filename=self.config_path)
 
-        with patch("os.chmod", side_effect=Exception("Chmod error")):
+        with patch("src.core.config_manager.os.chmod", side_effect=Exception("Chmod error")), \
+             patch("builtins.hasattr", return_value=False):
             cm._flush_config()
             self.mock_logger.warning.assert_called_with("Failed to set secure permissions for config file: Chmod error")
 

--- a/tests/logic_verification/core/test_config_manager_logic.py
+++ b/tests/logic_verification/core/test_config_manager_logic.py
@@ -302,7 +302,8 @@ class TestConfigManagerLogic(unittest.TestCase):
     @patch("src.core.config_manager.os.open")
     @patch("src.core.config_manager.os.fdopen")
     @patch("src.core.config_manager.os.chmod")
-    def test_save_config_force_sync(self, mock_chmod, mock_fdopen, mock_open_func, mock_makedirs, mock_exists):
+    @patch("builtins.hasattr", return_value=False)
+    def test_save_config_force_sync(self, mock_hasattr, mock_chmod, mock_fdopen, mock_open_func, mock_makedirs, mock_exists):
         """Test that force_sync writes immediately."""
         mock_open_func.return_value = 123
         mock_file_handle = MagicMock()


### PR DESCRIPTION
🎯 **What:** 
Replaced `os.chmod` paths with file-descriptor based `os.fchmod` to fix a Time-of-Check to Time-of-Use (TOCTOU) vulnerability during calibration and configuration file saving in `src/core/calibration.py` and `src/core/config_manager.py`.

⚠️ **Risk:** 
When using `os.chmod` by path, there is a tiny window of time between file creation/opening and applying the permissions. An attacker could potentially replace the file with a symlink to another sensitive file, causing `os.chmod` to change the permissions of the unintended file instead.

🛡️ **Solution:** 
The permissions are now changed using `os.fchmod` operating directly on the file descriptor `fd` returned by `os.open`, eliminating the race condition window. The logic properly checks for the availability of `fchmod`, utilizing it safely before closing the file via `os.fdopen`. Test mocks in `test_config_manager.py` were also updated to patch the built-in `hasattr` properly.

---
*PR created automatically by Jules for task [5211217282593114827](https://jules.google.com/task/5211217282593114827) started by @youtube-at-vach*