### PR TITLE
🧪 [Add test for ExportManager.get_all_exporters]

### DIFF
--- a/tests/core/export/test_manager.py
+++ b/tests/core/export/test_manager.py
@@ -81,3 +81,17 @@ def test_export_manager_init_idempotent():
 
     # The exporters dict should be the exact same object, not a new one
     assert manager._exporters is original_exporters
+
+
+def test_export_manager_get_all_exporters():
+    """Test get_all_exporters returns a copy of the exporters dictionary."""
+    ExportManager._instance = None
+    manager = ExportManager.instance()
+
+    exporters = manager.get_all_exporters()
+    assert "json" in exporters
+    assert "csv" in exporters
+
+    # Verify it returns a copy, modifying it doesn't affect internal state
+    exporters["dummy"] = "fake_exporter"
+    assert "dummy" not in manager._exporters


### PR DESCRIPTION
🎯 **What:** Missing test for `ExportManager.get_all_exporters`.
📊 **Coverage:** Now tests that `get_all_exporters` returns all default exporters and correctly returns a copy of the internal dictionary to prevent unwanted mutations.
✨ **Result:** Improved test coverage and reliability for `ExportManager` state access.

---
*PR created automatically by Jules for task [10318021988749703206](https://jules.google.com/task/10318021988749703206) started by @youtube-at-vach*