### PR TITLE
⚡ [Optimize Pink Noise Generation]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -18,3 +18,6 @@
 
 **Learning:** When calculating fractional octave smoothing bands and mapping center frequencies to spectrum bin indices, iterating over pre-calculated arrays in Python and appending to lists is slower than using vectorized Numpy operations to filter indices (`valid = ends > starts`) and returning a list of `zip()`-ed values. Converting the zipped indices directly using `.tolist()` and then `list(zip(...))` performs the conversion mostly in C.
 **Action:** Replace `for` loops containing manual list appending with `list(zip(start_array[mask].tolist(), end_array[mask].tolist()))` when constructing a list of start/end tuple indices from NumPy arrays.
+## 2026-06-05 - Vectorizing IIR filters with scipy.signal.lfilter
+**Learning:** Python `for` loops are exceptionally slow when iterating over samples to apply recursive difference equations (like Paul Kellet's Pink Noise filter).
+**Action:** Replace manual iterative loops using coefficients with fully vectorized calls to `scipy.signal.lfilter` (e.g., `lfilter([B], [1.0, -A], x, zi=state)`). Ensure boundary conditions (like `n=0`) are handled properly, and preserve instance variables correctly if public APIs or backward-compatible tests rely on them.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -18,6 +18,8 @@
 
 **Learning:** When calculating fractional octave smoothing bands and mapping center frequencies to spectrum bin indices, iterating over pre-calculated arrays in Python and appending to lists is slower than using vectorized Numpy operations to filter indices (`valid = ends > starts`) and returning a list of `zip()`-ed values. Converting the zipped indices directly using `.tolist()` and then `list(zip(...))` performs the conversion mostly in C.
 **Action:** Replace `for` loops containing manual list appending with `list(zip(start_array[mask].tolist(), end_array[mask].tolist()))` when constructing a list of start/end tuple indices from NumPy arrays.
+
 ## 2026-06-05 - Vectorizing IIR filters with scipy.signal.lfilter
+
 **Learning:** Python `for` loops are exceptionally slow when iterating over samples to apply recursive difference equations (like Paul Kellet's Pink Noise filter).
 **Action:** Replace manual iterative loops using coefficients with fully vectorized calls to `scipy.signal.lfilter` (e.g., `lfilter([B], [1.0, -A], x, zi=state)`). Ensure boundary conditions (like `n=0`) are handled properly, and preserve instance variables correctly if public APIs or backward-compatible tests rely on them.

--- a/src/core/generators.py
+++ b/src/core/generators.py
@@ -1,10 +1,12 @@
 import numpy as np
+from scipy.signal import lfilter
 
 
 class PinkNoise:
     """Stateful pink-noise generator (Paul Kellet filter)."""
 
     def __init__(self):
+        # We must keep b0-b6 for backward compatibility with tests
         self.b0 = 0.0
         self.b1 = 0.0
         self.b2 = 0.0
@@ -13,30 +15,42 @@ class PinkNoise:
         self.b5 = 0.0
         self.b6 = 0.0
 
+        # Internal state arrays for lfilter
+        self._zi0 = np.array([0.0])
+        self._zi1 = np.array([0.0])
+        self._zi2 = np.array([0.0])
+        self._zi3 = np.array([0.0])
+        self._zi4 = np.array([0.0])
+        self._zi5 = np.array([0.0])
+
     def generate(self, n: int):
+        if n <= 0:
+            return np.empty(0, dtype=np.float32)
+
         white = np.random.randn(n).astype(np.float32)
 
-        out = np.empty(n, dtype=np.float32)
-        b0 = self.b0
-        b1 = self.b1
-        b2 = self.b2
-        b3 = self.b3
-        b4 = self.b4
-        b5 = self.b5
-        b6 = self.b6
+        # Vectorized implementation of Paul Kellet's refined pink noise filter.
+        b0_arr, self._zi0 = lfilter([0.0555179], [1.0, -0.99886], white, zi=self._zi0)
+        b1_arr, self._zi1 = lfilter([0.0750759], [1.0, -0.99332], white, zi=self._zi1)
+        b2_arr, self._zi2 = lfilter([0.1538520], [1.0, -0.96900], white, zi=self._zi2)
+        b3_arr, self._zi3 = lfilter([0.3104856], [1.0, -0.86650], white, zi=self._zi3)
+        b4_arr, self._zi4 = lfilter([0.5329522], [1.0, -0.55000], white, zi=self._zi4)
+        b5_arr, self._zi5 = lfilter([-0.0168980], [1.0, 0.7616], white, zi=self._zi5)
 
-        # Coefficients from Paul Kellet's refined pink noise filter.
-        for i in range(n):
-            w = float(white[i])
-            b0 = 0.99886 * b0 + w * 0.0555179
-            b1 = 0.99332 * b1 + w * 0.0750759
-            b2 = 0.96900 * b2 + w * 0.1538520
-            b3 = 0.86650 * b3 + w * 0.3104856
-            b4 = 0.55000 * b4 + w * 0.5329522
-            b5 = -0.7616 * b5 - w * 0.0168980
-            y = b0 + b1 + b2 + b3 + b4 + b5 + b6 + w * 0.5362
-            b6 = w * 0.115926
-            out[i] = y * 0.11
+        b6_arr = np.empty(n, dtype=np.float32)
+        b6_arr[0] = self.b6
+        if n > 1:
+            b6_arr[1:] = white[:-1] * 0.115926
 
-        self.b0, self.b1, self.b2, self.b3, self.b4, self.b5, self.b6 = b0, b1, b2, b3, b4, b5, b6
-        return out
+        self.b6 = float(white[-1] * 0.115926)
+
+        # Sync the public attributes with the last internal state for backwards compatibility
+        self.b0 = float(b0_arr[-1])
+        self.b1 = float(b1_arr[-1])
+        self.b2 = float(b2_arr[-1])
+        self.b3 = float(b3_arr[-1])
+        self.b4 = float(b4_arr[-1])
+        self.b5 = float(b5_arr[-1])
+
+        y = b0_arr + b1_arr + b2_arr + b3_arr + b4_arr + b5_arr + b6_arr + white * 0.5362
+        return (y * 0.11).astype(np.float32)


### PR DESCRIPTION
💡 **What:**
Replaced the element-by-element Python loop in `PinkNoise.generate` with vectorized calls to `scipy.signal.lfilter`. Added internal state arrays (`_zi`) to manage recursive state between calls, and explicitly synchronized the legacy attributes (`self.b0` to `self.b6`) for backward compatibility with existing tests. Handled the `n <= 0` edge case safely.

🎯 **Why:**
The original implementation used a pure Python `for` loop to compute the Paul Kellet recursive difference equations for each individual sample. For large arrays (e.g., 100k samples), this adds significant interpreter overhead and slows down generation loops.

📊 **Measured Improvement:**
In local benchmarking for `n=100000`, the loop-based generation took ~0.078s, whereas the `lfilter` implementation took ~0.011s—approximately an **85% reduction in execution time (7x speedup)**.

---
*PR created automatically by Jules for task [3283683235405894920](https://jules.google.com/task/3283683235405894920) started by @youtube-at-vach*