### PR TITLE
Fix IndexError in Realtime SSS Analyzer continuous sweeps

### DIFF
--- a/src/gui/widgets/realtime_sss_analyzer.py
+++ b/src/gui/widgets/realtime_sss_analyzer.py
@@ -754,14 +754,15 @@ class RealtimeSSSAnalyzerWidget(QWidget):
             self.plot_freqs_array = np.zeros(self.max_blocks)
             self.current_analysis_freq = None
 
+            self.H_freqs = []
+            self.kernels_time = []
+            self.time_ms = []
+
             if self.is_hammerstein_mode:
                 self.raw_responses = np.zeros(
                     (self.num_amplitudes, self.max_blocks, self.module.max_harmonic), dtype=complex
                 )
                 self.raw_counts = np.zeros((self.num_amplitudes, self.max_blocks), dtype=int)
-                self.H_freqs = []
-                self.kernels_time = []
-                self.time_ms = []
 
             # Spawn calculation thread (always asynchronous)
             self.calc_thread = SSSCalculationThread(


### PR DESCRIPTION
Fixes an `IndexError` in the Real-time SSS analyzer where it crashes during continuous measurement sweeps or mode switches (e.g., from hammerstein to standard sweep). Stale data from previous sweeps (with potentially different max block sizes) was left in `self.H_freqs`, leading to an array bounds violation when drawing plots.

**Changes:**
- Extracted the clearing of `H_freqs`, `kernels_time`, and `time_ms` to be unconditionally executed at the beginning of `start_analysis()`, instead of only within `is_hammerstein_mode`.

---
*PR created automatically by Jules for task [13339808125266948439](https://jules.google.com/task/13339808125266948439) started by @youtube-at-vach*