### PR TITLE
docs: Fix internal links in English documentation to ensure language consistency

### DIFF
--- a/docs/index.en.md
+++ b/docs/index.en.md
@@ -16,11 +16,11 @@ The purpose of this tool is to **transform your everyday PC and audio interface 
 ## How to Read This Manual
 
 - For first-time users:
-  → Read the [Quickstart](quickstart.md) first.
+  → Read the [Quickstart](quickstart.en.md) first.
 - To use specific features:
-  → Refer to each [**Widget Guide**](widget_guide.md).
+  → Refer to each [**Widget Guide**](widget_guide.en.md).
 - To see actual measurement examples:
-  → Refer to the [**Measurement Recipes**](measurement_recipes/index.md).
+  → Refer to the [**Measurement Recipes**](measurement_recipes/index.en.md).
 
 ---
 

--- a/docs/measurement_recipes/distortion_measurement.en.md
+++ b/docs/measurement_recipes/distortion_measurement.en.md
@@ -73,7 +73,7 @@ The value displayed at this time (probably around -150dB) is the measurement low
 
 ### When Even Higher Precision Measurement is Required
 
-If you want to measure ultra-high performance DACs and amplifiers that fall below -150dB, consider using the **[LockinHarmonicAnalyzer](../widgets/lockin_harmonic_analyzer.md)**. By using the lock-in method, it is possible to observe even deeper noise floors, but for normal measurements, this Distortion Analyzer provides sufficient performance.
+If you want to measure ultra-high performance DACs and amplifiers that fall below -150dB, consider using the **[LockinHarmonicAnalyzer](../widgets/lockin_harmonic_analyzer.en.md)**. By using the lock-in method, it is possible to observe even deeper noise floors, but for normal measurements, this Distortion Analyzer provides sufficient performance.
 
 ---
 

--- a/docs/measurement_recipes/index.en.md
+++ b/docs/measurement_recipes/index.en.md
@@ -23,13 +23,13 @@ The most important thing in measurement is not just reading numbers, but **"meas
 
 The following guides are currently available:
 
-* **[Noise Measurement Recipe](noise_measurement.md)**
+* **[Noise Measurement Recipe](noise_measurement.en.md)**
     * Detailed analysis of residual noise (hiss) and hum noise from amplifiers and circuits. We explain techniques for identifying and evaluating causes for each component, such as 1/f noise, thermal noise, and external induction noise.
-* **[High-Precision Gain/Phase Measurement (Lock-in Amplifier)](lockin_amplifier.md)**
+* **[High-Precision Gain/Phase Measurement (Lock-in Amplifier)](lockin_amplifier.en.md)**
     * Explains how to measure gain and phase with higher precision than FFT. Introduces precision demonstration at the 0.001 dB level through loopback tests and ultra-precise frequency response measurement using FRA mode.
-* **[Distortion (THD+N) Measurement](distortion_measurement.md)**
+* **[Distortion (THD+N) Measurement](distortion_measurement.en.md)**
     * Explains basic procedures for measuring distortion in audio equipment. Also touches on measurement limits using the digital notch filter method and choosing between it and the lock-in THD analyzer.
-* **[Speaker Impedance Measurement](speaker_impedance.md)**
+* **[Speaker Impedance Measurement](speaker_impedance.en.md)**
     * Explains how to measure the $f_0$ (lowest resonant frequency) and impedance characteristics of a speaker unit. Introduces the connection diagram using the I-V method and how to read the measurement results step by step.
 
 ---
@@ -43,4 +43,4 @@ Measurement recipes are scheduled to be added and updated sequentially according
 ## References
 
 * The precision of the measurement values obtained in each recipe depends heavily on the performance of the audio interface used and the calibration status.
-* For the reliability of measurements and the limitations of this tool, please be sure to read [**Appendix: This tool is not a "measurement instrument"**](../appendix.md).
+* For the reliability of measurements and the limitations of this tool, please be sure to read [**Appendix: This tool is not a "measurement instrument"**](../appendix.en.md).

