### PR TITLE
🧪 [testing improvement] Add missing error test for AudioCalc.design_aes17_filter

### DIFF
--- a/tests/logic_verification/core/test_analysis.py
+++ b/tests/logic_verification/core/test_analysis.py
@@ -65,6 +65,13 @@ class TestAudioCalc:
         with pytest.raises(ValueError, match="Invalid sample rate"):
             AudioCalc.design_c_weighting(-100)
 
+
+    def test_design_aes17_filter_invalid(self):
+        with pytest.raises(ValueError, match="Invalid sample rate"):
+            AudioCalc.design_aes17_filter(0)
+        with pytest.raises(ValueError, match="Invalid sample rate"):
+            AudioCalc.design_aes17_filter(-100)
+
     def test_optimize_frequency_empty_signal(self):
         result = AudioCalc.optimize_frequency(np.array([]), 48000, 1000.0)
         assert result == 1000.0


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was the lack of coverage for the error condition in `AudioCalc.design_aes17_filter` when the sampling rate is invalid (less than or equal to 0).
📊 **Coverage:** The scenarios now tested include passing `0` and negative values (e.g., `-100`) as the sampling rate to `AudioCalc.design_aes17_filter` to ensure a `ValueError` is raised.
✨ **Result:** Test coverage for `src/core/analysis.py` has improved, catching invalid sampling rate bugs properly and making refactoring more robust.

---
*PR created automatically by Jules for task [17752017588602511760](https://jules.google.com/task/17752017588602511760) started by @youtube-at-vach*