### PR TITLE
docs: add documentation for Realtime SSS Lockin Analyzer widget

### DIFF
--- a/docs/widgets/realtime_sss_analyzer.en.md
+++ b/docs/widgets/realtime_sss_analyzer.en.md
@@ -1,0 +1,39 @@
+# Realtime SSS Lockin Analyzer
+
+## Overview
+
+The Realtime SSS Lockin Analyzer performs real-time frequency response and distortion sweeps using Synchronized Swept Sine (SSS) and digital Lock-in techniques. It allows measuring magnitude and phase responses over a specified frequency range and can track harmonics.
+
+## Operation
+
+### Starting and Stopping Measurement
+
+* **Start Sweep / Stop Sweep Button**: Starts and stops the SSS measurement sweep. The button will indicate progress and disable itself momentarily upon completion while finishing up asynchronous processing.
+
+### Calibrating Latency
+
+* **Calibrate Latency**: Before running a sweep (especially in Relative XFER modes), it is crucial to align the input and output timing. Clicking this button sends a test signal to measure and compensate for system latency, updating the label with the measured delay.
+
+## Settings
+
+### Settings Tab
+
+* **Start Freq / End Freq (Hz)**: Sets the frequency boundaries for the sweep.
+* **Duration (s)**: The time it takes to complete a single sweep.
+* **Amplitude (dBFS)**: The output signal level.
+* **Max Harmonic**: The highest harmonic order to analyze alongside the fundamental.
+* **Averages**: The number of sweep cycles to average, improving SNR.
+
+### Routing Tab
+
+* **Output Ch**: Selects which channel to output the sweep signal (Left, Right, or Stereo).
+* **Input Mode**: Configures the input reference and measurement channels.
+    * **Single Ch (Left / Right Input)**: Simple single-channel measurement.
+    * **2-Ch Relative (Ref=Left, Meas=Right / Ref=Right, Meas=Left)**: Dual-channel Transfer Function (XFER) mode.
+
+### Advanced Tab
+
+* **Analysis Cycles**: Number of cycles per frequency bin for the digital lock-in analysis.
+* **Meas Points**: Total number of frequency points measured in the sweep.
+* **Prevent Buffer Underrun**: When enabled, automatically pauses data processing during high CPU load to avoid audio dropouts.
+* **Asynchronous Calculation**: Runs the heavy SSS math in a background thread to keep the UI responsive.

--- a/docs/widgets/realtime_sss_analyzer.md
+++ b/docs/widgets/realtime_sss_analyzer.md
@@ -1,0 +1,39 @@
+# Realtime SSS Lockin Analyzer
+
+## 概要
+
+Realtime SSS Lockin Analyzerは、Synchronized Swept Sine (SSS) 信号とデジタルロックイン方式を使用して、リアルタイムに周波数特性と歪みのスイープ測定を行うツールです。指定した周波数範囲での振幅特性と位相特性、さらに高調波の追跡が可能です。
+
+## 操作方法
+
+### 測定の開始と停止
+
+* **Start Sweep / Stop Sweep ボタン**: SSS測定スイープを開始および停止します。測定中は進捗が表示され、完了時は非同期処理が終わるまで一時的にボタンが無効になります。
+
+### レイテンシのキャリブレーション
+
+* **Calibrate Latency**: スイープを実行する前（特に2ch相対測定モード時）に、入出力のタイミングを合わせることが重要です。このボタンを押すとテスト信号が送信され、システムのレイテンシ（遅延）を測定して補正し、ラベルに結果を表示します。
+
+## 設定項目
+
+### Settings タブ
+
+* **Start Freq / End Freq (Hz)**: スイープの開始および終了周波数を設定します。
+* **Duration (s)**: 1回のスイープにかかる時間を設定します。
+* **Amplitude (dBFS)**: 出力信号のレベルを設定します。
+* **Max Harmonic**: 基本波と同時に解析する最大高調波の次数を設定します。
+* **Averages**: スイープのアベレージング（平均化）回数を設定します。増やすとSNRが向上します。
+
+### Routing タブ
+
+* **Output Ch**: スイープ信号を出力するチャンネル（Left、Right、またはStereo）を選択します。
+* **Input Mode**: 入力のリファレンス（基準）と測定チャンネルを設定します。
+    * **Single Ch (Left / Right Input)**: 単一チャンネルでの測定です。
+    * **2-Ch Relative (Ref=Left, Meas=Right / Ref=Right, Meas=Left)**: 2チャンネルを使用した伝達特性（XFER）モードです。
+
+### Advanced タブ
+
+* **Analysis Cycles**: デジタルロックイン解析において、各周波数ビンで解析するサイクル数を設定します。
+* **Meas Points**: スイープ全体で測定する周波数ポイントの総数を設定します。
+* **Prevent Buffer Underrun**: 有効にすると、CPU負荷が高い場合にデータ処理を一時停止し、音声の途切れ（バッファアンダーラン）を防ぎます。
+* **Asynchronous Calculation**: 重いSSS計算をバックグラウンドのスレッドで実行し、UIの応答性を保ちます。


### PR DESCRIPTION
Added missing Japanese and English documentation for the recently added `RealtimeSSSAnalyzerWidget`. This fulfills the daily documentation check task to ensure UI widgets have corresponding accurate documentation.

---
*PR created automatically by Jules for task [14782776245462907276](https://jules.google.com/task/14782776245462907276) started by @youtube-at-vach*