### PR TITLE
🧹 Remove dead code measure_crosstalk

### DIFF
--- a/src/core/transmission_logic.py
+++ b/src/core/transmission_logic.py
@@ -325,44 +325,6 @@ def calculate_equalized_evm(rx_block: np.ndarray, tx_block: np.ndarray, regulari
     return float(np.clip(evm_percent, 0.0, 100.0))
 
 
-def measure_crosstalk(rx_block: np.ndarray, leak_reference: np.ndarray) -> float:
-    """
-    Measures crosstalk by finding the leakage correlation with the opposite channel's PRBS sequence.
-
-    Returns leakage ratio in dB.
-    """
-    N = len(rx_block)
-    M = len(leak_reference)
-
-    # Sub-segment correlation
-    sub_len = min(N, M)
-    rx_seg = rx_block[:sub_len]
-    leak_seg = leak_reference[:sub_len]
-
-    rx_ac = rx_seg - np.mean(rx_seg)
-    leak_ac = leak_seg - np.mean(leak_seg)
-
-    norm_rx = np.linalg.norm(rx_ac)
-    norm_leak = np.linalg.norm(leak_ac)
-
-    if norm_rx < 1e-6 or norm_leak < 1e-6:
-        return -120.0
-
-    rx_ac /= norm_rx
-    leak_ac /= norm_leak
-
-    # Calculate scalar projection of leak onto rx
-    # Represents the leakage coefficient
-    c_coeff = np.dot(rx_seg, leak_seg) / np.dot(leak_seg, leak_seg)
-    c_coeff_abs = abs(c_coeff)
-
-    if c_coeff_abs < 1e-6:
-        return -120.0
-
-    crosstalk_db = 20 * np.log10(c_coeff_abs + 1e-12)
-    return float(np.clip(crosstalk_db, -120.0, 0.0))
-
-
 def diagnose_bit_perfection(rx: np.ndarray, ref: np.ndarray) -> dict:
     """
     Analyzes rx and ref to determine exact digital transmission path bit-perfection.
@@ -622,7 +584,6 @@ def apply_octave_smoothing(freqs: np.ndarray, mag_db: np.ndarray, fraction: floa
     return smoothed
 
 
-
 def calculate_step_response(impulse_response: np.ndarray) -> np.ndarray:
     """
     インパルス応答 h[t] からステップ応答 (Step Response) を累積積分により高速に算出します。
@@ -652,7 +613,7 @@ def analyze_step_transient(step_y: np.ndarray, sr: float) -> dict:
         "settling_ms": 0.0,
         "droop_pct": 0.0,
         "step_gain": 0.0,
-        "valid": False
+        "valid": False,
     }
 
     N = len(step_y)
@@ -682,7 +643,7 @@ def analyze_step_transient(step_y: np.ndarray, sr: float) -> dict:
     if final_start >= N:
         final_start = N - 1
 
-    v_final = float(np.mean(step_y[final_start:min(final_start + 150, N)]))
+    v_final = float(np.mean(step_y[final_start : min(final_start + 150, N)]))
 
     # ステップ全体の高さ
     v_step = v_final - v_base
@@ -754,15 +715,15 @@ def analyze_step_transient(step_y: np.ndarray, sr: float) -> dict:
     droop_pct = (droop_val / v_step_abs) * 100.0
     droop_pct = max(0.0, droop_pct)
 
-    results.update({
-        "overshoot_pct": float(np.clip(overshoot_pct, 0.0, 200.0)),
-        "settling_samples": int(settling_samples),
-        "settling_ms": float(settling_ms),
-        "droop_pct": float(np.clip(droop_pct, 0.0, 100.0)),
-        "step_gain": float(v_step),
-        "valid": True
-    })
+    results.update(
+        {
+            "overshoot_pct": float(np.clip(overshoot_pct, 0.0, 200.0)),
+            "settling_samples": int(settling_samples),
+            "settling_ms": float(settling_ms),
+            "droop_pct": float(np.clip(droop_pct, 0.0, 100.0)),
+            "step_gain": float(v_step),
+            "valid": True,
+        }
+    )
 
     return results