--- a/docs/measurement_recipes/noise_measurement.en.md
+++ b/docs/measurement_recipes/noise_measurement.en.md
@@ -8,9 +8,9 @@ The widget to use depends on what kind of noise you want to see.
 
 | Purpose | Recommended Tool | Overview |
 | :--- | :--- | :--- |
-| **View noise spectrum** | [Spectrum Analyzer](../widgets/spectrum_analyzer.md) | Confirm at which frequencies and how much noise is included (distribution). This is the most common measurement. |
-| **Analyze noise types** | [Noise Profiler](../widgets/noise_profiler.md) | Decompose into components such as "hiss (white noise)" and "hum," and quantify their respective contributions. |
-| **View time-series changes in noise** | [Raw Time Series](../widgets/raw_time_series.md) | Monitor changes over time, such as "occasional pop noise" or "fluctuation of DC offset." |
+| **View noise spectrum** | [Spectrum Analyzer](../widgets/spectrum_analyzer.en.md) | Confirm at which frequencies and how much noise is included (distribution). This is the most common measurement. |
+| **Analyze noise types** | [Noise Profiler](../widgets/noise_profiler.en.md) | Decompose into components such as "hiss (white noise)" and "hum," and quantify their respective contributions. |
+| **View time-series changes in noise** | [Raw Time Series](../widgets/raw_time_series.en.md) | Monitor changes over time, such as "occasional pop noise" or "fluctuation of DC offset." |
 
 ---
 

--- a/docs/measurement_recipes/speaker_impedance.en.md
+++ b/docs/measurement_recipes/speaker_impedance.en.md
@@ -1,7 +1,7 @@
 # Speaker Impedance Measurement
 
 !!! Warning "Unverified Guide"
-    This guide was created based on AI inference. Please be sure to read [**Appendix: This tool is not a "measuring instrument"**](../appendix.md) regarding the reliability of measurement results and the limitations of this tool.
+    This guide was created based on AI inference. Please be sure to read [**Appendix: This tool is not a "measuring instrument"**](../appendix.en.md) regarding the reliability of measurement results and the limitations of this tool.
 
 This guide measures the electrical characteristics (impedance) of speaker units.
 By plotting the impedance curve, you can obtain clues for identifying the speaker's lowest resonant frequency ($f_0$) and parameters necessary for enclosure (box) design.

--- a/docs/quickstart.en.md
+++ b/docs/quickstart.en.md
@@ -157,6 +157,6 @@ In this mode, you can load audio files into the **Player** widget or generate si
 Once you are familiar with the basic operations, proceed to more detailed guides.
 
 - **To measure accurate voltage or SPL** → [Calibration](calibration.en.md)
-- **If you are unsure which tool to use** → [Widget Guide](widget_guide.md)
-- **To know how to measure in practice** → [Measurement Recipes](measurement_recipes/index.md)
-- **To see the waveform directly** → [Oscilloscope](widgets/oscilloscope.md)
+- **If you are unsure which tool to use** → [Widget Guide](widget_guide.en.md)
+- **To know how to measure in practice** → [Measurement Recipes](measurement_recipes/index.en.md)
+- **To see the waveform directly** → [Oscilloscope](widgets/oscilloscope.en.md)

--- a/docs/widget_guide.en.md
+++ b/docs/widget_guide.en.md
@@ -10,22 +10,22 @@ Checklist to find the best tool for "what you want to do" quickly.
 
 | What you want to do | Recommended Widget |
 | :--- | :--- |
