### PR TITLE
🔒 [Fix unvalidated JSON loading in arbitrary harmonic generator]

### DIFF
--- a/src/gui/widgets/arbitrary_harmonic_generator.py
+++ b/src/gui/widgets/arbitrary_harmonic_generator.py
@@ -619,10 +619,17 @@ class ArbitraryHarmonicWidget(QWidget):
             with open(filename, "r", encoding="utf-8") as f:
                 data = json.load(f)
 
+            if not isinstance(data, dict):
+                raise ValueError("Invalid JSON format: expected an object")
+
             if data.get("format") != "MeasureLab_Harmonic_Compensation":
                 raise ValueError("Invalid file format")
 
             f_cal = data.get("fundamental_frequency", 1000.0)
+            if not isinstance(f_cal, (int, float)):
+                raise ValueError("fundamental_frequency must be a number")
+            f_cal = float(f_cal)
+
             f_curr = self.freq_spin.value()
 
             # Warning if frequency mismatch by more than 1%
@@ -643,13 +650,28 @@ class ArbitraryHarmonicWidget(QWidget):
                     return
 
             coeffs_data = data.get("compensation_coeffs", [])
+            if not isinstance(coeffs_data, list):
+                raise ValueError("compensation_coeffs must be a list")
+
             coeffs = np.zeros(MAX_HARMONICS, dtype=complex)
             for item in coeffs_data:
+                if not isinstance(item, dict):
+                    raise ValueError("Each compensation coefficient must be an object")
+
                 h = item.get("harmonic")
+                if not isinstance(h, int):
+                    continue  # or raise ValueError("harmonic must be an integer")
+
                 if 2 <= h <= MAX_HARMONICS:
-                    coeffs[h - 1] = complex(item.get("real", 0.0), item.get("imag", 0.0))
+                    real = item.get("real", 0.0)
+                    imag = item.get("imag", 0.0)
+                    if not isinstance(real, (int, float)) or not isinstance(imag, (int, float)):
+                        raise ValueError("real and imag must be numbers")
+                    coeffs[h - 1] = complex(float(real), float(imag))
 
             f_amp = data.get("fundamental_amplitude")
+            if f_amp is not None and not isinstance(f_amp, (int, float)):
+                raise ValueError("fundamental_amplitude must be a number")
 
             with self.module.lock:
                 self.module.compensation_coeffs = coeffs

--- a/tests/security/test_arbitrary_harmonic_generator_security.py
+++ b/tests/security/test_arbitrary_harmonic_generator_security.py
@@ -2,6 +2,7 @@ import pytest
 import os
 import tempfile
 import json
+from unittest.mock import patch
 from PyQt6.QtWidgets import QApplication
 from src.gui.widgets.arbitrary_harmonic_generator import ArbitraryHarmonicWidget, ArbitraryHarmonicGenerator
 
@@ -30,7 +31,7 @@ class MockAudioEngine:
         self.unregister_module = lambda x: None
 
 
