### PR TITLE
🧹 [code health improvement] Remove unused FrequencyCounter import

### DIFF
--- a/src/gui/pyinstaller_imports.py
+++ b/src/gui/pyinstaller_imports.py
@@ -11,7 +11,6 @@ if False:
     from src.gui.widgets.bnim_meter import BNIMMeter  # noqa: F401
     from src.gui.widgets.boxcar_averager import BoxcarAverager  # noqa: F401
     from src.gui.widgets.distortion_analyzer import DistortionAnalyzer  # noqa: F401
-    from src.gui.widgets.frequency_counter import FrequencyCounter  # noqa: F401
     from src.gui.widgets.goniometer import Goniometer  # noqa: F401
     from src.gui.widgets.hrtf_player import HRTFPlayer  # noqa: F401
     from src.gui.widgets.impedance_analyzer import ImpedanceAnalyzer  # noqa: F401


### PR DESCRIPTION
🎯 **What:** Removed unused `FrequencyCounter` import from `src/gui/pyinstaller_imports.py`.
💡 **Why:** Improves code health and maintainability by removing unused imports.
✅ **Verification:** Confirmed changes via `git diff`, ran linting checks (ruff), and executed the full test suite.
✨ **Result:** Cleaner code without dead imports.

---
*PR created automatically by Jules for task [12441511586901152927](https://jules.google.com/task/12441511586901152927) started by @youtube-at-vach*