### PR TITLE
🔒 [security fix prevent PATH manipulation vulnerability in sysctl execution]

### DIFF
--- a/src/gui/widgets/processor_benchmark.py
+++ b/src/gui/widgets/processor_benchmark.py
@@ -54,7 +54,7 @@ def get_cpu_name():
         import subprocess
 
         try:
-            return subprocess.check_output(["sysctl", "-n", "machdep.cpu.brand_string"]).decode().strip()
+            return subprocess.check_output(["/usr/sbin/sysctl", "-n", "machdep.cpu.brand_string"]).decode().strip()
         except (OSError, subprocess.CalledProcessError) as e:
             logger.debug(f"Failed to read CPU name from sysctl: {e}")
 
@@ -215,8 +215,8 @@ class ProcessorBenchmarkWidget(QWidget):
         # Attempt to stop audio stream safely to prevent dropouts during heavy benchmark
         try:
             self.module.audio_engine.stop_stream()
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug(f"Failed to stop stream safely: {e}")
 
         self._benchmark_data.clear()
 
@@ -292,8 +292,8 @@ class ProcessorBenchmarkWidget(QWidget):
         # Restart the stream so that other widgets can be used immediately
         try:
             self.module.audio_engine._restart_stream()
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug(f"Failed to restart stream: {e}")
 
     def update_results_display(self):
         safety = self.safety_spin.value()


### PR DESCRIPTION
🎯 **What:** Hardcoded the path for `sysctl` command in subprocess execution to `/usr/sbin/sysctl`. Also fixed two silent `except Exception: pass` anti-patterns when stopping/restarting audio streams.
⚠️ **Risk:** Execution of a partial path like `sysctl` relies on the system `PATH` variable. A local attacker could theoretically manipulate the `PATH` environment variable to point `sysctl` to a malicious executable, leading to unauthorized command execution. Silent exception swallowing makes debugging and diagnosing potential stream errors impossible.
🛡️ **Solution:** Used the absolute path `/usr/sbin/sysctl` to ensure the correct binary is executed, mitigating PATH manipulation vulnerabilities. Added `logger.debug` statements to catch and log exceptions during stream start/stop operations.

---
*PR created automatically by Jules for task [15462795905902337810](https://jules.google.com/task/15462795905902337810) started by @youtube-at-vach*