### PR TITLE
🧹 [Fix bare except in recorder_player _cleanup_temp_file]

### DIFF
--- a/src/gui/widgets/recorder_player.py
+++ b/src/gui/widgets/recorder_player.py
@@ -246,13 +246,13 @@ class RecorderPlayer(MeasurementModule):
         if obj is not None:
             try:
                 obj.close()
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug(f"Failed to close temp obj: {e}")
         if filepath and os.path.exists(filepath):
             try:
                 os.remove(filepath)
-            except OSError:
-                pass
+            except OSError as e:
+                logger.debug(f"Failed to remove temp file: {e}")
 
     def cleanup(self):
         """


### PR DESCRIPTION
🎯 **What:**
Replaced empty `except Exception:` and `except OSError:` blocks (`pass`) with `except ... as e:` and `logger.debug(...)` in the `_cleanup_temp_file` static method of `RecorderPlayer`.

💡 **Why:**
Using bare `pass` in exception handlers silently swallows errors, making debugging difficult if temporary file cleanup fails. Logging these exceptions at the debug level improves code health and maintainability by providing visibility into cleanup failures without spamming production logs.

✅ **Verification:**
- Ran `ruff check` and `ruff format` to ensure code style compliance.
- Ran the full pytest suite (`PYTHONPATH=. QT_QPA_PLATFORM=offscreen python -m pytest tests/`) successfully.
- Visually verified the patch correctly updated both exception blocks in `src/gui/widgets/recorder_player.py`.

✨ **Result:**
The code now correctly logs cleanup errors using the existing `logger`, resolving the code health issue of silent failures while maintaining existing functionality.

---
*PR created automatically by Jules for task [17789539341827756755](https://jules.google.com/task/17789539341827756755) started by @youtube-at-vach*