-| **Output sound / Need a signal source** | [Signal Generator](widgets/signal_generator.md) |
-| **Synthesize complex waveforms / Blend specific harmonics** | [Arbitrary Harmonic Generator](widgets/arbitrary_harmonic_generator.md) |
-| **View frequency components (spectrum)** | [Spectrum Analyzer](widgets/spectrum_analyzer.md) |
-| **Check specific frequencies with extremely high resolution** | [Lock-in Spectrum Finder](widgets/lockin_spectrum_finder.md) |
-| **View original waveform shape** | [Oscilloscope](widgets/oscilloscope.md) |
-| **Measure distortion (THD) of amps or components** | [Distortion Analyzer](widgets/distortion_analyzer.md) |
-| **Apply feedforward distortion compensation to an audio signal** | [Feedforward Compensator](widgets/feedforward_compensator.md) |
-| **Measure frequency response of amps, etc.** | [Network Analyzer](widgets/network_analyzer.md) |
-| **Measure impedance of speakers** | [Impedance Analyzer](widgets/impedance_analyzer.md) |
-| **Measure ultra-low distortion (THD) with high precision** | [Lock-in Harmonic Analyzer](widgets/lockin_harmonic_analyzer.md) |
-| **Manage loudness (LUFS)** | [LUFS Meter](widgets/lufs_meter.md) |
-| **Know ambient noise level (SPL)** | [Sound Level Meter](widgets/sound_level_meter.md) |
-| **Analyze noise types (1/f, etc.)** | [Noise Profiler](widgets/noise_profiler.md) |
-| **Precisely align L/R acoustic characteristics** | [Stereo Alignment Monitor](widgets/stereo_alignment_monitor.md) |
-| **Overlay and compare multiple plot traces from different measurements** | [Plot Comparer](widgets/plot_comparer.md) |
-| **Evaluate digital/analog transmission path quality, latency, and integrity** | [Transmission Analyzer (Experimental)](widgets/transmission_analyzer.md) |
+| **Output sound / Need a signal source** | [Signal Generator](widgets/signal_generator.en.md) |
+| **Synthesize complex waveforms / Blend specific harmonics** | [Arbitrary Harmonic Generator](widgets/arbitrary_harmonic_generator.en.md) |
+| **View frequency components (spectrum)** | [Spectrum Analyzer](widgets/spectrum_analyzer.en.md) |
+| **Check specific frequencies with extremely high resolution** | [Lock-in Spectrum Finder](widgets/lockin_spectrum_finder.en.md) |
+| **View original waveform shape** | [Oscilloscope](widgets/oscilloscope.en.md) |
+| **Measure distortion (THD) of amps or components** | [Distortion Analyzer](widgets/distortion_analyzer.en.md) |
+| **Apply feedforward distortion compensation to an audio signal** | [Feedforward Compensator](widgets/feedforward_compensator.en.md) |
+| **Measure frequency response of amps, etc.** | [Network Analyzer](widgets/network_analyzer.en.md) |
+| **Measure impedance of speakers** | [Impedance Analyzer](widgets/impedance_analyzer.en.md) |
+| **Measure ultra-low distortion (THD) with high precision** | [Lock-in Harmonic Analyzer](widgets/lockin_harmonic_analyzer.en.md) |
+| **Manage loudness (LUFS)** | [LUFS Meter](widgets/lufs_meter.en.md) |
+| **Know ambient noise level (SPL)** | [Sound Level Meter](widgets/sound_level_meter.en.md) |
+| **Analyze noise types (1/f, etc.)** | [Noise Profiler](widgets/noise_profiler.en.md) |
+| **Precisely align L/R acoustic characteristics** | [Stereo Alignment Monitor](widgets/stereo_alignment_monitor.en.md) |
+| **Overlay and compare multiple plot traces from different measurements** | [Plot Comparer](widgets/plot_comparer.en.md) |
+| **Evaluate digital/analog transmission path quality, latency, and integrity** | [Transmission Analyzer (Experimental)](widgets/transmission_analyzer.en.md) |
 
 ---
 
@@ -33,13 +33,13 @@ Checklist to find the best tool for "what you want to do" quickly.
 
 Tools for outputting signals or generating reference signals.
 
