### PR TITLE
⚡ Optimize export trace membership lookup to use O(1) set

### DIFF
--- a/src/gui/widgets/export_dialog.py
+++ b/src/gui/widgets/export_dialog.py
@@ -278,11 +278,11 @@ class ExportSettingsDialog(QDialog):
             return
 
         # Gather target selection states
-        selected_trace_ids = []
+        selected_trace_ids = set()
         for i in range(self.target_list.count()):
             item = self.target_list.item(i)
             if item.checkState() == Qt.CheckState.Checked:
-                selected_trace_ids.append(item.data(Qt.ItemDataRole.UserRole))
+                selected_trace_ids.add(item.data(Qt.ItemDataRole.UserRole))
 
         traces_to_export = [t for t in self.traces if t.id in selected_trace_ids]
         if not traces_to_export:


### PR DESCRIPTION
💡 **What:** 
Replaced `selected_trace_ids = []` and `.append()` with `set()` and `.add()` inside `ExportSettingsDialog.do_export()`.

🎯 **Why:** 
The list comprehension `[t for t in self.traces if t.id in selected_trace_ids]` checks membership in a list, resulting in O(N*M) complexity (where N is the number of traces and M is the number of selected traces). By converting `selected_trace_ids` to a set, the membership check becomes O(1), improving the overall complexity to O(N).

📊 **Measured Improvement:** 
I created a synthetic benchmark to measure the impact of this exact lookup logic.
* **10 traces:**
  * List lookup: 0.003254 ms
  * Set lookup:  0.003669 ms
* **1000 traces:**
  * List lookup: 8.183362 ms
  * Set lookup:  0.081539 ms (100x faster)
* **10000 traces:**
  * List lookup: 673.665270 ms
  * Set lookup:  4.555366 ms (147x faster)

While the real-world scale of exported traces is likely closer to 10-100, the set lookup still guarantees O(N) linear time and is a trivial code change that prevents UI thread blocking for large comparisons.

---
*PR created automatically by Jules for task [9250206425448797879](https://jules.google.com/task/9250206425448797879) started by @youtube-at-vach*