### PR TITLE
🧪 [Testing Improvement] Add tests for save error paths in calibration.py

### DIFF
--- a/tests/logic_verification/core/test_calibration.py
+++ b/tests/logic_verification/core/test_calibration.py
@@ -1,3 +1,4 @@
+import unittest.mock
 import os
 import pytest
 import numpy as np
@@ -223,3 +224,18 @@ def test_get_frequency_correction_empty_map(calibration_manager):
     mag, phase = calibration_manager.get_frequency_correction(100.0)
     assert mag == 0.0
     assert phase == 0.0
+
+
+def test_save_error(calibration_manager):
+    """Test save method handles IOError correctly."""
+    with unittest.mock.patch('src.core.calibration.os.open', side_effect=OSError('Mocked error')),          unittest.mock.patch('builtins.open', side_effect=OSError('Mocked error')):
+        with unittest.mock.patch.object(calibration_manager.logger, 'error') as mock_logger:
+            calibration_manager.save()
+            mock_logger.assert_called_once()
+
+
+def test_save_frequency_map_error(calibration_manager, temp_map_path):
+    """Test save_frequency_map handles IOError correctly."""
+    with unittest.mock.patch('src.core.calibration.os.open', side_effect=OSError('Mocked error')),          unittest.mock.patch('builtins.open', side_effect=OSError('Mocked error')):
+        result = calibration_manager.save_frequency_map(temp_map_path, [[10.0, 0.0, 0.0]])
+        assert result is False


### PR DESCRIPTION
🎯 **What:** The `save` and `save_frequency_map` methods in `calibration.py` lacked test coverage for error conditions (specifically when writing to a file fails).

📊 **Coverage:** The new tests cover `OSError` occurrences during configuration file saves. `test_save_error` verifies that the exception is cleanly caught and logged, while `test_save_frequency_map_error` verifies that the `save_frequency_map` method gracefully catches the error and returns `False` instead of raising an exception.

✨ **Result:** Test coverage for `src/core/calibration.py` improved as these error handling paths are now actively exercised by the test suite, allowing confident refactoring without the risk of breaking exception handling.

---
*PR created automatically by Jules for task [11138652626009126108](https://jules.google.com/task/11138652626009126108) started by @youtube-at-vach*