-- **[Signal Generator](widgets/signal_generator.md)**
+- **[Signal Generator](widgets/signal_generator.en.md)**
     - Generates sine waves, noise, sweep signals, etc. It is the basic signal source for measurements.
 
-- **[Arbitrary Harmonic Generator](widgets/arbitrary_harmonic_generator.md)**
+- **[Arbitrary Harmonic Generator](widgets/arbitrary_harmonic_generator.en.md)**
     - An advanced signal generator that allows synthesizing complex waveforms by precisely controlling the amplitude and phase of multiple harmonic components (up to the 50th order) relative to the fundamental frequency.
 
-- **[Timecode Monitor & Generator](widgets/timecode_monitor.md)**
+- **[Timecode Monitor & Generator](widgets/timecode_monitor.en.md)**
     - Generates and monitors LTC (Linear Timecode). Used for checking synchronization with video equipment.
 
 ---
@@ -48,22 +48,22 @@ Tools for outputting signals or generating reference signals.
 
 Measures basic characteristics of audio signals (spectrum, level, frequency).
 
-- **[Spectrum Analyzer](widgets/spectrum_analyzer.md)**
+- **[Spectrum Analyzer](widgets/spectrum_analyzer.en.md)**
     - Real-time display of frequency components (spectrum) using FFT.
 
-- **[Lock-in Spectrum Finder](widgets/lockin_spectrum_finder.md)**
+- **[Lock-in Spectrum Finder](widgets/lockin_spectrum_finder.en.md)**
     - Uses lock-in detection to analyze the spectrum of a specified frequency band with high resolution. Ideal for magnifying specific peaks buried in noise.
 
-- **[Sound Level Meter](widgets/sound_level_meter.md)**
+- **[Sound Level Meter](widgets/sound_level_meter.en.md)**
     - A sound level meter. Measures sound pressure level (SPL) and equivalent continuous sound level (Leq).
 
-- **[LUFS Meter](widgets/lufs_meter.md)**
+- **[LUFS Meter](widgets/lufs_meter.en.md)**
     - Measures loudness units relative to full scale (LUFS). Suitable for level management for broadcasting and distribution.
 
-- **[Frequency Counter](widgets/frequency_counter.md)**
+- **[Frequency Counter](widgets/frequency_counter.en.md)**
     - Counts the frequency of input signals with high precision. Statistical analysis such as Allan deviation is also possible.
 
-- **[Spectrogram](widgets/spectrogram.md)**
+- **[Spectrogram](widgets/spectrogram.en.md)**
     - Visualizes changes in frequency components over time with colors (voiceprint analysis, etc.).
 
 ---
@@ -72,29 +72,29 @@ Measures basic characteristics of audio signals (spectrum, level, frequency).
 
 Tools for evaluating equipment performance and sound quality.
 
-- **[Distortion Analyzer](widgets/distortion_analyzer.md)**
+- **[Distortion Analyzer](widgets/distortion_analyzer.en.md)**
     - Measures THD (Total Harmonic Distortion) or THD+N. Use this for basic distortion measurements.
-- **[Nonlinear Analyzer](widgets/nonlinear_analyzer.md)**
+- **[Nonlinear Analyzer](widgets/nonlinear_analyzer.en.md)**
     - An advanced distortion analysis tool that uses the Hammerstein model to separate and extract 1st (linear) to 5th order harmonic kernels from equipment responses.
 
-- **[Feedforward Compensator](widgets/feedforward_compensator.md)**
+- **[Feedforward Compensator](widgets/feedforward_compensator.en.md)**
     - Applies feedforward distortion compensation (LICFF) to audio signals using Hammerstein system models.
 
-- **[Nonlinear Response Analyzer](widgets/nonlinear_response_analyzer.md)**
+- **[Nonlinear Response Analyzer](widgets/nonlinear_response_analyzer.en.md)**
     - Identifies Wiener models to analyze dynamic nonlinear system behavior.
