### PR TITLE
🧹 [Fix silent ValueError exception handling in settings.py]

### DIFF
--- a/src/gui/widgets/settings.py
+++ b/src/gui/widgets/settings.py
@@ -1874,8 +1874,8 @@ class SettingsWidget(QWidget):
                         "output_hostapi": out_hostapi,
                     }
                 )
-        except ValueError:
-            pass
+        except ValueError as e:
+            self.logger.debug(f"ValueError in on_sr_changed: {e}")
 
     def on_bs_changed(self, text):
         try:
@@ -1907,8 +1907,8 @@ class SettingsWidget(QWidget):
                         "output_hostapi": out_hostapi,
                     }
                 )
-        except ValueError:
-            pass
+        except ValueError as e:
+            self.logger.debug(f"ValueError in on_bs_changed: {e}")
 
     def on_buffer_level_changed(self):
         level = self.buffer_level_combo.currentData()


### PR DESCRIPTION
🎯 **What:** Replace bare `except ValueError: pass` with `self.logger.debug()` in settings widget.
💡 **Why:** Avoid swallowing exceptions silently to improve debugging and maintainability.
✅ **Verification:** Ensure tests pass and the logic works.
✨ **Result:** Improved code health.

---
*PR created automatically by Jules for task [7416225976852801470](https://jules.google.com/task/7416225976852801470) started by @youtube-at-vach*