### PR TITLE
🧪 [Add mock-based error test for save_hammerstein_model]

### DIFF
--- a/tests/core/test_core_hammerstein_model.py
+++ b/tests/core/test_core_hammerstein_model.py
@@ -63,6 +63,23 @@ def test_save_and_load_hammerstein_model(tmp_path, sample_hammerstein_data):
     )
 
 
+from unittest.mock import patch
+
+def test_save_hammerstein_model_error_mocked(tmp_path, sample_hammerstein_data):
+    # Use mock to force an error during JSON dumping to ensure exception handling and logging are tested
+    filepath = tmp_path / "test_model_error.json"
+    with patch("src.core.hammerstein_model.json.dump") as mock_dump:
+        mock_dump.side_effect = TypeError("Mocked JSON dump error")
+        with patch("src.core.hammerstein_model.logger") as mock_logger:
+            with pytest.raises(TypeError, match="Mocked JSON dump error"):
+                save_hammerstein_model(filepath, sample_hammerstein_data)
+
+            # Verify the error was logged
+            mock_logger.error.assert_called_once()
+            args, kwargs = mock_logger.error.call_args
+            assert "Failed to save Hammerstein model" in args[0]
+
+
 def test_save_hammerstein_model_error():
     # Attempt to save to an invalid path
     with pytest.raises((OSError, FileNotFoundError, json.JSONDecodeError)):

--- a/tests/core/test_core_hammerstein_model.py
+++ b/tests/core/test_core_hammerstein_model.py
@@ -1,6 +1,7 @@
 import json
 import pytest
 import numpy as np
+from unittest.mock import patch
 from src.core.hammerstein_model import (
     save_hammerstein_model,
     load_hammerstein_model,
@@ -63,7 +64,6 @@ def test_save_and_load_hammerstein_model(tmp_path, sample_hammerstein_data):
     )
 
 
-from unittest.mock import patch
 
 def test_save_hammerstein_model_error_mocked(tmp_path, sample_hammerstein_data):
     # Use mock to force an error during JSON dumping to ensure exception handling and logging are tested


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: Untested `save_hammerstein_model` error handling logic where JSON saving or OS-level writes fail.
📊 **Coverage:** Mocked `json.dump` to simulate an exception (e.g. `TypeError`) and asserted that the proper error logging `logger.error` behaviour occurs before re-raising the error. The pre-existing tests validating file errors remain untouched.
✨ **Result:** Improved test coverage and reliability for error handling paths in `hammerstein_model.py` without relying on unpredictable OS-level conditions.

---
*PR created automatically by Jules for task [17895332234961649378](https://jules.google.com/task/17895332234961649378) started by @youtube-at-vach*