### PR TITLE
🔒 Fix insecure config directory permissions

### DIFF
--- a/src/core/calibration.py
+++ b/src/core/calibration.py
@@ -23,7 +23,7 @@ class CalibrationManager:
             # If just a filename, put in user data dir
             user_dir = ConfigManager.get_user_data_dir()
             try:
-                os.makedirs(user_dir, exist_ok=True)
+                os.makedirs(user_dir, mode=0o700, exist_ok=True)
                 self.config_path = os.path.join(user_dir, config_filename)
             except Exception:
                 # Fallback to current working directory

--- a/src/core/config_manager.py
+++ b/src/core/config_manager.py
@@ -152,7 +152,7 @@ class ConfigManager:
         # Otherwise, use user data directory
         user_dir = ConfigManager.get_user_data_dir()
         try:
-            os.makedirs(user_dir, exist_ok=True)
+            os.makedirs(user_dir, mode=0o700, exist_ok=True)
         except OSError as e:
             self.logger.warning(f"Failed to create user data directory {user_dir}: {e}")
             # Fallback to CWD if we can't write to user dir

--- a/src/gui/widgets/detachable_wrapper.py
+++ b/src/gui/widgets/detachable_wrapper.py
@@ -239,7 +239,7 @@ class DetachableWidgetWrapper(QWidget):
     def save_screenshot(self):
         out_dir = self._get_screenshot_output_dir()
         try:
-            os.makedirs(out_dir, exist_ok=True)
+            os.makedirs(out_dir, mode=0o700, exist_ok=True)
         except Exception as e:
             QMessageBox.warning(self, tr("Error"), tr("Failed to create output folder: {0}").format(str(e)))
             return


### PR DESCRIPTION
🎯 **What:** The user configuration directory and screenshot output directories were being created with default permissions.
⚠️ **Risk:** Any local user could potentially read or modify the sensitive configuration and screenshot files if the default umask is too permissive.
🛡️ **Solution:** Explicitly set `mode=0o700` in `os.makedirs` to ensure that only the owning user has read, write, and execute access to these directories.

---
*PR created automatically by Jules for task [13910303809570814842](https://jules.google.com/task/13910303809570814842) started by @youtube-at-vach*