### PR TITLE
🧹 [fix empty exception blocks in PlotComparer's sync_y2_range]

### DIFF
--- a/src/gui/widgets/plot_comparer.py
+++ b/src/gui/widgets/plot_comparer.py
@@ -1147,12 +1147,12 @@ class PlotComparerWidget(QWidget):
         # Scale Y2 data automatically based on the visible range
         try:
             self.y2_view.autoRange(axis=pg.ViewBox.YAxis)
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug(f"Failed to autoRange Y2: {e}")
         try:
             self.on_range_changed()
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug(f"Failed in on_range_changed during sync_y2_range: {e}")
 
     def on_mouse_moved(self, pos):
         if not self.curve_items:


### PR DESCRIPTION
🎯 **What:** Fixed empty exception blocks (`except Exception: pass`) in `sync_y2_range` within `src/gui/widgets/plot_comparer.py`.
💡 **Why:** Silently swallowing generic exceptions makes it very difficult to debug unexpected failures in auto-ranging or signal emitting. Logging the error (even at the debug level) improves maintainability without impacting the user experience.
✅ **Verification:** Verified changes visually with `cat`, formatted with `ruff format`, checked with `ruff check`, and executed the full `pytest` suite ensuring all 825 tests pass (specifically `tests/logic_verification/gui/test_plot_comparer.py`).
✨ **Result:** Exceptions during Y2 auto-range synchronization are now appropriately recorded as debug logs rather than being silently ignored.

---
*PR created automatically by Jules for task [9932861149023573871](https://jules.google.com/task/9932861149023573871) started by @youtube-at-vach*