### PR TITLE
fix: unwrap phase before linear interpolation to prevent errors at wrap boundaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,4 @@ report.json
 measurement_report.json
 thd.json
 .vscode/settings.json
+hammerstein_kernel_sample*.json

--- a/scripts/verify_lockin_vs_nonlinear_real_device.py
+++ b/scripts/verify_lockin_vs_nonlinear_real_device.py
@@ -258,7 +258,9 @@ def main():
         meas_fund_phase_deg = meas_phases[0]
 
         # Interpolate reference loopback phase at fundamental frequency f0
-        ref_phase_f0 = np.interp(f0, freqs, phases.get("ref_phase", np.zeros_like(freqs)))
+        ref_phase_raw = phases.get("ref_phase", np.zeros_like(freqs))
+        ref_phase_unwrapped = np.degrees(np.unwrap(np.radians(ref_phase_raw)))
+        ref_phase_f0 = np.interp(f0, freqs, ref_phase_unwrapped)
 
         print(f"\n--- Comparative Verification at {f0} Hz (Measured Freq: {lockin_data['measured_freq']:.2f} Hz) ---")
         print(f"{'Harmonic':<10} | {'Pred Amp':<10} | {'Meas Amp':<10} | {'Amp Diff':<10} | {'Pred Ph':<10} | {'Corr Pred':<10} | {'Meas Ph':<10} | {'Ph Diff':<10} | {'Corr PhDiff':<12}")
@@ -280,7 +282,7 @@ def main():
             pred_rel_phase_deg = (pred_rel_phase_deg + 180) % 360 - 180
 
             # Apply loopback correction: ref_phase(f_n) - n * ref_phase(f_0)
-            ref_phase_fn = np.interp(f_n, freqs, phases.get("ref_phase", np.zeros_like(freqs)))
+            ref_phase_fn = np.interp(f_n, freqs, ref_phase_unwrapped)
             loopback_corr_deg = ref_phase_fn - n * ref_phase_f0
             pred_rel_phase_corr_deg = pred_rel_phase_deg + loopback_corr_deg
             pred_rel_phase_corr_deg = (pred_rel_phase_corr_deg + 180) % 360 - 180

--- a/src/core/calibration.py
+++ b/src/core/calibration.py
@@ -359,7 +359,10 @@ class CalibrationManager:
 
         # Use cached numpy arrays for interpolation
         mag_corr = np.interp(freq_arr, freq_cache, mag_cache)
-        phase_corr = np.interp(freq_arr, freq_cache, phase_cache)
+        # Unwrap phase before interpolation to avoid linear interpolation errors at wrap boundaries
+        phase_unwrapped = np.degrees(np.unwrap(np.radians(phase_cache)))
+        phase_corr = np.interp(freq_arr, freq_cache, phase_unwrapped)
+        phase_corr = (phase_corr + 180) % 360 - 180
 
         if is_scalar:
             return float(mag_corr[0]), float(phase_corr[0])

--- a/src/gui/widgets/hammerstein_analyzer.py
+++ b/src/gui/widgets/hammerstein_analyzer.py
@@ -1468,7 +1468,9 @@ class HammersteinAnalyzerWidget(QWidget):
 
         ref_phase_f0 = 0.0
         if self.ref_loopback_phase_chk.isChecked() and "ref_phase" in self.cached_phases:
-            ref_phase_f0 = np.interp(f0, self.cached_freqs, self.cached_phases["ref_phase"])
+            # Unwrap ref_phase before interpolation to avoid linear interpolation errors at wrap boundaries
+            ref_phase_unwrapped = np.degrees(np.unwrap(np.radians(self.cached_phases["ref_phase"])))
+            ref_phase_f0 = np.interp(f0, self.cached_freqs, ref_phase_unwrapped)
 
         for n in range(1, 6):
             h_key = f"h{n}"
@@ -1488,7 +1490,8 @@ class HammersteinAnalyzerWidget(QWidget):
             phase_val_deg = np.degrees(relative_phase_rad)
 
             if self.ref_loopback_phase_chk.isChecked() and "ref_phase" in self.cached_phases:
-                ref_phase_fn = np.interp(f_n, self.cached_freqs, self.cached_phases["ref_phase"])
+                # Use the unwrapped reference phase array to prevent phase wrap interpolation issues
+                ref_phase_fn = np.interp(f_n, self.cached_freqs, ref_phase_unwrapped)
                 loopback_corr_deg = ref_phase_fn - n * ref_phase_f0
                 phase_val_deg += loopback_corr_deg
 

--- a/src/gui/widgets/network_analyzer.py
+++ b/src/gui/widgets/network_analyzer.py
@@ -1644,7 +1644,9 @@ class NetworkAnalyzerWidget(QWidget, ComparableWidgetInterface):
 
             # Phase Subtraction
             if len(ref["phases"]) > 1:
-                interp_phases = np.interp(freqs_to_plot, ref["freqs"], ref["phases"])
+                # Unwrap reference phases to prevent incorrect interpolation results around wrap boundaries
+                ref_phases_unwrapped = np.degrees(np.unwrap(np.radians(ref["phases"])))
+                interp_phases = np.interp(freqs_to_plot, ref["freqs"], ref_phases_unwrapped)
                 phases_to_plot -= interp_phases
                 # Wrap to [-180, 180]
                 phases_to_plot = (phases_to_plot + 180) % 360 - 180


### PR DESCRIPTION
### Summary
Fixes a silent measurement degradation issue where interpolating phase angle data directly in the frequency domain (via `np.interp`) produces incorrect results when crossing phase wrap boundaries (+/- 180 degrees).

### Details of Changes
- **`src/gui/widgets/hammerstein_analyzer.py`**: Unwraps the reference loopback phase array prior to interpolation in the simulation update.
- **`src/core/calibration.py`**: Unwraps the frequency-phase calibration profile curve before performing interpolation.
- **`src/gui/widgets/network_analyzer.py`**: Unwraps reference phase trace data before doing phase subtraction in plot refreshing.
- **`scripts/verify_lockin_vs_nonlinear_real_device.py`**: Unwraps loopback reference phases before interpolating.

### Verification Results
All code quality checks and tests successfully passed:
- `pytest`: 928 passed, 7 skipped.
- `ruff check`: All checks passed.
- `mypy src/`: Success, no issues found.
- `check_trn_keys.py`: TEST PASSED.
- `check_ui_size_limits.py`: Verification Passed.
- `markdownlint`: 0 errors.