### PR TITLE
🔒 [security fix missing timeout for subprocess]

### DIFF
--- a/src/gui/widgets/processor_benchmark.py
+++ b/src/gui/widgets/processor_benchmark.py
@@ -54,8 +54,12 @@ def get_cpu_name():
         import subprocess
 
         try:
-            return subprocess.check_output(["/usr/sbin/sysctl", "-n", "machdep.cpu.brand_string"]).decode().strip()
-        except (OSError, subprocess.CalledProcessError) as e:
+            return (
+                subprocess.check_output(["/usr/sbin/sysctl", "-n", "machdep.cpu.brand_string"], timeout=2.0)
+                .decode()
+                .strip()
+            )
+        except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
             logger.debug(f"Failed to read CPU name from sysctl: {e}")
 
     return None

--- a/tests/logic_verification/gui/widgets/test_processor_benchmark_darwin.py
+++ b/tests/logic_verification/gui/widgets/test_processor_benchmark_darwin.py
@@ -26,3 +26,14 @@ def test_get_cpu_name_darwin_exception():
         result = get_cpu_name()
 
         assert result is None
+
+
+def test_get_cpu_name_darwin_timeout():
+    """Test that get_cpu_name correctly handles timeout exception."""
+    with (
+        patch("sys.platform", "darwin"),
+        patch("subprocess.check_output", side_effect=subprocess.TimeoutExpired("sysctl", 2.0)),
+    ):
+        result = get_cpu_name()
+
+        assert result is None


### PR DESCRIPTION
🎯 **What:** 
Added a `timeout=2.0` parameter to the `subprocess.check_output` execution in `src/gui/widgets/processor_benchmark.py` and caught the resulting `subprocess.TimeoutExpired` exception to ensure safe fallback.

⚠️ **Risk:** 
If the `sysctl` subprocess hangs or deadlocks, executing it without a timeout would cause the main application to block indefinitely, leading to an unresponsive UI or potential Denial of Service (DoS).

🛡️ **Solution:** 
Enforced a 2.0-second timeout limit for the execution of the `sysctl` command. Added `subprocess.TimeoutExpired` to the exception catching block so the application can gracefully return `None` (and log the failure) if the command takes too long. Included a unit test to verify this behavior.

---
*PR created automatically by Jules for task [1466800432065221132](https://jules.google.com/task/1466800432065221132) started by @youtube-at-vach*