### PR TITLE
🧹 [Fix swallowed exception in loopback finder]

### DIFF
--- a/src/gui/widgets/loopback_finder.py
+++ b/src/gui/widgets/loopback_finder.py
@@ -1,3 +1,4 @@
+import logging
 import numpy as np
 import sounddevice as sd
 from PyQt6.QtCore import QThread, pyqtSignal
@@ -18,6 +19,8 @@ from src.core.audio_engine import AudioEngine
 from src.core.fft_manager import fft_manager
 from src.core.localization import tr
 from src.measurement_modules.base import MeasurementModule
+
+logger = logging.getLogger(__name__)
 
 
 class LoopbackWorker(QThread):
@@ -78,7 +81,8 @@ class LoopbackFinder(MeasurementModule):
         try:
             devices, _ = self.audio_engine._get_cached_audio_info()
             has_cache = devices is not None and isinstance(devices, tuple)
-        except Exception:
+        except Exception as e:
+            logger.warning(f"Failed to get cached audio info: {e}")
             devices = None
             has_cache = False
 
@@ -88,8 +92,8 @@ class LoopbackFinder(MeasurementModule):
                 try:
                     devices = sd.query_devices()
                     has_cache = devices is not None and isinstance(devices, tuple)
-                except Exception:  # noqa: S110
-                    pass
+                except Exception as e:
+                    logger.warning(f"Failed to query sound devices: {e}")
             if not has_cache:
                 return sd.query_devices(dev_id)
             if isinstance(dev_id, int) and dev_id < len(devices):


### PR DESCRIPTION
🎯 **What:** Fixed swallowed general exceptions (`except Exception:`) in `src/gui/widgets/loopback_finder.py` by catching the exception explicitly (`except Exception as e:`) and logging a warning. Added `import logging` and a module-level logger.

💡 **Why:** It's bad practice to silently pass on general exceptions. Logging the error improves maintainability, debugging, and code health while preserving existing behavior.

✅ **Verification:** Verified by running the loopback finder module logic tests and formatting with `ruff`. Flaky regression tests in `test_nonlinear_analyzer.py` related to "Audio playback timed out" were verified to pass when isolated.

✨ **Result:** Enhanced code health without functional regression.

---
*PR created automatically by Jules for task [6350385513793594889](https://jules.google.com/task/6350385513793594889) started by @youtube-at-vach*