-- **[Linearity Analyzer](widgets/linearity_analyzer.md)**
+- **[Linearity Analyzer](widgets/linearity_analyzer.en.md)**
     - Measures input/output level linearity. Used for verifying the low-level signal reproduction capability and dynamic range of DACs.
 
-- **[Advanced Distortion Meter](widgets/advanced_distortion_meter.md)**
+- **[Advanced Distortion Meter](widgets/advanced_distortion_meter.en.md)**
     - Performs more advanced distortion analysis, such as multitone measurement and IMD (Intermodulation Distortion).
 
-- **[Lock-in Harmonic Analyzer](widgets/lockin_harmonic_analyzer.md)**
+- **[Lock-in Harmonic Analyzer](widgets/lockin_harmonic_analyzer.en.md)**
     - An ultra-low distortion (THD) measurement module utilizing the principle of a lock-in amplifier. It achieves high precision by performing multi-parallel IQ detection (up to 200th order) strictly tuned to the fundamental and harmonics.
 
-- **[Sound Quality Analyzer](widgets/sound_quality_analyzer.md)**
+- **[Sound Quality Analyzer](widgets/sound_quality_analyzer.en.md)**
     - Calculates psychoacoustic "sound quality" metrics such as sharpness and roughness.
 
-- **[Noise Profiler](widgets/noise_profiler.md)**
+- **[Noise Profiler](widgets/noise_profiler.en.md)**
     - Analyzes noise floor characteristics (1/f noise, white noise, etc.).
 
 ---
@@ -103,22 +103,22 @@ Tools for evaluating equipment performance and sound quality.
 
 Measures transmission characteristics, impedance, etc., of electronic circuits and systems.
 
-- **[Network Analyzer](widgets/network_analyzer.md)**
+- **[Network Analyzer](widgets/network_analyzer.en.md)**
     - Measures frequency response (gain, phase, group delay). Useful for checking characteristics of amplifiers and filters. Supports RIAA curve overlay for phono-equalizer testing.
 
-- **[Impedance Analyzer](widgets/impedance_analyzer.md)**
+- **[Impedance Analyzer](widgets/impedance_analyzer.en.md)**
     - Measures impedance characteristics (LCR) of speakers and components.
 
-- **[Lock-in Amplifier](widgets/lock_in_amplifier.md)**
+- **[Lock-in Amplifier](widgets/lock_in_amplifier.en.md)**
     - Detects infinitesimal signals buried in noise. Can also be used as an FRA (Frequency Response Analyzer).
 
-- **[Lock-in Frequency Counter](widgets/lock_in_frequency_counter.md)**
+- **[Lock-in Frequency Counter](widgets/lock_in_frequency_counter.en.md)**
     - Tracks minute frequency deviations or phase fluctuations relative to a reference signal.
 
-- **[Loopback Finder](widgets/loopback_finder.md)**
+- **[Loopback Finder](widgets/loopback_finder.en.md)**
     - Detects loopback paths of audio interfaces.
 
-- **[Transmission Analyzer (Experimental)](widgets/transmission_analyzer.md)**
+- **[Transmission Analyzer (Experimental)](widgets/transmission_analyzer.en.md)**
     - An experimental module that utilizes PRBS sequences (pseudo-random noise) to comprehensively measure digital audio bit-integrity (bit-perfection and DSP detection) as well as analog path metrics like EVM, impulse response, propagation delay, and clock jitter.
 
 ---
@@ -127,16 +127,16 @@ Measures transmission characteristics, impedance, etc., of electronic circuits a
 
 Observes waveform shapes and transient changes on the time axis.
 
-- **[Oscilloscope](widgets/oscilloscope.md)**
+- **[Oscilloscope](widgets/oscilloscope.en.md)**
     - A general-purpose oscilloscope. Observes the waveform itself.
 
