### PR TITLE
docs: Standardize Coffee Break section headers

### DIFF
--- a/docs/widgets/advanced_distortion_meter.en.md
+++ b/docs/widgets/advanced_distortion_meter.en.md
@@ -9,7 +9,7 @@ Instead of a single pure tone, it uses simultaneous multiple tones or specific c
 
 It is suitable for searching for the cause of phenomena such as "having good numbers in standard THD measurement, but the sound is muddy when actually listening."
 
-## ☕ Coffee Break: Why test with \"Complex Sounds\"?
+## ☕ Coffee Break: Why test with "Complex Sounds"?
 
 While audio equipment is often measured using a single pure sine wave, actual music contains many simultaneous frequencies.
 When multiple frequencies pass through an amplifier simultaneously, they can interfere with each other and generate new, unwanted frequencies (intermodulation distortion).


### PR DESCRIPTION
This PR standardizes the formatting of all "Coffee Break" section headers across the `docs/` documentation.

**1 PR = 1 Theme:**
* This PR focuses entirely on standardizing the "Coffee Break" headers according to the memory rules (`## ☕ コーヒーブレイク：` for Japanese, `## ☕ Coffee Break: ` for English).

**Specific Changes:**
* It fixes a specific typo in `docs/widgets/advanced_distortion_meter.en.md` where double quotes were mistakenly escaped (`\"Complex Sounds\"`), causing rendering issues.
* The script confirms there are no more than one Coffee Break section per page, and verifies that the sections remain under the 6-line constraint.

Tests and linters pass cleanly.

---
*PR created automatically by Jules for task [6260645409101508062](https://jules.google.com/task/6260645409101508062) started by @youtube-at-vach*