### PR TITLE
🧪 [Add tests for calculate_hysteresis empty input handling]

### DIFF
--- a/tests/logic_verification/instruments/test_linearity_analyzer_logic.py
+++ b/tests/logic_verification/instruments/test_linearity_analyzer_logic.py
@@ -346,3 +346,11 @@ def test_linearity_analyzer_amplitude_continuity():
     # outdata2[:, 0] must match expected_ramp_sig, and not match expected_step_sig
     assert np.allclose(outdata2[:, 0], expected_ramp_sig, atol=1e-5)
     assert not np.allclose(outdata2[:, 0], expected_step_sig, atol=1e-5)
+
+
+def test_calculate_hysteresis_empty_inputs():
+    """Verifies that calculate_hysteresis returns None for empty inputs."""
+    assert calculate_hysteresis([], [1.0], ["fwd"]) is None
+    assert calculate_hysteresis([1.0], [], ["fwd"]) is None
+    assert calculate_hysteresis([1.0], [1.0], []) is None
+    assert calculate_hysteresis([], [], []) is None


### PR DESCRIPTION
🎯 **What:** Missing test for calculate_hysteresis empty input handling. Added a new unit test for this condition.
📊 **Coverage:** Tests empty list combinations for `x_data`, `gain_data`, and `directions` to ensure `calculate_hysteresis` correctly returns `None` as expected.
✨ **Result:** Improved test coverage for `calculate_hysteresis` edge cases.

---
*PR created automatically by Jules for task [7224242281626066499](https://jules.google.com/task/7224242281626066499) started by @youtube-at-vach*