### PR TITLE
🧹 [code health improvement catch specific exceptions]

### DIFF
--- a/src/gui/widgets/processor_benchmark.py
+++ b/src/gui/widgets/processor_benchmark.py
@@ -40,8 +40,8 @@ def get_cpu_name():
             )
             name, _ = winreg.QueryValueEx(key, "ProcessorNameString")
             return name.strip()
-        except Exception:
-            pass
+        except OSError as e:
+            logger.debug(f"Failed to read CPU name from registry: {e}")
 
     elif sys.platform == "linux":
         try:
@@ -49,8 +49,8 @@ def get_cpu_name():
                 for line in f:
                     if "model name" in line:
                         return line.split(":")[1].strip()
-        except Exception:
-            pass
+        except OSError as e:
+            logger.debug(f"Failed to read CPU name from /proc/cpuinfo: {e}")
 
     elif sys.platform == "darwin":
         import subprocess
@@ -58,8 +58,8 @@ def get_cpu_name():
             return subprocess.check_output(
                 ["sysctl", "-n", "machdep.cpu.brand_string"]
             ).decode().strip()
-        except Exception:
-            pass
+        except (OSError, subprocess.CalledProcessError) as e:
+            logger.debug(f"Failed to read CPU name from sysctl: {e}")
 
     return None
 

--- a/tests/logic_verification/gui/widgets/test_processor_benchmark_darwin.py
+++ b/tests/logic_verification/gui/widgets/test_processor_benchmark_darwin.py
@@ -1,0 +1,26 @@
+from unittest.mock import MagicMock, patch
+import subprocess
+
+mock_dict = {
+    "numpy": MagicMock(),
+    "pyqtgraph": MagicMock(),
+    "PyQt6.QtCore": MagicMock(),
+    "PyQt6.QtWidgets": MagicMock(),
+    "src.core.analysis": MagicMock(),
+    "src.core.audio_engine": MagicMock(),
+    "src.core.fft_manager": MagicMock(),
+    "src.core.localization": MagicMock(),
+    "src.measurement_modules.base": MagicMock()
+}
+
+with patch.dict("sys.modules", mock_dict):
+    from src.gui.widgets.processor_benchmark import get_cpu_name
+
+def test_get_cpu_name_darwin_exception():
+    """Test that get_cpu_name correctly handles exceptions when sysctl fails on darwin."""
+    with patch("sys.platform", "darwin"), \
+         patch("subprocess.check_output", side_effect=subprocess.CalledProcessError(1, "sysctl")):
+
+        result = get_cpu_name()
+
+        assert result is None

--- a/tests/logic_verification/gui/widgets/test_processor_benchmark_linux.py
+++ b/tests/logic_verification/gui/widgets/test_processor_benchmark_linux.py
@@ -1,0 +1,25 @@
+from unittest.mock import MagicMock, patch
+
+mock_dict = {
+    "numpy": MagicMock(),
+    "pyqtgraph": MagicMock(),
+    "PyQt6.QtCore": MagicMock(),
+    "PyQt6.QtWidgets": MagicMock(),
+    "src.core.analysis": MagicMock(),
+    "src.core.audio_engine": MagicMock(),
+    "src.core.fft_manager": MagicMock(),
+    "src.core.localization": MagicMock(),
+    "src.measurement_modules.base": MagicMock()
+}
+
+with patch.dict("sys.modules", mock_dict):
+    from src.gui.widgets.processor_benchmark import get_cpu_name
+
+def test_get_cpu_name_linux_exception():
+    """Test that get_cpu_name correctly handles exceptions when reading /proc/cpuinfo fails on linux."""
+    with patch("sys.platform", "linux"), \
+         patch("builtins.open", side_effect=OSError("Mocked Exception")):
+
+        result = get_cpu_name()
+
+        assert result is None

--- a/tests/logic_verification/gui/widgets/test_processor_benchmark_win32.py
+++ b/tests/logic_verification/gui/widgets/test_processor_benchmark_win32.py
@@ -19,7 +19,7 @@ with patch.dict("sys.modules", mock_dict):
 def test_get_cpu_name_win32_exception():
     """Test that get_cpu_name correctly handles exceptions when winreg fails on win32."""
     mock_winreg = MagicMock()
-    mock_winreg.OpenKey.side_effect = Exception("Mocked Exception")
+    mock_winreg.OpenKey.side_effect = OSError("Mocked Exception")
 
     with patch("sys.platform", "win32"), \
          patch.dict("sys.modules", {"winreg": mock_winreg}):


### PR DESCRIPTION
🎯 **What:** Catch specific exceptions (`OSError`, `subprocess.CalledProcessError`) and log them instead of silently swallowing all exceptions via `except Exception: pass` in `get_cpu_name()`.
💡 **Why:** Silently catching broad exceptions can mask real issues and bugs. Catching specific exceptions improves debugging visibility and overall code maintainability.
✅ **Verification:** Confirmed by running the full test suite (`pytest`) to ensure no regressions were introduced.
✨ **Result:** A more robust and debuggable CPU information retrieval process across all supported platforms.

---
*PR created automatically by Jules for task [1266563126047192984](https://jules.google.com/task/1266563126047192984) started by @youtube-at-vach*