### PR TITLE
🔒 [security fix Command Injection via sysctl in ProcessorBenchmark]

### DIFF
--- a/src/gui/widgets/processor_benchmark.py
+++ b/src/gui/widgets/processor_benchmark.py
@@ -51,16 +51,21 @@ def get_cpu_name():
             logger.debug(f"Failed to read CPU name from /proc/cpuinfo: {e}")
 
     elif sys.platform == "darwin":
-        import subprocess
+        import ctypes
+        import ctypes.util
 
         try:
-            return (
-                subprocess.check_output(["/usr/sbin/sysctl", "-n", "machdep.cpu.brand_string"], timeout=2.0)
-                .decode()
-                .strip()
-            )
-        except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
-            logger.debug(f"Failed to read CPU name from sysctl: {e}")
+            libc_name = ctypes.util.find_library("c")
+            if libc_name is not None:
+                libc = ctypes.cdll.LoadLibrary(libc_name)
+                size = ctypes.c_size_t()
+                name = b"machdep.cpu.brand_string"
+                if libc.sysctlbyname(name, None, ctypes.byref(size), None, 0) == 0:
+                    buf = ctypes.create_string_buffer(size.value)
+                    if libc.sysctlbyname(name, buf, ctypes.byref(size), None, 0) == 0:
+                        return buf.value.decode("utf-8").strip()
+        except Exception as e:
+            logger.debug(f"Failed to read CPU name from sysctlbyname: {e}")
 
     return None
 

--- a/tests/logic_verification/gui/widgets/test_processor_benchmark_darwin.py
+++ b/tests/logic_verification/gui/widgets/test_processor_benchmark_darwin.py
@@ -1,5 +1,4 @@
 from unittest.mock import MagicMock, patch
-import subprocess
 
 mock_dict = {
     "numpy": MagicMock(),
@@ -18,22 +17,30 @@ with patch.dict("sys.modules", mock_dict):
 
 
 def test_get_cpu_name_darwin_exception():
-    """Test that get_cpu_name correctly handles exceptions when sysctl fails on darwin."""
-    with (
-        patch("sys.platform", "darwin"),
-        patch("subprocess.check_output", side_effect=subprocess.CalledProcessError(1, "sysctl")),
-    ):
-        result = get_cpu_name()
+    """Test that get_cpu_name correctly handles exceptions when sysctlbyname fails on darwin."""
+    with patch("sys.platform", "darwin"):
+        with patch("ctypes.util.find_library", return_value="c"), patch("ctypes.cdll.LoadLibrary") as mock_load:
+            # Simulate failure to get size
+            mock_load.return_value.sysctlbyname.return_value = -1
+            result = get_cpu_name()
+            assert result is None
 
-        assert result is None
 
+def test_get_cpu_name_darwin_success():
+    """Test that get_cpu_name returns the correct name when sysctlbyname succeeds."""
+    with patch("sys.platform", "darwin"):
+        with (
+            patch("ctypes.util.find_library", return_value="c"),
+            patch("ctypes.cdll.LoadLibrary") as mock_load,
+            patch("ctypes.create_string_buffer") as mock_buffer,
+        ):
+            # Simulate successful sysctlbyname calls
+            mock_load.return_value.sysctlbyname.return_value = 0
 
-def test_get_cpu_name_darwin_timeout():
-    """Test that get_cpu_name correctly handles timeout exception."""
-    with (
-        patch("sys.platform", "darwin"),
-        patch("subprocess.check_output", side_effect=subprocess.TimeoutExpired("sysctl", 2.0)),
-    ):
-        result = get_cpu_name()
+            # Setup the mocked buffer to return our test string
+            mock_buf_instance = MagicMock()
+            mock_buf_instance.value = b"Apple M1 Pro"
+            mock_buffer.return_value = mock_buf_instance
 
-        assert result is None
+            result = get_cpu_name()
+            assert result == "Apple M1 Pro"


### PR DESCRIPTION
🎯 **What:**
Fixed a potential command injection vulnerability in `ProcessorBenchmark` located in `src/gui/widgets/processor_benchmark.py`. The previous implementation retrieved the macOS CPU brand string by shelling out to `/usr/sbin/sysctl` using `subprocess.check_output`.

⚠️ **Risk:**
While the command arguments were currently hardcoded, utilizing `subprocess.check_output` creates a risky pattern that could lead to Command Injection if the code is ever refactored to accept dynamic parameters or user inputs, leading to arbitrary code execution under the user's privileges.

🛡️ **Solution:**
Replaced the `subprocess` call with a robust native integration using Python's `ctypes`. The code now securely queries `sysctlbyname` directly from the C standard library. This entirely removes the need to spawn an external process or invoke the shell, nullifying the attack vector. The unit tests in `tests/logic_verification/gui/widgets/test_processor_benchmark_darwin.py` were also updated to mock and verify the new `ctypes` flow correctly.

---
*PR created automatically by Jules for task [2483702256570033326](https://jules.google.com/task/2483702256570033326) started by @youtube-at-vach*