### PR TITLE
🧹 [code health improvement] Refactor global cache variable to class-based state

### DIFF
--- a/src/core/hammerstein_model.py
+++ b/src/core/hammerstein_model.py
@@ -92,7 +92,8 @@ def load_hammerstein_model(filepath):
 
 
 # Decoupled active model cache for inter-module communication
-_ACTIVE_MODEL_CACHE = None
+class _ActiveModelCache:
+    data = None
 
 
 def set_active_model(data):
@@ -100,8 +101,7 @@ def set_active_model(data):
     Caches the active Hammerstein model in memory.
     data: dict containing model structure (metadata, time_domain, frequency_domain).
     """
-    global _ACTIVE_MODEL_CACHE
-    _ACTIVE_MODEL_CACHE = data
+    _ActiveModelCache.data = data
 
 
 def get_active_model():
@@ -110,7 +110,7 @@ def get_active_model():
     Returns:
         dict: The model data, or None if no model is cached.
     """
-    return _ACTIVE_MODEL_CACHE
+    return _ActiveModelCache.data
 
 
 def has_active_model():
@@ -119,4 +119,4 @@ def has_active_model():
     Returns:
         bool: True if cached, False otherwise.
     """
-    return _ACTIVE_MODEL_CACHE is not None
+    return _ActiveModelCache.data is not None

--- a/tests/core/test_core_hammerstein_model.py
+++ b/tests/core/test_core_hammerstein_model.py
@@ -82,7 +82,7 @@ def test_active_model_cache(sample_hammerstein_data):
     import src.core.hammerstein_model as hm
 
     # Reset state before testing
-    hm._ACTIVE_MODEL_CACHE = None
+    hm.set_active_model(None)
 
     assert has_active_model() is False
     assert get_active_model() is None


### PR DESCRIPTION
🎯 **What:** Removed the module-level global variable `_ACTIVE_MODEL_CACHE` and its accompanying `global` assignments in `src/core/hammerstein_model.py`. It has been refactored to use a static class (`_ActiveModelCache`) with a `data` attribute.

💡 **Why:** Relying on the `global` keyword to manage state is a common code health anti-pattern that triggers linters (like PyLint warning W0603) and makes testing and state tracking brittle. Encapsulating the state inside a class provides cleaner, self-contained module state management.

✅ **Verification:** 
- The entire application's test suite was run (`pytest`), and all tests, including those directly testing the cache (`test_core_hammerstein_model.py`) and downstream consumers (`test_nonlinear_analyzer.py`), pass perfectly.
- Linting checks (`ruff`, `pylint`) confirm the removal of the global statement warning without introducing any new issues.

✨ **Result:** A cleaner module with zero `global` statements, eliminating the "unused variable" flagging while preserving exactly the same caching behavior for the application.

---
*PR created automatically by Jules for task [3031474928892504571](https://jules.google.com/task/3031474928892504571) started by @youtube-at-vach*