### PR TITLE
🧪 [Add error path test for CSV exporter]

### DIFF
--- a/tests/core/export/test_csv_exporter.py
+++ b/tests/core/export/test_csv_exporter.py
@@ -1,0 +1,22 @@
+import logging
+from unittest.mock import patch
+
+from src.core.export.csv_exporter import CsvTraceExporter
+
+
+def test_export_traces_error_path(caplog):
+    exporter = CsvTraceExporter()
+    with patch("builtins.open", side_effect=OSError("Permission denied")):
+        with caplog.at_level(logging.ERROR):
+            result = exporter.export_traces("fake_path.csv", [], {})
+
+    assert result is False
+    assert "Failed to export traces to CSV" in caplog.text
+
+
+def test_export_traces_success():
+    exporter = CsvTraceExporter()
+    with patch("builtins.open"):
+        result = exporter.export_traces("fake_path.csv", [], {})
+
+    assert result is True


### PR DESCRIPTION
🎯 **What:** Added a test for the error path (exception handling) in `CsvTraceExporter.export_traces()`.

📊 **Coverage:** Tests that when `open()` raises an exception, the exception is caught, logged, and the method returns `False`. Additionally, a basic happy path test is added to ensure successful execution returns `True`.

✨ **Result:** Improved test coverage by explicitly validating the error handling behavior when file creation fails.

---
*PR created automatically by Jules for task [14349726207282442417](https://jules.google.com/task/14349726207282442417) started by @youtube-at-vach*