### PR TITLE
🧪 [testing improvement] Cover calculate_evm error path for zero/tiny tx_block

### DIFF
--- a/tests/logic_verification/core/test_transmission.py
+++ b/tests/logic_verification/core/test_transmission.py
@@ -136,6 +136,21 @@ class TestTransmissionLogic(unittest.TestCase):
         evm_noise = calculate_evm(rx_altered, tx)
         self.assertGreater(evm_noise, 1.0)
 
+    def test_calculate_evm_zero_tx(self):
+        """Test Error Vector Magnitude handles effectively zero tx_block inputs."""
+        rx = np.ones(256)
+
+        # Exact zero
+        tx_zero = np.zeros(256)
+        evm_zero = calculate_evm(rx, tx_zero)
+        self.assertEqual(evm_zero, 100.0)
+
+        # Tiny tx (dot product < 1e-12)
+        # e.g., 256 * (1e-8)^2 = 256e-16 < 1e-12
+        tx_tiny = np.ones(256) * 1e-8
+        evm_tiny = calculate_evm(rx, tx_tiny)
+        self.assertEqual(evm_tiny, 100.0)
+
     def test_calculate_equalized_evm(self):
         """Test Equalized EVM calculations under linear frequency/phase distortions."""
         gen = PRBSGenerator("PRBS-9")


### PR DESCRIPTION
🎯 **What:** Added a missing unit test for the edge case where the `tx_block` input to `calculate_evm` is effectively zero (dot product `< 1e-12`).

📊 **Coverage:** Covered both an exactly zero array (`np.zeros`) and a minimally non-zero array where its total dot product falls below the `1e-12` threshold (`np.ones * 1e-8`). The tests ensure that both inputs correctly cap the Error Vector Magnitude (EVM) return value at 100.0%.

✨ **Result:** Improved robustness by confirming the early-return conditional safety check inside `calculate_evm` behaves mathematically as expected during dead or practically silent reference signals.

---
*PR created automatically by Jules for task [2831844768422658342](https://jules.google.com/task/2831844768422658342) started by @youtube-at-vach*