### PR TITLE
🧹 [code health improvement Log OSError during temp file cleanup in recorder_player]

### DIFF
--- a/src/gui/widgets/recorder_player.py
+++ b/src/gui/widgets/recorder_player.py
@@ -230,15 +230,15 @@ class RecorderPlayer(MeasurementModule):
         if self._temp_record_fd is not None:
             try:
                 os.close(self._temp_record_fd)
-            except OSError:
-                pass
+            except OSError as e:
+                logger.debug(f"Failed to close temp record fd: {e}")
             self._temp_record_fd = None
 
         if self._temp_record_file and os.path.exists(self._temp_record_file):
             try:
                 os.remove(self._temp_record_file)
-            except OSError:
-                pass
+            except OSError as e:
+                logger.debug(f"Failed to remove temp record file: {e}")
 
     def cleanup(self):
         """
@@ -262,8 +262,8 @@ class RecorderPlayer(MeasurementModule):
                     try:
                         os.close(self._temp_record_fd)
                         self._temp_record_fd = None
-                    except OSError:
-                        pass
+                    except OSError as e:
+                        logger.debug(f"Failed to close temp record fd: {e}")
                 return
 
             channels = first_chunk.shape[1] if first_chunk.ndim > 1 else 1


### PR DESCRIPTION
🎯 **What:**
Replaced silent `pass` statements inside `except OSError` blocks with `logger.debug` statements in `src/gui/widgets/recorder_player.py`. This ensures that when an error occurs while closing a file descriptor or removing a temporary file, the error message is captured in the logs.

💡 **Why:**
Silently swallowing `OSError` can hide potential permission or path issues, making it difficult to debug if the file system encounters unexpected errors during cleanup. Logging the exceptions provides visibility into failure cases without disrupting the control flow (i.e., cleanup is still a 'best effort' but no longer silent).

✅ **Verification:**
Executed the full test suite (`source .venv/bin/activate && QT_QPA_PLATFORM=offscreen python3 -m pytest tests/`), ensuring no logic is broken and that everything continues to function correctly.

✨ **Result:**
Improved maintainability and observability by logging previously hidden cleanup failures.

---
*PR created automatically by Jules for task [131180872400273461](https://jules.google.com/task/131180872400273461) started by @youtube-at-vach*