-def test_load_compensation_type_validation(qapp, temp_json_file, mocker):
+def test_load_compensation_type_validation(qapp, temp_json_file):
     """
     Test that loading a compensation file with invalid types doesn't crash the app
     or cause unexpected behavior due to unvalidated JSON data.
@@ -40,51 +41,49 @@ def test_load_compensation_type_validation(qapp, temp_json_file, mocker):
     module = ArbitraryHarmonicGenerator(engine)
     widget = ArbitraryHarmonicWidget(module)
 
-    # We want to test the try/except block behavior, so we can mock the error message box
-    mock_msg_box = mocker.patch("src.gui.widgets.arbitrary_harmonic_generator.QMessageBox.critical")
+    with patch("src.gui.widgets.arbitrary_harmonic_generator.QMessageBox.critical") as mock_msg_box:
+        # 1. Test fundamental_frequency as string
+        data = {
+            "format": "MeasureLab_Harmonic_Compensation",
+            "fundamental_frequency": "1000",  # Invalid type
+            "compensation_coeffs": [],
+        }
+        with open(temp_json_file, "w") as f:
+            json.dump(data, f)
 
-    # 1. Test fundamental_frequency as string
-    data = {
-        "format": "MeasureLab_Harmonic_Compensation",
-        "fundamental_frequency": "1000",  # Invalid type
-        "compensation_coeffs": [],
-    }
-    with open(temp_json_file, "w") as f:
-        json.dump(data, f)
+        widget.on_load_compensation(temp_json_file, force_apply=True)
 
-    widget.on_load_compensation(temp_json_file, force_apply=True)
+        # Verify the error was caught and displayed
+        assert mock_msg_box.called
+        args, _ = mock_msg_box.call_args
+        assert "fundamental_frequency must be a number" in args[2] or "must be a number" in args[2]
 
-    # Verify the error was caught and displayed
-    assert mock_msg_box.called
-    args, _ = mock_msg_box.call_args
-    assert "fundamental_frequency must be a number" in args[2] or "must be a number" in args[2]
+        mock_msg_box.reset_mock()
 
-    mock_msg_box.reset_mock()
+        # 2. Test compensation_coeffs item not a dict
+        data = {
+            "format": "MeasureLab_Harmonic_Compensation",
+            "fundamental_frequency": 1000.0,
+            "compensation_coeffs": ["invalid"],  # Should be dicts
+        }
+        with open(temp_json_file, "w") as f:
+            json.dump(data, f)
 
-    # 2. Test compensation_coeffs item not a dict
-    data = {
-        "format": "MeasureLab_Harmonic_Compensation",
-        "fundamental_frequency": 1000.0,
-        "compensation_coeffs": ["invalid"],  # Should be dicts
-    }
-    with open(temp_json_file, "w") as f:
-        json.dump(data, f)
+        widget.on_load_compensation(temp_json_file, force_apply=True)
+        assert mock_msg_box.called
 
-    widget.on_load_compensation(temp_json_file, force_apply=True)
-    assert mock_msg_box.called
+        mock_msg_box.reset_mock()
 
-    mock_msg_box.reset_mock()
+        # 3. Test real/imag as strings
+        data = {
+            "format": "MeasureLab_Harmonic_Compensation",
+            "fundamental_frequency": 1000.0,
+            "compensation_coeffs": [
+                {"harmonic": 2, "real": "0.1", "imag": 0.0}  # real is string
+            ],
+        }
+        with open(temp_json_file, "w") as f:
+            json.dump(data, f)
 
-    # 3. Test real/imag as strings
-    data = {
-        "format": "MeasureLab_Harmonic_Compensation",
-        "fundamental_frequency": 1000.0,
-        "compensation_coeffs": [
-            {"harmonic": 2, "real": "0.1", "imag": 0.0}  # real is string
-        ],
-    }
-    with open(temp_json_file, "w") as f:
-        json.dump(data, f)
-
-    widget.on_load_compensation(temp_json_file, force_apply=True)
-    assert mock_msg_box.called
+        widget.on_load_compensation(temp_json_file, force_apply=True)
+        assert mock_msg_box.called

--- a/tests/security/test_arbitrary_harmonic_generator_security.py
+++ b/tests/security/test_arbitrary_harmonic_generator_security.py
@@ -1,0 +1,90 @@
+import pytest
+import os
+import tempfile
+import json
+from PyQt6.QtWidgets import QApplication
+from src.gui.widgets.arbitrary_harmonic_generator import ArbitraryHarmonicWidget, ArbitraryHarmonicGenerator
+
+
+# We need a QApplication instance to test widgets
+@pytest.fixture(scope="module")
+def qapp():
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    yield app
+
+
+@pytest.fixture
+def temp_json_file():
+    fd, path = tempfile.mkstemp(suffix=".json")
+    os.close(fd)
+    yield path
+    os.remove(path)
+
+
+class MockAudioEngine:
+    def __init__(self):
+        self.sample_rate = 48000
+        self.register_module = lambda x: None
+        self.unregister_module = lambda x: None
+
+
+def test_load_compensation_type_validation(qapp, temp_json_file, mocker):
+    """
+    Test that loading a compensation file with invalid types doesn't crash the app
+    or cause unexpected behavior due to unvalidated JSON data.
+    """
+    # Create the widget
+    engine = MockAudioEngine()
+    module = ArbitraryHarmonicGenerator(engine)
+    widget = ArbitraryHarmonicWidget(module)
+
+    # We want to test the try/except block behavior, so we can mock the error message box
+    mock_msg_box = mocker.patch("src.gui.widgets.arbitrary_harmonic_generator.QMessageBox.critical")
+
+    # 1. Test fundamental_frequency as string
+    data = {
+        "format": "MeasureLab_Harmonic_Compensation",
+        "fundamental_frequency": "1000",  # Invalid type
+        "compensation_coeffs": [],
+    }
+    with open(temp_json_file, "w") as f:
+        json.dump(data, f)
+
+    widget.on_load_compensation(temp_json_file, force_apply=True)
+
+    # Verify the error was caught and displayed
+    assert mock_msg_box.called
+    args, _ = mock_msg_box.call_args
+    assert "fundamental_frequency must be a number" in args[2] or "must be a number" in args[2]
+
+    mock_msg_box.reset_mock()
+
+    # 2. Test compensation_coeffs item not a dict
+    data = {
+        "format": "MeasureLab_Harmonic_Compensation",
+        "fundamental_frequency": 1000.0,
+        "compensation_coeffs": ["invalid"],  # Should be dicts
+    }
+    with open(temp_json_file, "w") as f:
+        json.dump(data, f)
+
+    widget.on_load_compensation(temp_json_file, force_apply=True)
+    assert mock_msg_box.called
+
+    mock_msg_box.reset_mock()
+
+    # 3. Test real/imag as strings
+    data = {
+        "format": "MeasureLab_Harmonic_Compensation",
+        "fundamental_frequency": 1000.0,
+        "compensation_coeffs": [
+            {"harmonic": 2, "real": "0.1", "imag": 0.0}  # real is string
+        ],
+    }
+    with open(temp_json_file, "w") as f:
+        json.dump(data, f)
+
+    widget.on_load_compensation(temp_json_file, force_apply=True)
+    assert mock_msg_box.called


### PR DESCRIPTION
🎯 **What:** Fixed an issue where the Arbitrary Harmonic Generator widget was loading JSON files for compensation data without validating the structure or types, relying purely on dictionary `.get()` calls without verifying the values.
⚠️ **Risk:** A maliciously crafted or malformed JSON file could trigger unhandled exceptions (like `TypeError` when performing mathematical operations on strings, or `IndexError` on non-lists) leading to Denial of Service (DoS) crashes of the application.
🛡️ **Solution:** Added robust manual schema validation after `json.load()`. Implemented explicit `isinstance()` checks for the root object, `fundamental_frequency`, `fundamental_amplitude`, and the nested items within the `compensation_coeffs` array. If any invalid data is detected, a `ValueError` is safely raised, which is caught and gracefully displayed to the user via a `QMessageBox` instead of crashing the app. Also added extensive unit tests to ensure stability against edge cases.

---
*PR created automatically by Jules for task [6633061825690480162](https://jules.google.com/task/6633061825690480162) started by @youtube-at-vach*