### PR TITLE
Clean up useless tests

### DIFF
--- a/tests/core/export/test_base.py
+++ b/tests/core/export/test_base.py
@@ -1,4 +1,3 @@
-import pytest
 from typing import List, Dict, Any
 from src.core.export.base import BaseTraceExporter
 

--- a/tests/core/export/test_base.py
+++ b/tests/core/export/test_base.py
@@ -3,21 +3,6 @@ from typing import List, Dict, Any
 from src.core.export.base import BaseTraceExporter
 
 
-def test_base_trace_exporter_cannot_be_instantiated():
-    with pytest.raises(TypeError):
-        BaseTraceExporter()
-
-
-def test_incomplete_subclass_cannot_be_instantiated():
-    class IncompleteExporter(BaseTraceExporter):
-        @property
-        def format_id(self) -> str:
-            return "test"
-
-    with pytest.raises(TypeError):
-        IncompleteExporter()
-
-
 def test_complete_subclass_can_be_instantiated():
     class CompleteExporter(BaseTraceExporter):
         @property

--- a/tests/core/test_core_hammerstein_model.py
+++ b/tests/core/test_core_hammerstein_model.py
@@ -64,7 +64,6 @@ def test_save_and_load_hammerstein_model(tmp_path, sample_hammerstein_data):
     )
 
 
-
 def test_save_hammerstein_model_error_mocked(tmp_path, sample_hammerstein_data):
     # Use mock to force an error during JSON dumping to ensure exception handling and logging are tested
     filepath = tmp_path / "test_model_error.json"
@@ -78,31 +77,6 @@ def test_save_hammerstein_model_error_mocked(tmp_path, sample_hammerstein_data):
             mock_logger.error.assert_called_once()
             args, kwargs = mock_logger.error.call_args
             assert "Failed to save Hammerstein model" in args[0]
-
-
-def test_save_hammerstein_model_error():
-    # Attempt to save to an invalid path
-    with pytest.raises((OSError, FileNotFoundError, json.JSONDecodeError)):
-        save_hammerstein_model(
-            "/invalid/path/that/does/not/exist/model.json",
-            {
-                "time_domain": {"time_ms": [], "kernels": {}},
-                "frequency_domain": {"freqs": [], "magnitudes_db": {}, "phases_deg": {}},
-            },
-        )
-
-
-def test_load_hammerstein_model_error(tmp_path):
-    # Attempt to load from non-existent file
-    with pytest.raises((OSError, FileNotFoundError, json.JSONDecodeError)):
-        load_hammerstein_model(tmp_path / "non_existent.json")
-
-    # Attempt to load invalid JSON
-    invalid_json_path = tmp_path / "invalid.json"
-    with open(invalid_json_path, "w") as f:
-        f.write("{invalid_json}")
-    with pytest.raises((OSError, FileNotFoundError, json.JSONDecodeError)):
-        load_hammerstein_model(invalid_json_path)
 
 
 def test_active_model_cache(sample_hammerstein_data):

--- a/tests/core/test_core_hammerstein_model.py
+++ b/tests/core/test_core_hammerstein_model.py
@@ -1,4 +1,3 @@
-import json
 import pytest
 import numpy as np
 from unittest.mock import patch

--- a/tests/logic_verification/core/test_analysis.py
+++ b/tests/logic_verification/core/test_analysis.py
@@ -1,6 +1,5 @@
 from unittest.mock import patch, MagicMock
 import numpy as np
-import pytest
 
 from src.core.analysis import AudioCalc, get_cached_window, _calculate_ra_raw
 

--- a/tests/logic_verification/core/test_analysis.py
+++ b/tests/logic_verification/core/test_analysis.py
@@ -52,24 +52,10 @@ class TestAudioCalc:
         assert sos is not None
         assert sos.shape == (4, 6)  # 3 original + 1 peaking biquad
 
-    def test_design_a_weighting_invalid(self):
-        with pytest.raises(ValueError, match="Invalid sample rate"):
-            AudioCalc.design_a_weighting(0)
-
     def test_design_c_weighting_valid(self):
         sos = AudioCalc.design_c_weighting(48000)
         assert sos is not None
         assert sos.shape == (3, 6)  # 2 original + 1 peaking biquad
