### PR TITLE
🧪 [Add test for ExportManager.register_exporter]

### DIFF
--- a/tests/core/export/test_manager.py
+++ b/tests/core/export/test_manager.py
@@ -81,3 +81,18 @@ def test_export_manager_init_idempotent():
 
     # The exporters dict should be the exact same object, not a new one
     assert manager._exporters is original_exporters
+
+
+def test_export_manager_register_exporter(mocker):
+    """Test that register_exporter inserts the exporter and logs a message."""
+    manager = ExportManager()
+
+    dummy = mocker.Mock(spec=BaseTraceExporter)
+    dummy.format_id = "test_format"
+
+    mock_logger = mocker.patch("src.core.export.manager.logger.info")
+
+    manager.register_exporter(dummy)
+
+    assert manager._exporters["test_format"] is dummy
+    mock_logger.assert_called_once_with("Registered exporter for format: 'test_format'")

--- a/tests/core/export/test_manager.py
+++ b/tests/core/export/test_manager.py
@@ -83,16 +83,17 @@ def test_export_manager_init_idempotent():
     assert manager._exporters is original_exporters
 
 
-def test_export_manager_register_exporter(mocker):
+def test_export_manager_register_exporter():
     """Test that register_exporter inserts the exporter and logs a message."""
+    from unittest.mock import Mock, patch
+
     manager = ExportManager()
 
-    dummy = mocker.Mock(spec=BaseTraceExporter)
+    dummy = Mock(spec=BaseTraceExporter)
     dummy.format_id = "test_format"
 
-    mock_logger = mocker.patch("src.core.export.manager.logger.info")
+    with patch("src.core.export.manager.logger.info") as mock_logger:
+        manager.register_exporter(dummy)
 
-    manager.register_exporter(dummy)
-
-    assert manager._exporters["test_format"] is dummy
-    mock_logger.assert_called_once_with("Registered exporter for format: 'test_format'")
+        assert manager._exporters["test_format"] is dummy
+        mock_logger.assert_called_once_with("Registered exporter for format: 'test_format'")


### PR DESCRIPTION
🎯 **What:** The `register_exporter` method in `ExportManager` had missing test coverage, specifically regarding its side-effects (insertion into the internal dictionary and the logging output).

📊 **Coverage:** A new test `test_export_manager_register_exporter` has been added to `tests/core/export/test_manager.py`. It uses a mock exporter to verify that the method correctly inserts the exporter into `_exporters` under the correct `format_id` and appropriately logs the registration action.

✨ **Result:** Test coverage for `src/core/export/manager.py` is now comprehensively validated, ensuring future refactoring won't accidentally break exporter registration.

---
*PR created automatically by Jules for task [369349378249628381](https://jules.google.com/task/369349378249628381) started by @youtube-at-vach*