### PR TITLE
🔒 [security] Enforce explicit TLS verification in update checker

### DIFF
--- a/src/core/update_checker.py
+++ b/src/core/update_checker.py
@@ -39,7 +39,7 @@ class UpdateChecker(QThread):
             url = UPDATE_CHECK_URL
 
             headers = {"User-Agent": f"MeasureLab/{__version__}"}
-            response = requests.get(url, headers=headers, timeout=5)
+            response = requests.get(url, headers=headers, timeout=5, verify=True)
 
             if response.status_code == 200:
                 data = response.json()


### PR DESCRIPTION
🎯 **What:** The `requests.get` call used for checking new software versions in `src/core/update_checker.py` previously relied on default behavior for TLS verification. This patch explicitly adds `verify=True` to the request arguments.

⚠️ **Risk:** While `requests` defaults to verifying TLS certificates, failing to explicitly enforce verification in the codebase can cause static analysis security scanners (e.g., Bandit, Semgrep) to flag the call as a potential security risk. It also leaves the door open to unintentional insecure behavior if the default behavior were to change or be overridden globally, potentially exposing users to Man-in-the-Middle (MITM) attacks during update checks.

🛡️ **Solution:** Modified the `requests.get()` invocation to explicitly include `verify=True`. This enforces strict TLS connection verification, defending against MITM attacks and satisfying rigorous security static analysis rules, while preserving the existing 5-second timeout behavior.

---
*PR created automatically by Jules for task [15568830917246075191](https://jules.google.com/task/15568830917246075191) started by @youtube-at-vach*