### PR TITLE
🧪 [Add tests for QtLogHandler error handling]

### DIFF
--- a/tests/logic_verification/gui/test_log_viewer_logic.py
+++ b/tests/logic_verification/gui/test_log_viewer_logic.py
@@ -1,0 +1,50 @@
+import logging
+from unittest.mock import MagicMock, patch
+
+from src.gui.widgets.log_viewer import QtLogHandler
+
+
+def test_qt_log_handler_emit_none():
+    handler = QtLogHandler()
+    handler.signals = MagicMock()
+    handler.emit(None)
+    handler.signals.log_emitted.emit.assert_not_called()
+
+
+def test_qt_log_handler_emit_success():
+    handler = QtLogHandler()
+    handler.signals = MagicMock()
+    record = logging.LogRecord(
+        name="test_logger",
+        level=logging.INFO,
+        pathname="test.py",
+        lineno=1,
+        msg="Test message",
+        args=(),
+        exc_info=None,
+    )
+    handler.emit(record)
+    handler.signals.log_emitted.emit.assert_called_once()
+    args, _ = handler.signals.log_emitted.emit.call_args
+    assert "Test message" in args[0]
+    assert args[1] == logging.INFO
+
+
+def test_qt_log_handler_emit_exception():
+    handler = QtLogHandler()
+    handler.signals = MagicMock()
+    record = logging.LogRecord(
+        name="test_logger",
+        level=logging.INFO,
+        pathname="test.py",
+        lineno=1,
+        msg="Test message",
+        args=(),
+        exc_info=None,
+    )
+
+    with patch.object(handler, "format", side_effect=Exception("Test Exception")):
+        with patch.object(handler, "handleError") as mock_handle_error:
+            handler.emit(record)
+            mock_handle_error.assert_called_once_with(record)
+            handler.signals.log_emitted.emit.assert_not_called()


### PR DESCRIPTION
🎯 **What:** Added comprehensive tests for `QtLogHandler` in `src/gui/widgets/log_viewer.py`, specifically addressing the untested `except Exception:` block within the `emit` method that handles formatting and emission errors.
📊 **Coverage:** The new tests cover:
- Early exit when `record` is `None`.
- Successful happy path log emission ensuring the message string and correct log level are emitted.
- The error condition where formatting fails (mocked by raising an `Exception`), verifying that `self.handleError(record)` is correctly called.
✨ **Result:** Increased code coverage for `src/gui/widgets/log_viewer.py`. The `QtLogHandler.emit` method and its safety exception block are now 100% covered.

---
*PR created automatically by Jules for task [15740831049868820213](https://jules.google.com/task/15740831049868820213) started by @youtube-at-vach*