### PR TITLE
🔒 [security fix] Fix unrestricted NamedTemporaryFile deletion flag

### DIFF
--- a/src/gui/widgets/recorder_player.py
+++ b/src/gui/widgets/recorder_player.py
@@ -228,7 +228,7 @@ class RecorderPlayer(MeasurementModule):
         self._check_stop_callback()
 
     def _remove_temp_file(self):
-        if hasattr(self, '_temp_record_obj') and self._temp_record_obj is not None:
+        if hasattr(self, "_temp_record_obj") and self._temp_record_obj is not None:
             try:
                 self._temp_record_obj.close()
             except Exception as e:
@@ -272,7 +272,7 @@ class RecorderPlayer(MeasurementModule):
             first_chunk = self._write_queue.get()
             if first_chunk is None:
                 # If we exit before opening the file, ensure the object is closed
-                if getattr(self, '_temp_record_obj', None) is not None:
+                if getattr(self, "_temp_record_obj", None) is not None:
                     try:
                         self._temp_record_obj.close()
                     except Exception as e:
@@ -318,8 +318,8 @@ class RecorderPlayer(MeasurementModule):
         self._remove_temp_file()
 
         # Create new temp file object to manage lifecycle securely and avoid TOCTOU
-        # We use delete=False so we can explicitly control deletion and ensure cross-platform compatibility
-        self._temp_record_obj = tempfile.NamedTemporaryFile(suffix=".wav", delete=False)
+        # We use delete=True, delete_on_close=False to prevent ungraceful exit leaks while keeping the file readable
+        self._temp_record_obj = tempfile.NamedTemporaryFile(suffix=".wav", delete=True, delete_on_close=False)
         self._temp_record_file = self._temp_record_obj.name
 
         # Add a weakref finalizer to ensure cleanup on garbage collection if the app exits ungracefully


### PR DESCRIPTION
🎯 **What:** The `NamedTemporaryFile` in `recorder_player.py` was created with `delete=False`, which can lead to temporary files not being cleaned up if the application crashes before the manual cleanup logic or the weakref finalizer can run. This is now fixed by using `delete=True` with `delete_on_close=False` (available in Python 3.12+).
⚠️ **Risk:** Left unfixed, temporary files could accumulate in the system's temporary directory, potentially leading to storage exhaustion or exposing sensitive recorded data if the OS does not clean the temporary directory automatically.
🛡️ **Solution:** Updated the `NamedTemporaryFile` creation to use `delete=True, delete_on_close=False`. This ensures that the file is safely deleted when the file object is closed or garbage-collected by Python's context manager, while still allowing the file descriptor to be managed manually for reading after it is written.

---
*PR created automatically by Jules for task [10804774352588537639](https://jules.google.com/task/10804774352588537639) started by @youtube-at-vach*