### PR TITLE
🧹 [Fix empty slice calculations in analysis and timecode monitor]

### DIFF
--- a/src/core/analysis.py
+++ b/src/core/analysis.py
@@ -1258,7 +1258,7 @@ class AudioCalc:
         i_white_start = AudioCalc._get_freq_index(freqs, 1000.0, axis_info, side="left")
         i_white_end = AudioCalc._get_freq_index(freqs, 20000.0, axis_info, side="right")
 
-        if i_white_start < i_white_end:
+        if i_white_start < i_white_end and len(mag[i_white_start:i_white_end]) > 0:
             # Median is robust to peaks, but under-estimates RMS of Gaussian noise (Rayleigh magnitude)
             white_density = np.median(mag[i_white_start:i_white_end]) * RAYLEIGH_RMS_FACTOR
         else:

--- a/src/gui/widgets/timecode_monitor.py
+++ b/src/gui/widgets/timecode_monitor.py
@@ -923,6 +923,8 @@ class TimecodeMonitor(MeasurementModule):
             keep_f = f_u[keep_mask]
 
         offsets2 = keep_f.astype(np.float64) - (float(fps) * keep_t)
+        if len(offsets2) == 0:
+            return False
         b = float(np.median(offsets2))
 
         f_last = int(keep_f[-1])


### PR DESCRIPTION
🎯 **What:**
Fixed issues where `np.median` could be called on empty slices, causing `RuntimeWarning`s, `NaN` propagation, and potentially `IndexError`s.

💡 **Why:**
- In `src/core/analysis.py`, calculating white noise density with an empty frequency slice resulted in `NaN` being propagated into the measurements.
- In `src/gui/widgets/timecode_monitor.py`, an empty sequence could crash the UI thread when attempting to compute offsets and access the last element of the sequence (`keep_f[-1]`).

✅ **Verification:**
Added appropriate guard checks and verified with the test suite that existing functionality remains intact. The checks ensure that when sequences are empty, the code falls back to safe default behaviors (returning fallback noise density or early exiting).

✨ **Result:**
The application is more stable against edge cases with empty data slices, preventing silent measurement failures and runtime crashes.

---
*PR created automatically by Jules for task [18353153075003583829](https://jules.google.com/task/18353153075003583829) started by @youtube-at-vach*