### PR TITLE
🧹 [Fix empty except block in CalibrationManager]

### DIFF
--- a/src/core/calibration.py
+++ b/src/core/calibration.py
@@ -223,8 +223,8 @@ class CalibrationManager:
         try:
             self.lockin_gain_offset = float(offset)
             self.save()
-        except (ValueError, TypeError):
-            pass
+        except (ValueError, TypeError) as e:
+            self.logger.warning("Invalid lock-in gain offset provided: %s", e)
 
     def set_last_profile(self, name):
         """Sets the last selected profile name."""


### PR DESCRIPTION
🎯 **What:** Replaced the empty `except` block (bare `pass`) in `set_lockin_gain_offset` with proper exception logging in `src/core/calibration.py`.

💡 **Why:** Swallowing exceptions silently makes it difficult to diagnose why the lock-in gain offset failed to set if invalid input is provided. Logging the exception improves code maintainability and traceability without changing the functional behavior of the program.

✅ **Verification:** 
- Formatted and linted `src/core/calibration.py` using `ruff`.
- Ran the full test suite (`python -m pytest tests/`) via `QT_QPA_PLATFORM=offscreen`. All 825 tests passed.
- Verified the code change correctly catches `ValueError` and `TypeError` and logs them using `self.logger.warning`.

✨ **Result:** Improved code health by removing a silent failure anti-pattern and replacing it with actionable logging.

---
*PR created automatically by Jules for task [4087110554790289956](https://jules.google.com/task/4087110554790289956) started by @youtube-at-vach*