### PR TITLE
🧹 Fix swallowed exception in timecode monitor (S110)

### DIFF
--- a/src/gui/widgets/timecode_monitor.py
+++ b/src/gui/widgets/timecode_monitor.py
@@ -1390,8 +1390,8 @@ class TimecodeMonitorWidget(QWidget, CompactableWidgetInterface):
         # Ensure we don't keep decoding/generating LTC after the widget is closed.
         try:
             self._set_monitor_running(False)
-        except Exception:  # noqa: S110
-            pass
+        except Exception as e:
+            logger.warning(f"Error stopping timecode monitor during closure: {e}")
         return super().closeEvent(event)
 
     def on_link_toggled(self, checked: bool):


### PR DESCRIPTION
🎯 **What:** Replaced the swallowed general exception (`pass`) in `TimecodeMonitorWidget.closeEvent` with explicit error logging using `logger.warning`.

💡 **Why:** Silently ignoring exceptions can mask potential bugs during widget closure. Logging the error helps maintainability and debuggability without altering the intended non-blocking behavior of the close operation.

✅ **Verification:**
- Ran format and lint checks (noqa: S110 was removed)
- Ran the full test suite (`pytest`) successfully, ensuring no regressions.
- Verified the code health issue is resolved by removing the `pass`.

✨ **Result:** The codebase is cleaner and adheres to better logging practices for exception handling.

---
*PR created automatically by Jules for task [8126397126231494430](https://jules.google.com/task/8126397126231494430) started by @youtube-at-vach*