-- **[Raw Time Series](widgets/raw_time_series.md)**
+- **[Raw Time Series](widgets/raw_time_series.en.md)**
     - A tool like a chart recorder that records waveforms over a long period and allows you to check them by scrolling.
 
-- **[Transient Analyzer](widgets/transient_analyzer.md)**
+- **[Transient Analyzer](widgets/transient_analyzer.en.md)**
     - Triggers and analyzes transient phenomena such as impulse responses. Wavelet transform display is also possible.
 
-- **[Boxcar Averager](widgets/boxcar_averager.md)**
+- **[Boxcar Averager](widgets/boxcar_averager.en.md)**
     - Averages repetitive signals to remove noise and extract minute waveforms.
 
 ---
@@ -145,19 +145,19 @@ Observes waveform shapes and transient changes on the time axis.
 
 Handles stereo image and spatial sound reverberation.
 
-- **[Goniometer](widgets/goniometer.md)**
+- **[Goniometer](widgets/goniometer.en.md)**
     - Displays phase relationship (spread) of stereo signals using Lissajous figures, etc.
 
-- **[BNIM Meter](widgets/bnim_meter.md)**
+- **[BNIM Meter](widgets/bnim_meter.en.md)**
     - Binaural Neural Image Map. Visualizes sound source localization (ITD/ILD) based on auditory models.
 
-- **[HRTF Player](widgets/hrtf_player.md)**
+- **[HRTF Player](widgets/hrtf_player.en.md)**
     - Loads Head-Related Transfer Functions (HRTF/SOFA) and simulates 3D audio playback via convolution.
 
-- **[Stereo Alignment Monitor](widgets/stereo_alignment_monitor.md)**
+- **[Stereo Alignment Monitor](widgets/stereo_alignment_monitor.en.md)**
     - Monitors the consistency of L/R level, frequency response, and phase in real-time to verify stereo alignment.
 
-- **[Spatial Binaural Mixer](widgets/spatial_binaural_mixer.md)**
+- **[Spatial Binaural Mixer](widgets/spatial_binaural_mixer.en.md)**
     - A high-quality offline multitrack spatial audio renderer. Load stems and independently position them in 3D space using HRTF, avoiding real-time processing artifacts.
 
 ---
@@ -166,21 +166,21 @@ Handles stereo image and spatial sound reverberation.
 
 Other useful functions.
 
-- **[Recorder & Player](widgets/recorder_player.md)**
+- **[Recorder & Player](widgets/recorder_player.en.md)**
     - Simple recording and playback function.
-- **[Waveform Loop Player](widgets/waveform_loop_player.md)**
+- **[Waveform Loop Player](widgets/waveform_loop_player.en.md)**
     - A tool that allows you to load an audio file, inspect its waveform, and loop a selected region. Useful for repeatedly observing transient responses.
-- **[Inverse Filter](widgets/inverse_filter.md)**
+- **[Inverse Filter](widgets/inverse_filter.en.md)**
     - Creates an inverse filter to cancel out the characteristics of speakers and rooms.
-- **[Detachable Wrapper](widgets/detachable_wrapper.md)**
+- **[Detachable Wrapper](widgets/detachable_wrapper.en.md)**
     - A framework for detaching any widget into a separate window.
-- **[Plot Comparer](widgets/plot_comparer.md)**
+- **[Plot Comparer](widgets/plot_comparer.en.md)**
     - Imports measurement traces saved/exported from other modules (Spectrum Analyzer, Network Analyzer, Oscilloscope, etc.) and allows detailed comparison by overlaying them with adjustable gain offsets, axis shifts, and peak alignment.
-- **[Processor Benchmark](widgets/processor_benchmark.md)**
+- **[Processor Benchmark](widgets/processor_benchmark.en.md)**
     - Tests the FFT and rendering performance of your PC to verify real-time processing limits.
