### PR TITLE
🧹 [Remove unused _interp_crossing_time dead code]

### DIFF
--- a/src/gui/widgets/oscilloscope.py
+++ b/src/gui/widgets/oscilloscope.py
@@ -392,37 +392,6 @@ class Oscilloscope(MeasurementModule):
                 return None
 
     @staticmethod
-    def _interp_crossing_time(t: np.ndarray, y: np.ndarray, level: float, direction: str):
-        """Return interpolated crossing time for the first crossing in the requested direction.
-
-        direction: 'rising' or 'falling'
-        """
-        if t is None or y is None or len(t) < 2:
-            return None
-        if direction == "rising":
-            mask = (y[:-1] < level) & (y[1:] >= level)
-        else:
-            mask = (y[:-1] > level) & (y[1:] <= level)
-
-        idx = np.argmax(mask)
-        if not mask[idx]:
-            return None
-        i = int(idx)
-        y0 = float(y[i])
-        y1 = float(y[i + 1])
-        t0 = float(t[i])
-        t1 = float(t[i + 1])
-        denom = y1 - y0
-        if denom == 0:
-            return t0
-        frac = (level - y0) / denom
-        if frac < 0:
-            frac = 0
-        elif frac > 1:
-            frac = 1
-        return t0 + frac * (t1 - t0)
-
-    @staticmethod
     def estimate_frequency_hz(t: np.ndarray, y: np.ndarray):
         """Estimate frequency from rising zero-crossings (DC-removed)."""
         if t is None or y is None or len(t) < 4:

--- a/tests/logic_verification/instruments/test_oscilloscope_logic.py
+++ b/tests/logic_verification/instruments/test_oscilloscope_logic.py
@@ -42,34 +42,6 @@ class MockAudioEngine:
 class TestOscilloscopeStaticMethods(unittest.TestCase):
     """Tests for static helper methods in Oscilloscope class."""
 
-    def test_interp_crossing_time(self):
-        # We need to import Oscilloscope.
-        # Ideally we import it normally if dependencies allow.
-        # Since we have numpy/scipy installed, it should work.
-        from src.gui.widgets.oscilloscope import Oscilloscope
-
-        # Rising crossing
-        t = np.array([0.0, 1.0])
-        y = np.array([-1.0, 1.0])
-        res = Oscilloscope._interp_crossing_time(t, y, 0.0, "rising")
-        self.assertAlmostEqual(res, 0.5)
-
-        # Falling crossing
-        y = np.array([1.0, -1.0])
-        res = Oscilloscope._interp_crossing_time(t, y, 0.0, "falling")
-        self.assertAlmostEqual(res, 0.5)
-
-        # No crossing
-        y = np.array([0.5, 1.0])
-        res = Oscilloscope._interp_crossing_time(t, y, 0.0, "rising")
-        self.assertIsNone(res)
-
-        # Multiple crossings (pick first)
-        t = np.array([0.0, 1.0, 2.0, 3.0])
-        y = np.array([-1.0, 1.0, -1.0, 1.0])
-        res = Oscilloscope._interp_crossing_time(t, y, 0.0, "rising")
-        self.assertAlmostEqual(res, 0.5)
-
     def test_estimate_frequency_hz(self):
         from src.gui.widgets.oscilloscope import Oscilloscope
 


### PR DESCRIPTION
🎯 **What:** Removed the unused `_interp_crossing_time` static method from `src/gui/widgets/oscilloscope.py` and its corresponding test `test_interp_crossing_time` from `tests/logic_verification/instruments/test_oscilloscope_logic.py`.
💡 **Why:** The method was dead code that is no longer used, removing it improves the codebase health and readability.
✅ **Verification:** Verified by passing the `ruff check`, `ruff format`, and executing the entire pytest suite successfully.
✨ **Result:** Cleaned up code and improved maintainability without functional regressions.

---
*PR created automatically by Jules for task [3694758458312334720](https://jules.google.com/task/3694758458312334720) started by @youtube-at-vach*