### PR TITLE
🧪 [Add empty array test for track_jitter_fractional]

### DIFF
--- a/src/core/transmission_logic.py
+++ b/src/core/transmission_logic.py
@@ -552,12 +552,16 @@ def track_jitter_fractional(
 
     Returns: (best_offset, fractional_correlation, fractional_delay)
     """
+    N = len(rx_block)
+    H = len(tx_history)
+
+    if N == 0 or H == 0:
+        return last_offset, 0.0, 0.0
+
     # 1. Coarse standard integer search
     best_integer_offset, _ = track_jitter(rx_block, tx_history, last_offset, max_search)
 
     # 2. Extract corresponding reference segment from history
-    N = len(rx_block)
-    H = len(tx_history)
     if best_integer_offset + N <= H:
         tx_seg = tx_history[best_integer_offset : best_integer_offset + N]
     else:

--- a/tests/logic_verification/core/test_transmission.py
+++ b/tests/logic_verification/core/test_transmission.py
@@ -262,6 +262,18 @@ class TestTransmissionLogic(unittest.TestCase):
         est_delay_neg = estimate_fractional_delay(tx_delayed_neg_segment, tx_segment)
         self.assertAlmostEqual(est_delay_neg, target_shift_neg, delta=0.02)
 
+    def test_track_jitter_fractional_empty_array(self):
+        """Test track_jitter_fractional with empty input arrays."""
+        rx_block = np.array([])
+        tx_history = np.array([])
+        last_offset = 50
+
+        best_offset, frac_corr, frac_delay = track_jitter_fractional(rx_block, tx_history, last_offset)
+
+        self.assertEqual(best_offset, last_offset)
+        self.assertEqual(frac_corr, 0.0)
+        self.assertEqual(frac_delay, 0.0)
+
     def test_track_jitter_fractional(self):
         """Test hybrid integer-fractional tracking under simulated drifts, validating exact integer and fractional recovery."""
         gen = PRBSGenerator("PRBS-9")


### PR DESCRIPTION
🎯 **What:** Added empty array handling to `track_jitter_fractional` and its corresponding test.
📊 **Coverage:** Now testing empty arrays (`rx_block` or `tx_history`) for `track_jitter_fractional`.
✨ **Result:** Increased test coverage and fixed an error path that could crash with empty arrays.

---
*PR created automatically by Jules for task [4285037662043602943](https://jules.google.com/task/4285037662043602943) started by @youtube-at-vach*