### PR TITLE
🔒 [QA Fix] Prevent thread deadlocks in buffer waits and fix swallowed exceptions

### DIFF
--- a/src/core/audio_engine.py
+++ b/src/core/audio_engine.py
@@ -109,8 +109,8 @@ class VirtualStream:
                 # So we are good.
 
             except Exception as e:
-                self.logger.error(f"VirtualStream Error: {e}")
-                # Don't crash thread, just log
+                self.logger.error(f"VirtualStream Error: {e}", exc_info=True)
+                # Don\'t crash thread, just log
                 pass
 
 

--- a/src/gui/widgets/impedance_analyzer.py
+++ b/src/gui/widgets/impedance_analyzer.py
@@ -200,7 +200,7 @@ class ImpedanceAnalyzer(MeasurementModule):
         while not self._buffer_ready_event.is_set():
             if cancel_event and cancel_event.is_set():
                 break
-            self._buffer_ready_event.wait()
+            self._buffer_ready_event.wait(0.1)
 
     @property
     def name(self) -> str:

--- a/src/gui/widgets/linearity_analyzer.py
+++ b/src/gui/widgets/linearity_analyzer.py
@@ -331,7 +331,7 @@ class LinearityAnalyzer(MeasurementModule):
         while not self._buffer_ready_event.is_set():
             if cancel_event and cancel_event.is_set():
                 break
-            self._buffer_ready_event.wait()
+            self._buffer_ready_event.wait(0.1)
 
     def get_latest_buffer_into(self, out: np.ndarray) -> None:
         """Writes the current buffer contents ordered chronologically into `out`."""


### PR DESCRIPTION
## 🎯 What:
Fixes silent thread lockups (deadlocks) when measuring linearity and impedance if the audio stream halts or stutters. Also fixes silent exception swallowing in the virtual audio engine.

## ⚠️ Risk:
The `_buffer_ready_event.wait()` calls lacked timeouts. If `wait_for_buffer` was called and the audio callback never fired to set the event (e.g. if the audio device disconnected, the stream halted, or a race condition occurred between `.clear()` and the callback), the thread would hang indefinitely. Since it's hung on `.wait()`, it would never loop back around to check the `cancel_event`, meaning the UI cancellation buttons would appear unresponsive or fail to stop the measurement worker.

In `VirtualStream`, an overly broad `except Exception` lacked traceback logging, making bugs extremely difficult to debug during test failures or offline mode crashes.

## 🛡️ Solution:
1.  Added a `0.1` timeout to `_buffer_ready_event.wait()` in `LinearityAnalyzer` and `ImpedanceAnalyzer`. This ensures the loop wakes up frequently to poll the `cancel_event` and `is_running` states, ensuring robust cancellation even if the audio buffers stop arriving.
2.  Added `exc_info=True` to the `VirtualStream` `logger.error` call in `src/core/audio_engine.py`.

---
*PR created automatically by Jules for task [8316368316895990157](https://jules.google.com/task/8316368316895990157) started by @youtube-at-vach*