### PR TITLE
🧪 [Add test coverage for audio stream close exception]

### DIFF
--- a/tests/logic_verification/core/test_audio_engine_logic.py
+++ b/tests/logic_verification/core/test_audio_engine_logic.py
@@ -78,6 +78,25 @@ class TestAudioEngineLogic(unittest.TestCase):
         # Verify stream is set to None even when exception occurs
         self.assertIsNone(self.engine.stream)
 
+    def test_stop_stream_close_exception(self):
+        # Create a mock stream that succeeds on stop but raises an exception on close
+        mock_stream = MagicMock()
+        mock_stream.stop.return_value = None
+        mock_stream.close.side_effect = Exception("Mock exception on close")
+
+        self.engine.stream = mock_stream
+
+        # This should handle the exception and log it
+        self.engine.stop_stream()
+
+        # Check if the logger was called with the exception
+        self.engine.logger.error.assert_called_once()
+        args, _ = self.engine.logger.error.call_args
+        self.assertIn("Mock exception on close", args[0])
+
+        # Verify stream is set to None
+        self.assertIsNone(self.engine.stream)
+
     def test_unregister_nonexistent(self):
         # Unregistering a non-existent callback should not crash and might not log "Unregistered callback"
         # or it handles it gracefully.


### PR DESCRIPTION
🎯 **What:** The previous test `test_stop_stream_exception` only verified exception handling when `stream.stop()` failed, leaving `stream.close()` (which is skipped when `stop()` raises) untested. This PR adds a new test method, `test_stop_stream_close_exception`, to explicitly mock a scenario where `stop()` succeeds but `close()` raises an exception, ensuring full execution of both lines within the `try` block.
📊 **Coverage:** The test coverage for the exception handling block inside `src/core/audio_engine.py:781-789` (specifically testing `self.stream.close()`) is now complete.
✨ **Result:** Increased test coverage for error conditions during audio stream shutdown, proving that the stream reference clears safely regardless of whether `stop()` or `close()` raises the exception.

---
*PR created automatically by Jules for task [5452041821196380277](https://jules.google.com/task/5452041821196380277) started by @youtube-at-vach*