### PR TITLE
🧹 [Fix empty except blocks in network analyzer]

### DIFF
--- a/src/gui/widgets/network_analyzer.py
+++ b/src/gui/widgets/network_analyzer.py
@@ -1442,8 +1442,8 @@ class NetworkAnalyzerWidget(QWidget, ComparableWidgetInterface):
                 rect = vb.sceneBoundingRect()
                 if rect is not None:
                     self.gd_view.setGeometry(rect)
-        except (RuntimeError, AttributeError, TypeError):
-            pass
+        except (RuntimeError, AttributeError, TypeError) as e:
+            logger.debug(f"Error during view update: {e}")
 
     def update_coh_views(self):
         try:
@@ -1457,8 +1457,8 @@ class NetworkAnalyzerWidget(QWidget, ComparableWidgetInterface):
                 rect = vb.sceneBoundingRect()
                 if rect is not None:
                     self.coh_view.setGeometry(rect)
-        except (RuntimeError, AttributeError, TypeError):
-            pass
+        except (RuntimeError, AttributeError, TypeError) as e:
+            logger.debug(f"Error during view update: {e}")
 
     def on_ir_snr_result(self, snr):
         self.ir_snr_label.setText(tr("IR SNR: {0:.1f} dB").format(snr))


### PR DESCRIPTION
🎯 **What:**
Fixed the code health issue of empty `except` blocks (bare `pass`) in `src/gui/widgets/network_analyzer.py`. The `update_gd_views` and `update_coh_views` methods previously caught `RuntimeError`, `AttributeError`, and `TypeError` but silently ignored them. They now catch the exception as `e` and log it via `logger.debug`.

💡 **Why:**
Silently ignoring exceptions makes debugging and diagnosing potential state/GUI failures significantly harder. By logging the exceptions via `logger.debug()`, we record view update failures during testing/development without spamming standard output in production. This improves observability and maintainability.

✅ **Verification:**
1. Ran `ruff format` and `ruff check --fix` on `src/gui/widgets/network_analyzer.py` (verified 0 issues).
2. Ran the full test suite (`QT_QPA_PLATFORM=offscreen PYTHONPATH=. python -m pytest tests/`).
3. Confirmed all 825 tests successfully passed.

✨ **Result:**
The `except` blocks no longer silently swallow view update failures, leading to better diagnostic logs and code health without impacting existing behavior.

---
*PR created automatically by Jules for task [15831904946883489322](https://jules.google.com/task/15831904946883489322) started by @youtube-at-vach*