### PR TITLE
🧹 [code health improvement refactor init_ui in lock_in_amplifier.py]

### DIFF
--- a/src/gui/widgets/lock_in_amplifier.py
+++ b/src/gui/widgets/lock_in_amplifier.py
@@ -651,6 +651,26 @@ class LockInAmplifierWidget(QWidget):
         # Tabs for Modes
         self.tabs = QTabWidget()
 
+        self._init_manual_control_tab()
+        self._init_fra_tab()
+        self._init_calibration_tab()
+
+        main_layout.addWidget(self.tabs)
+        self.setLayout(main_layout)
+
+        # Data storage for FRA
+        self.fra_freqs = []
+        self.fra_log_freqs = []
+        self.fra_raw_mags = []  # Linear (0-1)
+        self.fra_phases = []
+        self.fra_worker = None
+
+        # Data storage for Calibration
+        self.cal_data = []  # List of [freq, mag_db, phase_deg]
+        self.cal_worker = None
+
+
+    def _init_manual_control_tab(self):
         # --- Tab 1: Manual Control (Existing) ---
         manual_widget = QWidget()
         manual_layout = QHBoxLayout(manual_widget)
@@ -890,6 +910,8 @@ class LockInAmplifierWidget(QWidget):
 
         self.tabs.addTab(manual_widget, tr("Manual Control"))
 
+
+    def _init_fra_tab(self):
         # --- Tab 2: Frequency Response Analyzer (FRA) ---
         fra_widget = QWidget()
         fra_layout = QHBoxLayout(fra_widget)
@@ -1024,6 +1046,8 @@ class LockInAmplifierWidget(QWidget):
 
         self.tabs.addTab(fra_widget, tr("Frequency Response"))
 
+
+    def _init_calibration_tab(self):
         # --- Tab 3: Calibration ---
         cal_widget = QWidget()
         cal_layout = QHBoxLayout(cal_widget)
@@ -1140,20 +1164,6 @@ class LockInAmplifierWidget(QWidget):
         cal_layout.addWidget(self.cal_plot, stretch=3)
 
         self.tabs.addTab(cal_widget, tr("Calibration"))
-
-        main_layout.addWidget(self.tabs)
-        self.setLayout(main_layout)
-
-        # Data storage for FRA
-        self.fra_freqs = []
-        self.fra_log_freqs = []
-        self.fra_raw_mags = []  # Linear (0-1)
-        self.fra_phases = []
-        self.fra_worker = None
-
-        # Data storage for Calibration
-        self.cal_data = []  # List of [freq, mag_db, phase_deg]
-        self.cal_worker = None
 
     def on_toggle(self, checked):
         if checked:


### PR DESCRIPTION
🎯 **What:** The `init_ui` function in `src/gui/widgets/lock_in_amplifier.py` was overly long and complex, handling the setup for three different tabs. It has been broken down into three smaller, specific methods: `_init_manual_control_tab`, `_init_fra_tab`, and `_init_calibration_tab`.
     💡 **Why:** Breaking down the UI setup into specific layout methods improves readability and makes the codebase easier to maintain, similar to the pattern already used in `network_analyzer.py`.
     ✅ **Verification:** Ran the full pytest test suite with `source .venv/bin/activate && QT_QPA_PLATFORM=offscreen python3 -m pytest` to ensure no functionality is broken and UI tests still pass.
     ✨ **Result:** The `init_ui` method is now clean and modular.

---
*PR created automatically by Jules for task [13797193592955722520](https://jules.google.com/task/13797193592955722520) started by @youtube-at-vach*