### PR TITLE
🧪 [test improvement] Add test for AudioEngine set_mute_output and set_loopback

### DIFF
--- a/tests/logic_verification/core/test_audio_engine.py
+++ b/tests/logic_verification/core/test_audio_engine.py
@@ -93,6 +93,26 @@ class TestAudioEngineBasicSettings(unittest.TestCase):
         self.engine._restart_stream = MagicMock()
         self.engine._start_master_stream = MagicMock()
 
+    def test_set_loopback(self):
+        self.assertFalse(self.engine.loopback)
+        self.engine.set_loopback(True)
+        self.assertTrue(self.engine.loopback)
+        self.engine.logger.debug.assert_called_with("Set software loopback: True")
+
+        self.engine.set_loopback(False)
+        self.assertFalse(self.engine.loopback)
+        self.engine.logger.debug.assert_called_with("Set software loopback: False")
+
+    def test_set_mute_output(self):
+        self.assertFalse(self.engine.mute_output)
+        self.engine.set_mute_output(True)
+        self.assertTrue(self.engine.mute_output)
+        self.engine.logger.debug.assert_called_with("Set mute output: True")
+
+        self.engine.set_mute_output(False)
+        self.assertFalse(self.engine.mute_output)
+        self.engine.logger.debug.assert_called_with("Set mute output: False")
+
     def test_set_offline_mode(self):
         self.assertFalse(self.engine.offline_mode)
 


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of unit tests covering `AudioEngine.set_mute_output` and `AudioEngine.set_loopback`.
📊 **Coverage:** Tests verify the initial state, the successful modification of the `mute_output` and `loopback` variables respectively, and that proper logger messages are called.
✨ **Result:** Improved overall coverage of boolean setter functions in AudioEngine.

---
*PR created automatically by Jules for task [6476498855124743524](https://jules.google.com/task/6476498855124743524) started by @youtube-at-vach*