-
-

--- a/tests/logic_verification/core/test_transmission.py
+++ b/tests/logic_verification/core/test_transmission.py
@@ -13,7 +13,6 @@ from src.core.transmission_logic import (
     extract_frequency_response,
     calculate_evm,
     calculate_equalized_evm,
-    measure_crosstalk,
     diagnose_bit_perfection,
     estimate_fractional_delay,
     shift_signal_fractional,
@@ -168,24 +167,6 @@ class TestTransmissionLogic(unittest.TestCase):
         self.assertGreater(evm_noisy_equalized, 0.5)
         self.assertLess(evm_noisy_equalized, evm_unequalized)  # Equalization still removes linear part
 
-    def test_measure_crosstalk(self):
-        """Test stereo crosstalk leakage measurement with longer block sizes for orthogonality."""
-        gen1 = PRBSGenerator("PRBS-9")
-        gen2 = PRBSGenerator("PRBS-15")
-
-        # Generate longer sequence for cross-channel orthogonality
-        tx_aligned = gen1.generate_reference_sequence(8192, bit_depth=24)
-        tx_leak = gen2.generate_reference_sequence(8192, bit_depth=24)
-
-        # Crosstalk at -40 dB leakage ratio
-        leakage_db = -40.0
-        leakage_coeff = 10 ** (leakage_db / 20.0)
-
-        rx = tx_aligned + leakage_coeff * tx_leak
-
-        crosstalk_result = measure_crosstalk(rx, tx_leak)
-        self.assertAlmostEqual(crosstalk_result, leakage_db, delta=10.0)
-
     def test_diagnose_bit_perfection_success(self):
         """Test transparent bit-for-bit diagnosis."""
         gen = PRBSGenerator(mode="PRBS-9")
@@ -292,7 +273,6 @@ class TestTransmissionLogic(unittest.TestCase):
         # Validate that the final fractional correlation is extremely high
         self.assertGreater(frac_corr, 0.98)
 
-
     def test_calculate_step_response(self):
         """Test step response calculation from impulse response."""
         h = np.zeros(128, dtype=np.float32)
@@ -319,7 +299,7 @@ class TestTransmissionLogic(unittest.TestCase):
         # 2. Step response with overshoot & ringing settling
         step_y_ring = np.zeros(512, dtype=np.float32)
         step_y_ring[128:] = 1.0
-        step_y_ring[128:135] = 1.2   # 20% Overshoot
+        step_y_ring[128:135] = 1.2  # 20% Overshoot
         step_y_ring[135:150] = 1.05  # Rings outside 2% tolerance band
 
         res_ring = analyze_step_transient(step_y_ring, 48000)
@@ -354,7 +334,7 @@ class TestTransmissionLogic(unittest.TestCase):
         # Rising at index 128
         step_decay[128:] = 1.0
         # Simulated droop: decay factor after rising edge
-        decay_factor = np.exp(-np.arange(384) / 500.0) # Decay to ~46% over 384 samples
+        decay_factor = np.exp(-np.arange(384) / 500.0)  # Decay to ~46% over 384 samples
         step_decay[128:] *= decay_factor
 
         res_decay = analyze_step_transient(step_decay, 48000)


### PR DESCRIPTION
🎯 **What:** Removed unused `measure_crosstalk` method and its corresponding test.
💡 **Why:** It is completely unused dead code, which clutters the transmission logic and adds unnecessary maintenance burden.
✅ **Verification:** Searched the entire codebase with grep to ensure there were no other references, and ran the full pytest suite.
✨ **Result:** Improved code readability and reduced codebase size without altering any existing application behavior.

---
*PR created automatically by Jules for task [4891077855257074793](https://jules.google.com/task/4891077855257074793) started by @youtube-at-vach*