### PR TITLE
🔒 [security fix insecure impedance analyzer calibration file permissions]

### DIFF
--- a/src/gui/widgets/impedance_analyzer.py
+++ b/src/gui/widgets/impedance_analyzer.py
@@ -534,6 +534,7 @@ class ImpedanceAnalyzer(MeasurementModule):
         }
         # Secure file creation with 600 permissions
         fd = os.open(filename, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        os.fchmod(fd, 0o600)
         with os.fdopen(fd, "w") as f:
             json.dump(data, f, indent=4)
 


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is insecure file permissions when saving impedance analyzer calibration data to an existing file. If the file already exists with permissive permissions, `os.open(..., 0o600)` does not restrict the existing file's permissions.
⚠️ **Risk:** If an attacker pre-creates the file with permissive permissions or if the file previously had insecure permissions, the sensitive calibration data could be readable or writable by unauthorized users.
🛡️ **Solution:** The fix calls `os.fchmod(fd, 0o600)` on the open file descriptor before writing, explicitly and securely enforcing `0o600` permissions even on existing files, avoiding TOCTOU race conditions.

---
*PR created automatically by Jules for task [15527487897762040894](https://jules.google.com/task/15527487897762040894) started by @youtube-at-vach*