### PR TITLE
Fix measurement leakage in single channel mode and prevent extreme clock drift correction

### DIFF
--- a/src/core/nonlinear_analyzer_core.py
+++ b/src/core/nonlinear_analyzer_core.py
@@ -14,13 +14,16 @@ def find_subsample_peak(ir):
     """
     idx_int = np.argmax(np.abs(ir))
     N_total = len(ir)
+    win_size = 32  # Use 32 samples window for high accuracy
+
+    if N_total < win_size:
+        return float(idx_int)
 
     # Shift the signal temporarily so that the peak is far away from boundaries (to N_total // 2)
     shift_amount = N_total // 2 - idx_int
     ir_shifted = np.roll(ir, shift_amount)
 
     idx_int_sh = N_total // 2
-    win_size = 32  # Use 32 samples window for high accuracy
     half = win_size // 2
     start = idx_int_sh - half
     end = idx_int_sh + half
@@ -225,19 +228,21 @@ def process_amplitude_responses(
     # Choose alignment signal source: Ref channel in XFER mode, Meas channel otherwise
     if input_mode in {"XFER", "XFER_REV"}:
         base_align_sig = responses_ref[ref_step_idx]
+        t_ref_base = find_subsample_peak(base_align_sig)
     else:
+        # For single channel mode, do not align individual steps to prevent
+        # non-linear distortion components from affecting peak detection and causing leakage.
+        # However, we still find the base peak to know the absolute timing.
         base_align_sig = responses_meas[ref_step_idx]
-
-    t_ref_base = find_subsample_peak(base_align_sig)
+        t_ref_base = find_subsample_peak(base_align_sig)
 
     for j in range(num_amplitudes):
         if input_mode in {"XFER", "XFER_REV"}:
             align_sig = responses_ref[j]
+            t_ref_j = find_subsample_peak(align_sig)
+            delay_j = t_ref_j - t_ref_base
         else:
-            align_sig = responses_meas[j]
-
-        t_ref_j = find_subsample_peak(align_sig)
-        delay_j = t_ref_j - t_ref_base
+            delay_j = 0.0
 
         # Apply fractional delay shift in frequency domain (shift back by -delay_j)
         ref_aligned = apply_fractional_delay(responses_ref[j], -delay_j)

--- a/src/gui/widgets/nonlinear_analyzer.py
+++ b/src/gui/widgets/nonlinear_analyzer.py
@@ -404,8 +404,8 @@ class NonlinearAnalyzer(MeasurementModule):
 
                 logger.info("Estimated clock drift: %.2f ppm (factor: %.8f)", drift_ppm, drift_factor)
 
-                # 4. Apply resampling if drift is significant (> 1.0 ppm)
-                if np.abs(drift_ppm) > 1.0:
+                # 4. Apply resampling if drift is significant (> 1.0 ppm) and physically plausible (< 1000.0 ppm)
+                if 1.0 < np.abs(drift_ppm) < 1000.0:
                     logger.info("Applying clock drift compensation via linear resampling...")
                     t_orig = np.arange(total_len, dtype=np.float64)
                     t_corrected = t_orig / drift_factor
@@ -415,6 +415,13 @@ class NonlinearAnalyzer(MeasurementModule):
                         rec_data_corrected[:, ch] = np.interp(t_orig, t_corrected, rec_data[:, ch])
                     rec_data = rec_data_corrected
                     logger.info("Clock drift compensation completed.")
+                elif np.abs(drift_ppm) >= 1000.0:
+                    logger.warning(
+                        "Estimated clock drift (%.2f ppm) is physically implausible. "
+                        "This likely indicates noise interference or peak-finding error. "
+                        "Skipping compensation to prevent signal degradation.",
+                        drift_ppm
+                    )
             except Exception as e:
                 logger.error("Failed to compensate clock drift: %s", e)
 

--- a/tests/logic_verification/measurement_modules/test_nonlinear_analyzer.py
+++ b/tests/logic_verification/measurement_modules/test_nonlinear_analyzer.py
@@ -699,3 +699,70 @@ def test_nonlinear_analyzer_descending_sweep():
     h1_phase = phases["h1"][assert_mask]
     assert np.all(np.abs(h1_phase) < 10.0), f"Phase response for h1 is wrapping abnormally: {np.max(np.abs(h1_phase))} deg"
 
+
+def test_nonlinear_analyzer_single_channel_distortion():
+    """
+    Verifies that for single channel mode ("L"), the Parallel Hammerstein
+    separation accurately recovers polynomial coefficients for a quadratic system
+    without getting affected by peak-finding alignment fluctuations.
+    """
+    sample_rate = 44100
+    sweep_duration = 2.0
+    start_freq = 20.0
+    end_freq = 20000.0
+    P = 5
+
+    sss, _ = generate_sss_and_inverse(sample_rate, sweep_duration, start_freq, end_freq)
+
+    max_amp = 0.5
+    num_amplitudes = 5
+    amplitudes = np.linspace(0.2, 1.0, num_amplitudes) * max_amp
+
+    responses_meas = []
+    responses_ref = []
+
+    a = 0.1
+    for amp in amplitudes:
+        x_sig = amp * sss
+        # Simulate quadratic system
+        y_sig = x_sig + a * (x_sig**2)
+
+        padding = np.zeros(int(0.2 * sample_rate))
+        x_sig_padded = np.concatenate([x_sig, padding])
+        y_sig_padded = np.concatenate([y_sig, padding])
+
+        ir_ref = deconvolve_signal(x_sig_padded, sss)
+        ir_meas = deconvolve_signal(y_sig_padded, sss)
+
+        responses_ref.append(ir_ref)
+        responses_meas.append(ir_meas)
+
+    # Process using input_mode="L"
+    freqs, mags, phases, time_ms, separated_kernels_data = process_amplitude_responses(
+        responses_meas,
+        responses_ref,
+        sample_rate,
+        start_freq,
+        end_freq,
+        input_mode="L",
+        latency_sec=0.0,
+        sweep_duration=sweep_duration,
+        P=P,
+        amplitudes=amplitudes,
+    )
+
+    assert_mask = (freqs >= 200.0) & (freqs <= 15000.0)
+
+    # h1 is fundamental (near 0 dB)
+    assert np.all(np.abs(mags["h1"][assert_mask]) < 1.5)
+
+    # h2 should be the dominant distortion component and match expected coefficient weight (~-20 dB)
+    h2_avg = np.mean(mags["h2"][assert_mask])
+    assert -23.0 < h2_avg < -17.0, f"h2 level {h2_avg} dB deviates from expected (~-20 dB)"
+
+    # h3, h4, h5 should be suppressed (<-30 dB)
+    for p in [3, 4, 5]:
+        h_key = f"h{p}"
+        max_val = np.max(mags[h_key][assert_mask])
+        assert max_val < -30.0, f"Harmonic {h_key} detected in quadratic system under single-channel mode: {max_val:.2f} dB"
+


### PR DESCRIPTION
## Description
This PR addresses several critical QA and measurement reliability issues identified in the `NonlinearAnalyzer` module and `NonlinearAnalyzerCore`:

1. **Measurement Leakage / Peak-Finding Fluctuations in Single-Channel Mode**:
   - In single-channel modes (`L`, `R`), the measurement input mode does not have a clean loopback reference channel (`responses_ref`). 
   - Previously, the algorithm aligned different amplitude steps using the peak position of the distorted measurement channel response. Because high non-linear distortion (especially at higher amplitudes) changes the shape of the impulse response, peak-finding (`find_subsample_peak`) fluctuated across steps.
   - This fluctuation introduced artificial fractional delay offsets between steps, which caused severe leakage of non-linear distortion components back into the fundamental linear kernel (`h1`) and degraded the accuracy of higher-order kernels (`h2` to `h5`) during Chebyshev separation.
   - **Fix**: Step-by-step relative fractional delay alignment is now disabled for single-channel modes. Absolute timing alignment is still done based on the maximum amplitude baseline step, while relative delay offsets (`delay_j`) are kept at `0.0`.
   - **Test**: Added `test_nonlinear_analyzer_single_channel_distortion` in `test_nonlinear_analyzer.py` to verify that polynomial coefficients (e.g. quadratic coefficients) are recovered accurately in single-channel mode.

2. **Extreme Clock Drift Correction Safeguard**:
   - In environments with severe noise or peak mismatches, the estimated clock drift between the first and last sweep block could produce an implausibly large drift (e.g., thousands of ppm).
   - Attempting to resample the signal with such huge drift rates severely warped the sweeps and broke the deconvolution.
   - **Fix**: Added a guard limit of `1000.0` ppm. If the estimated drift is outside the `1.0 < |drift_ppm| < 1000.0` range, the resampling is skipped, and a warning is logged.

3. **Impulse Response Peak Guard**:
   - Added a length safety check in `find_subsample_peak` to prevent `ValueError: operands could not be broadcast together` when the impulse response is very short (less than `win_size = 32`).

## Validation
- Ran full test suite (975 items): All tests passed successfully, including the newly added single-channel distortion verification test.
- Verified size limit checks (`scripts/check_ui_size_limits.py` passed).
- Ran linters and type checkers (Ruff, Mypy, translation checks, markdownlint), which all passed without warnings.