### PR TITLE
🧹 [Code Health] Remove unused ExportManager import from core export init

### DIFF
--- a/src/core/export/__init__.py
+++ b/src/core/export/__init__.py
@@ -1,3 +1,0 @@
-from .manager import ExportManager
-
-__all__ = ["ExportManager"]

--- a/src/gui/widgets/export_dialog.py
+++ b/src/gui/widgets/export_dialog.py
@@ -22,7 +22,7 @@ from PyQt6.QtWidgets import (
     QListWidgetItem,
 )
 from src.core.localization import tr
-from src.core.export import ExportManager
+from src.core.export.manager import ExportManager
 from src.core.comparison_manager import ComparisonTrace
 
 


### PR DESCRIPTION
🎯 **What:** Removed the unused `ExportManager` import and its `__all__` export declaration from `src/core/export/__init__.py`, and updated the downstream caller in `src/gui/widgets/export_dialog.py` to import directly from `manager.py`.
💡 **Why:** The codebase analysis reported an unused import issue in `__init__.py`. By explicitly importing `ExportManager` from its definition module where needed, we remove unnecessary top-level exports, reducing namespace pollution and satisfying strict linting requirements.
✅ **Verification:** Verified the code manually via `git diff`, ran the local test suite using `QT_QPA_PLATFORM=offscreen PYTHONPATH=. python3 -m pytest tests/core/export/` which passed successfully. 
✨ **Result:** Cleaned up `__init__.py` without breaking existing GUI functionality.

---
*PR created automatically by Jules for task [6613963200812885411](https://jules.google.com/task/6613963200812885411) started by @youtube-at-vach*