### PR TITLE
🧹 [Code Health] Remove dead code `get_supported_formats`

### DIFF
--- a/src/core/export/manager.py
+++ b/src/core/export/manager.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, List, Optional
+from typing import Dict, Optional
 from .base import BaseTraceExporter
 from .json_exporter import JsonTraceExporter
 from .csv_exporter import CsvTraceExporter
@@ -36,6 +36,3 @@ class ExportManager:
 
     def get_all_exporters(self) -> Dict[str, BaseTraceExporter]:
         return self._exporters.copy()
-
-    def get_supported_formats(self) -> List[str]:
-        return list(self._exporters.keys())

--- a/tests/core/export/test_manager.py
+++ b/tests/core/export/test_manager.py
@@ -20,7 +20,7 @@ def test_export_manager_initializes_with_default_exporters():
     ExportManager._instance = None
     manager = ExportManager.instance()
 
-    formats = manager.get_supported_formats()
+    formats = list(manager.get_all_exporters().keys())
     assert "json" in formats
     assert "csv" in formats
 
@@ -55,7 +55,7 @@ def test_export_manager_register_and_get_exporter():
     dummy = DummyExporter()
     manager.register_exporter(dummy)
 
-    assert "dummy" in manager.get_supported_formats()
+    assert "dummy" in manager.get_all_exporters()
     assert manager.get_exporter("dummy") is dummy
 
     all_exporters = manager.get_all_exporters()
@@ -82,57 +82,3 @@ def test_export_manager_init_idempotent():
     # The exporters dict should be the exact same object, not a new one
     assert manager._exporters is original_exporters
 
-
-def test_export_manager_get_supported_formats():
-    """Test that get_supported_formats returns a list of registered format IDs."""
-    manager = ExportManager()
-
-    class DummyExporter1(BaseTraceExporter):
-        @property
-        def format_id(self) -> str:
-            return "dummy1"
-
-        @property
-        def name(self) -> str:
-            return "Dummy1 Format"
-
-        @property
-        def file_filter(self) -> str:
-            return "Dummy1 Files (*.dummy1)"
-
-        @property
-        def default_extension(self) -> str:
-            return ".dummy1"
-
-        def export_traces(self, filepath, traces, options) -> bool:
-            return True
-
-    class DummyExporter2(BaseTraceExporter):
-        @property
-        def format_id(self) -> str:
-            return "dummy2"
-
-        @property
-        def name(self) -> str:
-            return "Dummy2 Format"
-
-        @property
-        def file_filter(self) -> str:
-            return "Dummy2 Files (*.dummy2)"
-
-        @property
-        def default_extension(self) -> str:
-            return ".dummy2"
-
-        def export_traces(self, filepath, traces, options) -> bool:
-            return True
-
-    manager.register_exporter(DummyExporter1())
-    manager.register_exporter(DummyExporter2())
-
-    formats = manager.get_supported_formats()
-    assert "dummy1" in formats
-    assert "dummy2" in formats
-    # Should include default exporters + newly added dummy exporters
-    assert "json" in formats
-    assert "csv" in formats


### PR DESCRIPTION
🎯 **What:** Removed the completely unused `get_supported_formats` method from `src/core/export/manager.py`.

💡 **Why:** The function was entirely unused across the repository. Simple removal prevents confusion, eliminates dead code, and improves the overall maintainability of the export system.

✅ **Verification:**
- Verified no internal references to `get_supported_formats` exist (outside of test files).
- Removed the specific `test_export_manager_get_supported_formats` unit test.
- Updated `tests/core/export/test_manager.py` to correctly test `ExportManager` properties using `manager.get_all_exporters().keys()`.
- Successfully ran the entire test suite via `pytest` to confirm no unintended regressions were introduced.
- Cleaned up unused types via `ruff check --fix`.

✨ **Result:** A cleaner `ExportManager` interface without dead code, simpler tests, and slightly lower cognitive load.

---
*PR created automatically by Jules for task [7715035812262675791](https://jules.google.com/task/7715035812262675791) started by @youtube-at-vach*