### PR TITLE
🧹 [fix swallowed exception in timecode_monitor]

### DIFF
--- a/src/gui/widgets/timecode_monitor.py
+++ b/src/gui/widgets/timecode_monitor.py
@@ -826,8 +826,8 @@ class TimecodeMonitor(MeasurementModule):
         # Apply input delay compensation (if any)
         try:
             total_frames += int(ch.input_offset_frames)
-        except Exception:  # noqa: S110
-            pass
+        except (ValueError, TypeError) as e:
+            logger.debug(f"Failed to apply input delay compensation: {e}")
 
         mem = self.jam_memories[s]
         mem.valid = True


### PR DESCRIPTION
🎯 **What:** The code health issue addressed is a swallowed exception (`except Exception: pass`) when parsing input offsets.
💡 **Why:** Silently catching `Exception` makes debugging much harder and can hide actual bugs (such as `AttributeError` if `ch` is None). Catching the specific types that we expect `int()` to raise (`ValueError`, `TypeError`) and logging the error improves maintainability and makes potential issues visible without crashing the process.
✅ **Verification:** I ran `ruff check` (no lint errors) and the test suite (`pytest tests/logic_verification/instruments/test_timecode_monitor_ltc.py` etc.) to confirm that the changes did not break anything. 
✨ **Result:** The system will now explicitly log when input delay compensation fails instead of swallowing errors.

---
*PR created automatically by Jules for task [14486098247604449867](https://jules.google.com/task/14486098247604449867) started by @youtube-at-vach*