### PR TITLE
🧪 [Add explicit test for ExportManager.get_exporter]

### DIFF
--- a/tests/core/export/test_manager.py
+++ b/tests/core/export/test_manager.py
@@ -81,3 +81,17 @@ def test_export_manager_init_idempotent():
 
     # The exporters dict should be the exact same object, not a new one
     assert manager._exporters is original_exporters
+
+
+def test_export_manager_get_exporter_explicit():
+    """Explicitly test get_exporter for existing and non-existing formats."""
+    manager = ExportManager()
+
+    # Test getting an existing default exporter
+    json_exporter = manager.get_exporter("json")
+    assert json_exporter is not None
+    assert isinstance(json_exporter, JsonTraceExporter)
+
+    # Test getting a non-existent exporter
+    missing_exporter = manager.get_exporter("unsupported_format_xyz")
+    assert missing_exporter is None


### PR DESCRIPTION
🎯 **What:** The testing gap in `ExportManager.get_exporter` has been addressed by adding an explicit unit test targeting the dictionary lookup functionality.

📊 **Coverage:** The new test `test_export_manager_get_exporter_explicit` explicitly covers querying for both an existing default exporter (e.g., `"json"`) and querying for a nonexistent key, ensuring correct return types and `None` handling.

✨ **Result:** Test coverage and explicitness for straightforward dictionary lookups within `ExportManager` are now highly robust.

---
*PR created automatically by Jules for task [16794175254305183070](https://jules.google.com/task/16794175254305183070) started by @youtube-at-vach*