### PR TITLE
🧪 [add test for coreaudio conversion quality]

### DIFF
--- a/tests/logic_verification/core/test_config_manager.py
+++ b/tests/logic_verification/core/test_config_manager.py
@@ -102,6 +102,18 @@ class TestConfigManager(unittest.TestCase):
         cm.set_dithering_bit_depth("24")
         self.assertEqual(cm.get_dithering_bit_depth(), "24")
 
+
+    def test_coreaudio_conversion_quality(self):
+        cm = self.ConfigManager(config_filename=self.config_path)
+
+        self.assertEqual(cm.get_coreaudio_conversion_quality(), "min")
+        cm.set_coreaudio_conversion_quality("max")
+        self.assertEqual(cm.get_coreaudio_conversion_quality(), "max")
+
+        cm.config.pop("audio", None)
+        cm.set_coreaudio_conversion_quality("high")
+        self.assertEqual(cm.get_coreaudio_conversion_quality(), "high")
+
     def test_theme(self):
         cm = self.ConfigManager(config_filename=self.config_path)
 


### PR DESCRIPTION
🎯 **What:** The `get_coreaudio_conversion_quality` and `set_coreaudio_conversion_quality` methods in `ConfigManager` were missing tests.
📊 **Coverage:** The new test covers default value retrieval, updating the value, and setting the value when the "audio" config block is missing.
✨ **Result:** Test coverage for `ConfigManager` is improved, ensuring robustness of coreaudio configuration getters and setters.

---
*PR created automatically by Jules for task [17436618350670478006](https://jules.google.com/task/17436618350670478006) started by @youtube-at-vach*