### PR TITLE
build: exclude autogenerated log files from git tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,8 @@ thd.json
 .vscode/settings.json
 hammerstein_kernel_sample*.json
 inverse_hammerstein_model*.json
+
+# Auto-generated check logs
+docs/daily_check.log
+docs/translation_check.log
+

--- a/docs/daily_check.log
+++ b/docs/daily_check.log
@@ -1,1 +1,0 @@
-Thu Feb  5 22:24:50 UTC 2026: Checked commit 5f62bb8. No documentation updates required. Verification passed.

--- a/docs/translation_check.log
+++ b/docs/translation_check.log
@@ -1,2 +1,0 @@
-Sat Jan 24 01:38:20 UTC 2026
-Translation check passed.


### PR DESCRIPTION
### 変更内容
- 自動生成されるログファイル（`docs/daily_check.log`、`docs/translation_check.log`）を git のインデックスから削除しました。
- `.gitignore` に上記ログファイルを追加し、今後の自動生成・更新時に git で追跡されないように設定しました。

### 検証内容
- ローカル品質チェック（Ruff, Mypy, 翻訳キーチェック, UIサイズ制限チェック, Markdown lint, Pytest）をすべて実施し、すべてパスしていることを確認済みです。