-- **[Settings](widgets/settings.md)**
+- **[Settings](widgets/settings.en.md)**
     - Configure audio device settings, language settings, theme changes, etc.
 - **[Log Viewer](widgets/log_viewer.en.md)**
     - Displays real-time application logs, warnings, and errors for diagnostics and troubleshooting.
-- **[Welcome](widgets/welcome.md)**
+- **[Welcome](widgets/welcome.en.md)**
     - The startup screen.

--- a/docs/widgets/arbitrary_harmonic_generator.en.md
+++ b/docs/widgets/arbitrary_harmonic_generator.en.md
@@ -26,4 +26,4 @@ The core feature of this module is the ability to adjust individual harmonics.
 
 ### Data Management
 
-* **Export/Import**: You can export the current harmonic compensation profile to a JSON file and import it later. This is seamlessly integrated with the [Lock-in Harmonic Analyzer](lockin_harmonic_analyzer.md), allowing you to measure a system's distortion profile and then load that profile into the generator to create a pre-distorted or compensated signal.
+* **Export/Import**: You can export the current harmonic compensation profile to a JSON file and import it later. This is seamlessly integrated with the [Lock-in Harmonic Analyzer](lockin_harmonic_analyzer.en.md), allowing you to measure a system's distortion profile and then load that profile into the generator to create a pre-distorted or compensated signal.

--- a/docs/widgets/feedforward_compensator.en.md
+++ b/docs/widgets/feedforward_compensator.en.md
@@ -2,7 +2,7 @@
 
 The Feedforward Compensator is an advanced signal processing widget designed to apply real-time or offline nonlinear distortion compensation to audio signals based on a Parallel Hammerstein model.
 
-By loading a Hammerstein model (1st to 5th order impulse response kernels) measured and extracted by modules such as the [Nonlinear Analyzer](nonlinear_analyzer.md), it generates a compensated signal with inverse distortion to actively cancel (reduce) the distortion of physical audio devices.
+By loading a Hammerstein model (1st to 5th order impulse response kernels) measured and extracted by modules such as the [Nonlinear Analyzer](nonlinear_analyzer.en.md), it generates a compensated signal with inverse distortion to actively cancel (reduce) the distortion of physical audio devices.
 
 ---
 
@@ -45,7 +45,7 @@ To compensate for distortion caused by nonlinear components, the following itera
 
 ### Model Source
 
-* **Load Forward Model JSON... Button:** Loads a Hammerstein model JSON file (containing kernels `h1` through `h5`) exported from the [Nonlinear Analyzer](nonlinear_analyzer.md).
+* **Load Forward Model JSON... Button:** Loads a Hammerstein model JSON file (containing kernels `h1` through `h5`) exported from the [Nonlinear Analyzer](nonlinear_analyzer.en.md).
 * **Status:** Displays the load status of the model.
 * **Rate:** Displays the sampling rate of the loaded model.
 * **N Samples:** Displays the number of samples (model length) of the kernels (impulse responses).

--- a/docs/widgets/lockin_spectrum_finder.en.md
+++ b/docs/widgets/lockin_spectrum_finder.en.md
@@ -18,9 +18,9 @@ Standard spectrum analyzers calculate energy across broad frequency bands, obscu
 
 This widget is specialized for "finding" weak signals within a specific narrow band. For effective measurement, use it in combination with the following widgets depending on your goals:
 
-* **[Spectrum Analyzer](spectrum_analyzer.md)**
+* **[Spectrum Analyzer](spectrum_analyzer.en.md)**
     If you want to quickly grasp the frequency components and noise distribution over a wide frequency band, use the Spectrum Analyzer first. When you find a minor peak or noise that you want to examine in more detail with extremely high resolution, switch to this widget (especially utilizing the Zoom mode) for a deeper analysis.
