### PR TITLE
🧹 [code health improvement remove unused import BoxcarAverager]

### DIFF
--- a/src/gui/pyinstaller_imports.py
+++ b/src/gui/pyinstaller_imports.py
@@ -9,7 +9,6 @@ if False:
     from src.gui.widgets.advanced_distortion_meter import AdvancedDistortionMeter  # noqa: F401
 
     from src.gui.widgets.bnim_meter import BNIMMeter  # noqa: F401
-    from src.gui.widgets.boxcar_averager import BoxcarAverager  # noqa: F401
     from src.gui.widgets.distortion_analyzer import DistortionAnalyzer  # noqa: F401
     from src.gui.widgets.frequency_counter import FrequencyCounter  # noqa: F401
     from src.gui.widgets.goniometer import Goniometer  # noqa: F401


### PR DESCRIPTION
🎯 **What:** Removed unused import `BoxcarAverager` from `src/gui/pyinstaller_imports.py`
💡 **Why:** `BoxcarAverager` import was found in `src/gui/pyinstaller_imports.py` but the description says this is unused import. Removing it cleans up code without affecting the functionality, keeping our file minimal and easier to read.
✅ **Verification:** The file compiles cleanly and all pytest suites are executed and passing locally.
✨ **Result:** Improved maintainability by reducing dead code.

---
*PR created automatically by Jules for task [6862370297799462694](https://jules.google.com/task/6862370297799462694) started by @youtube-at-vach*