### PR TITLE
🧹 [Remove unused BaseTraceExporter import]

### DIFF
--- a/src/core/export/__init__.py
+++ b/src/core/export/__init__.py
@@ -1,4 +1,3 @@
-from .base import BaseTraceExporter
 from .manager import ExportManager
 
-__all__ = ["BaseTraceExporter", "ExportManager"]
+__all__ = ["ExportManager"]


### PR DESCRIPTION
🎯 **What:** Remove unused `BaseTraceExporter` from `src/core/export/__init__.py` and its `__all__` list.
💡 **Why:** Cleans up the namespace since `BaseTraceExporter` is not meant to be part of the public `export` module API.
✅ **Verification:** Ran formatters, linters, and the full test suite to verify that no other code incorrectly relied on importing `BaseTraceExporter` via `src.core.export`.
✨ **Result:** Improved code health and a smaller, more focused surface area for the `src.core.export` module.

---
*PR created automatically by Jules for task [9388817059839740231](https://jules.google.com/task/9388817059839740231) started by @youtube-at-vach*