-* **[Lock-in Amplifier](lock_in_amplifier.md)**
+* **[Lock-in Amplifier](lock_in_amplifier.en.md)**
     Once you have identified the exact frequency of the target signal using this widget, use the Lock-in Amplifier. By perfectly synchronizing (locking) to the identified frequency, you can measure the actual accurate amplitude and phase, and evaluate long-term stability.
 
 ## Modes

--- a/docs/widgets/nonlinear_analyzer.en.md
+++ b/docs/widgets/nonlinear_analyzer.en.md
@@ -17,7 +17,7 @@ This widget provides the following analysis capabilities:
 * **Hammerstein Kernel Extraction:** Extracts kernels from 1st (linear) up to 5th order from the measured response.
 * **Bode Plot (Magnitude/Phase) Display:** Plots the gain frequency response (Magnitude) and phase frequency response (Phase) of each extracted kernel. The X-axis range is now dynamically adjusted based on the input signal's actual length, providing an optimal view for any sweep setting.
 * **Impulse Response Display:** Allows viewing the impulse response of each kernel in the time domain.
-* **Model Caching and Exporting:** Once a measurement is complete, the extracted model is automatically saved to the active model cache. This allows other modules (e.g., [Response Viewer](response_viewer.md)) to use it for advanced analysis or simulation. It can also be exported locally as a JSON file.
+* **Model Caching and Exporting:** Once a measurement is complete, the extracted model is automatically saved to the active model cache. This allows other modules (e.g., [Response Viewer](response_viewer.en.md)) to use it for advanced analysis or simulation. It can also be exported locally as a JSON file.
 
 ## Settings
 
@@ -74,5 +74,5 @@ To observe impulse response peak details closely, the time axis (X-axis) is auto
 
 ## To Analyze Responses and Run Simulations
 
-To perform more detailed analysis using the measured Parallel Hammerstein model—such as THD maps, gain compression curves, tone response simulations, and Wiener representation conversion—please use the [Response Viewer](response_viewer.md) module.
+To perform more detailed analysis using the measured Parallel Hammerstein model—such as THD maps, gain compression curves, tone response simulations, and Wiener representation conversion—please use the [Response Viewer](response_viewer.en.md) module.
 Once a measurement completes, the model is automatically kept in the active cache. Simply open the Response Viewer and click **Load Live Cache** to start analyzing.

--- a/docs/widgets/response_viewer.en.md
+++ b/docs/widgets/response_viewer.en.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-The Response Viewer is an advanced visualization tool for analyzing linear and harmonic response characteristics (up to the 5th order) extracted by the [Nonlinear Analyzer](nonlinear_analyzer.md). It allows you to deeply evaluate the measured Hammerstein model's frequency response and simulate the system's output behavior (e.g., gain compression) at arbitrary frequencies and amplitudes.
+The Response Viewer is an advanced visualization tool for analyzing linear and harmonic response characteristics (up to the 5th order) extracted by the [Nonlinear Analyzer](nonlinear_analyzer.en.md). It allows you to deeply evaluate the measured Hammerstein model's frequency response and simulate the system's output behavior (e.g., gain compression) at arbitrary frequencies and amplitudes.
 
 ## Key Features and Operation
 


### PR DESCRIPTION
This PR addresses an issue where internal links in the English documentation (`*.en.md`) were pointing to the default Japanese versions (`*.md`).

**What:**
* Replaced instances of `.md` links with `.en.md` across various English documentation files, including `index.en.md`, `quickstart.en.md`, and several widget and measurement recipe guides.

**Why:**
* To improve information reachability and ensure consistency between the Japanese and English versions of the documentation, preventing users from being incorrectly navigated away from the English version.

**Note:**
This PR strictly focuses on this single theme (fixing links) to adhere to the "1 PR = 1 theme" guideline. Temporary garbage scripts used for finding and replacing links have been cleaned up. No functional application code is changed.

---
*PR created automatically by Jules for task [7227690731795867130](https://jules.google.com/task/7227690731795867130) started by @youtube-at-vach*