### PR TITLE
docs: update realtime sss analyzer documentation

### DIFF
--- a/docs/widgets/realtime_sss_analyzer.en.md
+++ b/docs/widgets/realtime_sss_analyzer.en.md
@@ -35,6 +35,10 @@ The Realtime SSS Lockin Analyzer performs real-time frequency response and disto
 
 * **Analysis Cycles**: Number of cycles per frequency bin for the digital lock-in analysis (up to 512.0 cycles).
 * **Meas Points**: Total number of frequency points measured in the sweep.
+* **Min Window**: Sets the minimum window time (in ms) for digital lock-in analysis, which sets a lower bound on ENBW resolution.
+* **Resolution (ENBW)**: Displays the Equivalent Noise Bandwidth (ENBW) resolution in Hz based on the analysis window size in real-time.
+* **Meas Mode**: Select between Standard Sweep and Hammerstein model measurement mode.
+* **Amp Steps**: Defines the number of amplitude steps (e.g., 5) when using Hammerstein measurement mode.
 * **Prevent Buffer Underrun**: When enabled, automatically pauses data processing during high CPU load to avoid audio dropouts.
 * **Asynchronous Calculation**: Runs the heavy SSS math in a background thread to keep the UI responsive.
 * **Unwrap Phase**: Toggles phase unwrapping for phase plots. When enabled, phase transitions over ±180 degrees are smoothed out into a continuous curve.

--- a/docs/widgets/realtime_sss_analyzer.md
+++ b/docs/widgets/realtime_sss_analyzer.md
@@ -35,6 +35,10 @@ Realtime SSS Lockin Analyzerは、Synchronized Swept Sine (SSS) 信号とデジ�
 
 * **Analysis Cycles**: デジタルロックイン解析において、各周波数ビンで解析するサイクル数を設定します（最大512.0サイクル）。
 * **Meas Points**: スイープ全体で測定する周波数ポイントの総数を設定します。
+* **Min Window**: デジタルロックイン解析における最小ウィンドウ時間（ms）を設定し、ENBW解像度の下限を制限します。
+* **Resolution (ENBW)**: 解析ウィンドウサイズに基づくENBW（等価ノイズ帯域幅）の解像度をHz単位でリアルタイムに表示します。
+* **Meas Mode**: 通常のスイープ測定とHammersteinモデル測定モードを切り替えます。
+* **Amp Steps**: Hammerstein測定モードでの振幅のステップ数（例：5）を設定します。
 * **Prevent Buffer Underrun**: 有効にすると、CPU負荷が高い場合にデータ処理を一時停止し、音声の途切れ（バッファアンダーラン）を防ぎます。
 * **Asynchronous Calculation**: 重いSSS計算をバックグラウンドのスレッドで実行し、UIの応答性を保ちます。
 * **Unwrap Phase**: 位相プロットのアンラップ（折り返し解除）を切り替えます。有効にすると、±180度を超える位相の変化が連続的な曲線として滑らかに表示されます。


### PR DESCRIPTION
Updates the markdown documentation for the Realtime SSS Analyzer widget to include recently added UI parameters for Hammerstein model measurement and real-time ENBW resolution calculation.

- Synchronized `docs/widgets/realtime_sss_analyzer.md` and `docs/widgets/realtime_sss_analyzer.en.md`.
- No code logic changes were made.

---
*PR created automatically by Jules for task [2066514002115321333](https://jules.google.com/task/2066514002115321333) started by @youtube-at-vach*