### PR TITLE
🧪 [Add test for _build_module_activity_tooltip in MainWindow]

### DIFF
--- a/tests/logic_verification/gui/test_main_window_activity.py
+++ b/tests/logic_verification/gui/test_main_window_activity.py
@@ -71,3 +71,30 @@ def test_refresh_sidebar_activity_indicators_updates_visuals_and_tooltips(qtbot)
     inactive_item = window.sidebar.item(2)
     assert not inactive_item.font().bold()
     assert inactive_item.foreground().color() == default_brush.color()
+
+
+def test_build_module_activity_tooltip(qtbot):
+    window = _build_window_stub(qtbot)
+
+    # Test case 1: Active module
+    window.modules[0] = _DummyModule(is_playing=True)
+    window.module_widgets[0] = _DummyWrapper(is_detached=False)
+    tooltip1 = window._build_module_activity_tooltip(0)
+    assert tr("Signal Generator") in tooltip1
+    assert tr("ACTIVE") in tooltip1
+    assert tr("Widget is detached in a separate window.") not in tooltip1
+
+    # Test case 2: Inactive and detached module
+    window.modules[1] = _DummyModule()
+    window.module_widgets[1] = _DummyWrapper(is_detached=True)
+    tooltip2 = window._build_module_activity_tooltip(1)
+    assert tr("Recorder / Player") in tooltip2
+    assert tr("ACTIVE") not in tooltip2
+    assert tr("Widget is detached in a separate window.") in tooltip2
+
+    # Test case 3: Active and detached module
+    window.modules[1] = _DummyModule(is_recording=True)
+    tooltip3 = window._build_module_activity_tooltip(1)
+    assert tr("Recorder / Player") in tooltip3
+    assert tr("ACTIVE") in tooltip3
+    assert tr("Widget is detached in a separate window.") in tooltip3


### PR DESCRIPTION
🎯 **What:** Added a missing unit test for the `_build_module_activity_tooltip` method in `src/gui/main_window.py`. The previous implementation was not tested.

📊 **Coverage:** The new test `test_build_module_activity_tooltip` covers all major scenarios:
- Active module with attached widget
- Inactive module with detached widget
- Active module with detached widget
It validates the correct string formations including localized translation components like `ACTIVE` and `Widget is detached in a separate window.`.

✨ **Result:** Test coverage for `src/gui/main_window.py` is improved, ensuring the correct formatting logic is preserved for future refactoring. All tests pass without regressions.

---
*PR created automatically by Jules for task [10938004380599788890](https://jules.google.com/task/10938004380599788890) started by @youtube-at-vach*