### PR TITLE
🔒 [Fix CSV injection vulnerability in metadata export]

### DIFF
--- a/src/core/export/csv_exporter.py
+++ b/src/core/export/csv_exporter.py
@@ -29,7 +29,8 @@ class CsvTraceExporter(BaseTraceExporter):
     def _sanitize_csv_field(self, field: str) -> str:
         """Sanitizes a string to prevent CSV injection (Formula Injection)."""
         field_str = str(field)
-        if field_str.startswith(("=", "+", "-", "@", "\t", "\r")):
+        field_str = field_str.replace("\n", " ").replace("\r", " ")
+        if field_str.startswith(("=", "+", "-", "@", "\t")):
             return f"'{field_str}"
         return field_str
 
@@ -47,7 +48,9 @@ class CsvTraceExporter(BaseTraceExporter):
                 if include_metadata:
                     writer.writerow(["# MeasureLab Exported Traces"])
                     for t in traces:
-                        writer.writerow([f"# Trace: {t.name} (Source: {t.source_module}, Timestamp: {t.timestamp})"])
+                        safe_name = self._sanitize_csv_field(t.name)
+                        safe_source = self._sanitize_csv_field(t.source_module)
+                        writer.writerow([f"# Trace: {safe_name} (Source: {safe_source}, Timestamp: {t.timestamp})"])
                     writer.writerow([])  # empty line separator
 
                 if layout == "merged":

--- a/tests/core/export/test_csv_exporter.py
+++ b/tests/core/export/test_csv_exporter.py
@@ -226,13 +226,16 @@ def test_export_csv_injection_prevention(tmp_path, sample_traces):
     # Modify trace name to simulate CSV injection
     sample_traces[0].name = "=cmd|' /C calc'!A0"
 
+    # Test another injection vector with newlines
+    sample_traces[1].name = "Normal\n=cmd|' /C calc'!A0"
+
     exporter = CsvTraceExporter()
     filepath = str(tmp_path / "injection.csv")
 
     options = {
         "layout": "merged",
         "include_headers": True,
-        "include_metadata": False,
+        "include_metadata": True,
     }
 
     assert exporter.export_traces(filepath, sample_traces, options) is True
@@ -241,7 +244,23 @@ def test_export_csv_injection_prevention(tmp_path, sample_traces):
         reader = csv.reader(f)
         lines = list(reader)
 
-    header = lines[0]
+    # Check metadata rows
+    metadata_row_1 = lines[1]
+    # Because _sanitize_csv_field removes newlines but doesn't prepend quote unless it starts with "="
+    # The string "# Trace: =cmd..." does not start with "=" so it isn't prepended with quote.
+    # BUT we must ensure the newline injection doesn't create a new row starting with "="
+
+    metadata_row_2 = lines[2]
+    # The newline should be replaced by a space
+    assert "\n" not in metadata_row_2[0]
+    assert "Normal =cmd" in metadata_row_2[0]
+
+    header_idx = 6 # title, t1, t2, t3, t4, empty
+    header = lines[header_idx]
     # Check that the malicious trace name was sanitized by prepending an apostrophe
     assert header[1].startswith("'=")
     assert header[1] == "'=cmd|' /C calc'!A0 - Voltage (dBV)"
+
+    # Check that the newline injection was sanitized in header
+    assert "\n" not in header[2]
+    assert "Normal =cmd" in header[2]

--- a/tests/core/export/test_csv_exporter.py
+++ b/tests/core/export/test_csv_exporter.py
@@ -246,9 +246,7 @@ def test_export_csv_injection_prevention(tmp_path, sample_traces):
 
     # Check metadata rows
     metadata_row_1 = lines[1]
-    # Because _sanitize_csv_field removes newlines but doesn't prepend quote unless it starts with "="
-    # The string "# Trace: =cmd..." does not start with "=" so it isn't prepended with quote.
-    # BUT we must ensure the newline injection doesn't create a new row starting with "="
+    assert metadata_row_1[0].startswith("# Trace: '=")
 
     metadata_row_2 = lines[2]
     # The newline should be replaced by a space


### PR DESCRIPTION
🎯 **What:** Fixed a CSV injection vulnerability where `t.name` and `t.source_module` fields were not being properly sanitized before being written to the metadata rows during a CSV export. Additionally, fixed an edge case where injection payloads containing newline characters (`\n`, `\r`) could force malicious formulas onto new rows, bypassing standard start-of-field sanitization checks.

⚠️ **Risk:** An attacker could craft a trace with a malicious name (e.g. starting with `=cmd|...` or injecting a newline before the formula) that, when exported to CSV and opened in Excel by an unsuspecting user, would automatically execute arbitrary system commands. This is a severe client-side RCE risk.

🛡️ **Solution:** 
1. Updated `_sanitize_csv_field` to strip `\n` and `\r` from fields.
2. Updated the metadata row rendering in `csv_exporter.py` to wrap `t.name` and `t.source_module` with the updated `_sanitize_csv_field` function.
3. Enhanced existing unit tests in `test_csv_exporter.py` to assert that newline characters and malicious payload strings are properly neutralized.

---
*PR created automatically by Jules for task [16693538109326872770](https://jules.google.com/task/16693538109326872770) started by @youtube-at-vach*