### PR TITLE
🧪 [Add tests for ThemeManager._apply_system_theme]

### DIFF
--- a/tests/logic_verification/core/test_theme_manager.py
+++ b/tests/logic_verification/core/test_theme_manager.py
@@ -129,6 +129,28 @@ class TestThemeManager(unittest.TestCase):
         if "src.core.theme_manager" in sys.modules:
             del sys.modules["src.core.theme_manager"]
 
+    def test_apply_system_theme_dark(self):
+        tm = self.ThemeManager(self.mock_app)
+        tm._detect_system_theme = MagicMock(return_value="dark")
+        tm._apply_dark_theme = MagicMock()
+        tm._apply_light_theme = MagicMock()
+
+        tm._apply_system_theme()
+
+        tm._apply_dark_theme.assert_called_once()
+        tm._apply_light_theme.assert_not_called()
+
+    def test_apply_system_theme_light(self):
+        tm = self.ThemeManager(self.mock_app)
+        tm._detect_system_theme = MagicMock(return_value="light")
+        tm._apply_dark_theme = MagicMock()
+        tm._apply_light_theme = MagicMock()
+
+        tm._apply_system_theme()
+
+        tm._apply_light_theme.assert_called_once()
+        tm._apply_dark_theme.assert_not_called()
+
     def test_get_current_theme_with_config(self):
         """Test that get_current_theme resolves 'system' using config_manager and internal Qt detection."""
         mock_config = MagicMock()


### PR DESCRIPTION
🎯 **What:** Missing tests for ThemeManager._apply_system_theme method which were unverified.
📊 **Coverage:** ThemeManager._apply_system_theme logic determining which child apply method to call based on the detected system theme. Both "light" and "dark" themes are tested using mocks.
✨ **Result:** Test suite is now more robust and protects _apply_system_theme from potential regressions.

---
*PR created automatically by Jules for task [7537555336767590236](https://jules.google.com/task/7537555336767590236) started by @youtube-at-vach*