### PR TITLE
fix: Align LS and IIR extraction phase in RealtimeSSSEngine

### DIFF
--- a/src/core/realtime_sss_core.py
+++ b/src/core/realtime_sss_core.py
@@ -289,11 +289,17 @@ class RealtimeSSSEngine:
         sig_results = self._fit_harmonics(theta_win, sig_win, weights)
         result_freq = self._frequency_at_sample(float(np.mean(hist_n[mask])))
 
+        # Apply 90-degree phase correction (multiply by 1j) to match sine excitation
+        # and maintain consistency with the IIR DDC demodulator.
+        sig_results = [val * 1j for val in sig_results]
+
         if ref_win is None or len(ref_win) != len(sig_win):
             return result_freq, sig_results
 
         ref_results = self._fit_harmonics(theta_win, ref_win, weights)
         ref_h1 = ref_results[0] if ref_results else 0.0j
+        # Also apply 90-degree phase correction to the reference fundamental
+        ref_h1 = ref_h1 * 1j
         ref_conj = np.conj(ref_h1)
         ref_mag2 = float(np.real(ref_h1 * ref_conj))
         if ref_mag2 <= 1e-24:

--- a/tests/core/test_realtime_sss_core.py
+++ b/tests/core/test_realtime_sss_core.py
@@ -284,3 +284,57 @@ def test_engine_ls_extractor_decimation_continuity():
         assert diffs[idx] < 0.015, f"Discontinuity detected at D change index {idx} (D changed from {valid_d[idx]} to {valid_d[idx+1]}): jump was {diffs[idx]:.5f}"
 
 
+def test_engine_ls_vs_iir_phase_consistency():
+    # IIR
+    engine_iir = RealtimeSSSEngine(
+        sample_rate=48000,
+        sweep_duration=1.0,
+        start_freq=100,
+        end_freq=1000,
+        output_amplitude=0.5,
+        lpf_factor=0.08,
+        max_harmonic=3,
+        extraction_mode="iir",
+    )
+    engine_iir.prepare_sweep()
+    engine_iir.set_latency(0)
+
+    # LS
+    engine_ls = RealtimeSSSEngine(
+        sample_rate=48000,
+        sweep_duration=1.0,
+        start_freq=100,
+        end_freq=1000,
+        output_amplitude=0.5,
+        lpf_factor=0.08,
+        max_harmonic=3,
+        extraction_mode="ls",
+    )
+    engine_ls.prepare_sweep()
+    engine_ls.set_latency(0)
+
+    frames = 1024
+    num_blocks = 5
+    for block_idx in range(num_blocks):
+        outdata = np.zeros((frames, 1))
+        indata = np.zeros((frames, 1))
+        start = block_idx * frames
+        assert engine_iir.out_sig is not None
+        indata[:frames, 0] = engine_iir.out_sig[start : start + frames]
+
+        f_mid_iir, results_iir = engine_iir.process_block(indata, outdata, block_index=block_idx)
+        f_mid_ls, results_ls = engine_ls.process_block(indata, outdata, block_index=block_idx)
+
+    # Compare phase of fundamental for the last block
+    h1_iir = results_iir[0]
+    h1_ls = results_ls[0]
+
+    phase_iir = np.angle(h1_iir)
+    phase_ls = np.angle(h1_ls)
+    phase_diff = np.abs(phase_iir - phase_ls)
+    # Normalize phase diff to [-pi, pi]
+    phase_diff = (phase_diff + np.pi) % (2 * np.pi) - np.pi
+    assert np.abs(phase_diff) < 0.1, f"Phase mismatch between IIR ({phase_iir}) and LS ({phase_ls}) modes: {phase_diff}"
+
+
+


### PR DESCRIPTION
### Description
This PR resolves a 90-degree (1j) phase mismatch between the **Least Squares (LS)** harmonic extraction mode and the **IIR / Digital Down-Converter (DDC)** demodulation mode in the SSS (Swept-Sine System) real-time engine.

- **Root Cause**: The DDC demodulator uses a complex mixing signal `1j * np.exp(-1j * theta)`, resulting in a 90-degree phase shift compared to a purely real mixing logic. The LS estimator, on the other hand, was purely real, which caused a 90-degree phase offset relative to the DDC/IIR mode output.
- **Fix**: Applied a 90-degree phase shift (`* 1j`) to the LS extraction results (for both measurement and reference channels) to maintain strict phase consistency between the extraction modes.

### Verification Results
1. **New Unit Test**: Added `test_engine_ls_vs_iir_phase_consistency` to `tests/core/test_realtime_sss_core.py`. The test successfully verifies that the phase mismatch between IIR and LS is within 0.1 radians. (Test passed).
2. **Algorithm Integrity**: Ran `scripts/verify_realtime_sss_vs_nonlinear.py` which verifies real-time SSS vs. offline Nonlinear Analyzer (deconvolution). (All checks PASSED).
3. **Local CI Checks**: Verified locally with `ruff`, `mypy`, `check_trn_keys.py`, `check_ui_size_limits.py`, and `markdownlint-cli2`. (All checks PASSED).