### PR TITLE
🧪 [Add test for WrappingSplashScreen.showMessage]

### DIFF
--- a/tests/logic_verification/gui/test_startup_logic.py
+++ b/tests/logic_verification/gui/test_startup_logic.py
@@ -1,0 +1,18 @@
+from unittest.mock import patch
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QPixmap
+from src.gui.startup import WrappingSplashScreen
+
+
+def test_wrapping_splash_screen_show_message_updates_state_and_repaints(qtbot):
+    pixmap = QPixmap(100, 100)
+    splash = WrappingSplashScreen(pixmap)
+    qtbot.addWidget(splash)
+
+    with patch.object(splash, "repaint") as mock_repaint:
+        splash.showMessage("Test message", alignment=Qt.AlignmentFlag.AlignCenter, color=Qt.GlobalColor.red)
+
+        assert splash._message == "Test message"
+        assert splash._alignment == Qt.AlignmentFlag.AlignCenter
+        assert splash._color == Qt.GlobalColor.red
+        mock_repaint.assert_called_once()


### PR DESCRIPTION
🎯 **What:** Adds unit tests to cover `WrappingSplashScreen.showMessage` functionality, which was previously missing test coverage.
📊 **Coverage:** The test explicitly verifies that calling `showMessage` updates the internal state (`_message`, `_alignment`, `_color`) correctly and subsequently triggers a UI `repaint()`.
✨ **Result:** Improved test coverage and reliability for the GUI startup code, ensuring that splash screen messages are reliably processed.

---
*PR created automatically by Jules for task [552585582700419755](https://jules.google.com/task/552585582700419755) started by @youtube-at-vach*