-
-    def test_design_c_weighting_invalid(self):
-        with pytest.raises(ValueError, match="Invalid sample rate"):
-            AudioCalc.design_c_weighting(-100)
-
-    def test_design_aes17_filter_invalid(self):
-        with pytest.raises(ValueError, match="Invalid sample rate"):
-            AudioCalc.design_aes17_filter(0)
-        with pytest.raises(ValueError, match="Invalid sample rate"):
-            AudioCalc.design_aes17_filter(-100)
 
     def test_lowpass_filter_basic(self):
         sr = 48000

--- a/tests/logic_verification/core/test_calibration.py
+++ b/tests/logic_verification/core/test_calibration.py
@@ -57,15 +57,6 @@ def test_spl_calibration(calibration_manager):
     assert spl == 100.0
 
 
-def test_spl_calibration_invalid(calibration_manager):
-    """Test invalid inputs for SPL calibration."""
-    with pytest.raises(ValueError):
-        calibration_manager.set_spl_calibration("invalid", 80.0)
-
-    with pytest.raises(ValueError):
-        calibration_manager.set_spl_calibration(-20.0, "invalid")
-
-
 def test_set_sensitivities(calibration_manager):
     """Test setting sensitivity and gain."""
     calibration_manager.set_input_sensitivity(2.5)
@@ -231,6 +222,7 @@ def test_save_frequency_map_error(calibration_manager, temp_map_path):
 
     # Mock os.open to raise an exception
     import unittest.mock as mock
+
     with mock.patch("os.open", side_effect=OSError("Permission denied")):
         result = calibration_manager.save_frequency_map(temp_map_path, map_data)
 

--- a/tests/logic_verification/core/test_calibration_manager.py
+++ b/tests/logic_verification/core/test_calibration_manager.py
@@ -114,25 +114,6 @@ def test_spl_calibration(cal_manager):
     assert new_cm.spl_offset_db == 100.0
 
 
-def test_spl_invalid_input(cal_manager):
-    """Test invalid input for SPL calibration."""
-    # Test invalid type for measured_dbfs_c
-    with pytest.raises(ValueError, match="Invalid SPL calibration values"):
-        cal_manager.set_spl_calibration("invalid", 80.0)
-    with pytest.raises(ValueError, match="Invalid SPL calibration values"):
-        cal_manager.set_spl_calibration(None, 80.0)
-
-    # Test invalid type for measured_spl_db
-    with pytest.raises(ValueError, match="Invalid SPL calibration values"):
-        cal_manager.set_spl_calibration(-20.0, "invalid")
-    with pytest.raises(ValueError, match="Invalid SPL calibration values"):
-        cal_manager.set_spl_calibration(-20.0, [80.0])
-
-    # Test invalid type for both
-    with pytest.raises(ValueError, match="Invalid SPL calibration values"):
-        cal_manager.set_spl_calibration("abc", "def")
-
-
 def test_get_spl_offset_db_none(cal_manager):
     """Test get_spl_offset_db returns None when not calibrated."""
     assert cal_manager.get_spl_offset_db() is None
@@ -192,12 +173,6 @@ def test_delete_non_existent_profile(cal_manager):
     # Ensure it handles missing profiles gracefully
     cal_manager.delete_profile("ghost_profile")
     assert "ghost_profile" not in cal_manager.get_profiles()
-
-
-def test_load_non_existent_profile(cal_manager):
-    """Test loading a profile that doesn't exist."""
-    with pytest.raises(ValueError, match="Profile 'fake' not found"):
-        cal_manager.load_profile("fake")
 
 
 def test_conversions(cal_manager):


### PR DESCRIPTION
This PR removes trivial and low-value tests from the pytest suite, focusing on removing tests that only verify built-in Python behaviors or basic type checking. Crucially, high-value tests verifying actual algorithm functionality, benchmark performance, and GUI behavior have been preserved in accordance with the task requirements.

---
*PR created automatically by Jules for task [10212403428719374257](https://jules.google.com/task/10212403428719374257) started by @youtube-at-vach*