### PR TITLE
🧪 [testing improvement] Add tests for AudioEngine set_loopback and set_mute_output

### DIFF
--- a/tests/logic_verification/core/test_audio_engine.py
+++ b/tests/logic_verification/core/test_audio_engine.py
@@ -116,6 +116,19 @@ class TestAudioEngineBasicSettings(unittest.TestCase):
         self.assertFalse(self.engine.offline_mode)
         self.engine._restart_stream.assert_not_called()
 
+
+    def test_set_loopback(self):
+        self.assertFalse(self.engine.loopback)
+        self.engine.set_loopback(True)
+        self.assertTrue(self.engine.loopback)
+        self.engine.logger.debug.assert_called_with("Set software loopback: True")
+
+    def test_set_mute_output(self):
+        self.assertFalse(self.engine.mute_output)
+        self.engine.set_mute_output(True)
+        self.assertTrue(self.engine.mute_output)
+        self.engine.logger.debug.assert_called_with("Set mute output: True")
+
     def test_set_pipewire_jack_resident(self):
         self.assertFalse(self.engine.pipewire_jack_resident)
 


### PR DESCRIPTION
🎯 **What:** The `AudioEngine.set_loopback` and `AudioEngine.set_mute_output` properties lacked test coverage, creating a gap in verifying state updates.
📊 **Coverage:** Added test cases covering the happy path for both methods, asserting state changes and verifying that the debug logger is correctly called.
✨ **Result:** Improved test coverage for `AudioEngine` settings, ensuring simple setter methods function correctly and produce the expected logs.

---
*PR created automatically by Jules for task [18141899639886744671](https://jules.google.com/task/18141899639886744671) started by @youtube-at-vach*