### PR TITLE
🧹 [remove unused set_module method]

### DIFF
--- a/src/core/session_manager.py
+++ b/src/core/session_manager.py
@@ -8,10 +8,6 @@ class SessionManager:
         self.is_running = False
         self.results = []
 
-    def set_module(self, module):
-        """Sets the current measurement module."""
-        self.current_module = module
-
     def start_measurement(self):
         """Starts the measurement process."""
         if self.current_module:

--- a/tests/logic_verification/core/test_session_manager.py
+++ b/tests/logic_verification/core/test_session_manager.py
@@ -8,23 +8,9 @@ def session_manager():
     return SessionManager()
 
 
-def test_set_module(session_manager):
-    """Verify that set_module correctly updates the current_module."""
-    dummy_module = "dummy_module"
-    session_manager.set_module(dummy_module)
-    assert session_manager.current_module == dummy_module
-
-
-def test_set_module_none(session_manager):
-    """Verify that set_module(None) clears the current_module."""
-    session_manager.set_module("temp_module")
-    session_manager.set_module(None)
-    assert session_manager.current_module is None
-
-
 def test_start_measurement_success(session_manager):
     """Verify that start_measurement sets is_running to True when a module is set."""
-    session_manager.set_module("valid_module")
+    session_manager.current_module = "valid_module"
     session_manager.start_measurement()
     assert session_manager.is_running is True
 
@@ -38,7 +24,7 @@ def test_start_measurement_no_module(session_manager):
 
 def test_stop_measurement(session_manager):
     """Verify that stop_measurement sets is_running to False."""
-    session_manager.set_module("valid_module")
+    session_manager.current_module = "valid_module"
     session_manager.start_measurement()
     assert session_manager.is_running is True
 
@@ -48,7 +34,7 @@ def test_stop_measurement(session_manager):
 
 def test_stop_measurement_idempotent(session_manager):
     """Verify that calling stop_measurement multiple times is safe."""
-    session_manager.set_module("valid_module")
+    session_manager.current_module = "valid_module"
     session_manager.start_measurement()
     session_manager.stop_measurement()
     assert session_manager.is_running is False
@@ -60,7 +46,7 @@ def test_stop_measurement_idempotent(session_manager):
 
 def test_start_measurement_idempotent(session_manager):
     """Verify that calling start_measurement multiple times keeps is_running True."""
-    session_manager.set_module("valid_module")
+    session_manager.current_module = "valid_module"
     session_manager.start_measurement()
     assert session_manager.is_running is True
 
@@ -71,11 +57,11 @@ def test_start_measurement_idempotent(session_manager):
 
 def test_change_module_while_running(session_manager):
     """Verify behavior when changing module while running."""
-    session_manager.set_module("module_a")
+    session_manager.current_module = "module_a"
     session_manager.start_measurement()
     assert session_manager.is_running is True
 
-    session_manager.set_module("module_b")
+    session_manager.current_module = "module_b"
     assert session_manager.current_module == "module_b"
     # Assuming implementation allows changing module while running without stopping
     assert session_manager.is_running is True


### PR DESCRIPTION
🎯 **What:** Removed the unused `set_module` method from `SessionManager` in `src/core/session_manager.py`, and refactored the unit tests in `tests/logic_verification/core/test_session_manager.py` to directly assign `session_manager.current_module` instead of calling this removed method. Two obsolete tests strictly testing the removed method were also removed.

💡 **Why:** This `set_module` utility method was a shallow wrapper around assigning an attribute, and it wasn't being used anywhere in the actual application code. Removing dead code reduces cognitive load and improves the overall maintainability and readability of the codebase.

✅ **Verification:** Verified the fix by running `./.venv/bin/pytest tests/logic_verification/core/test_session_manager.py` to ensure that all remaining SessionManager tests pass as expected without the helper method. I also confirmed that running mypy and ruff check on the modified files reported no issues.

✨ **Result:** A slightly cleaner and leaner `SessionManager` class.

---
*PR created automatically by Jules for task [12511026477676859929](https://jules.google.com/task/12511026477676859929) started by @youtube-at-vach*