### PR TITLE
Fix phase unwrap distortion and index bounds in Realtime SSS Analyzer

### DIFF
--- a/src/gui/widgets/realtime_sss_analyzer.py
+++ b/src/gui/widgets/realtime_sss_analyzer.py
@@ -1118,7 +1118,7 @@ class RealtimeSSSAnalyzerWidget(QWidget):
             # 2. Scale responses by amplitude and apply phase correction
             # To compensate for sine expansion phase offsets:
             # H1: 1.0, H2: 1j, H3: -1.0, H4: -1j, H5: 1.0
-            phase_corrections = [1.0, 1j, -1.0, -1j, 1.0]
+            phase_corrections = [(1j) ** p for p in range(P)]
             R_array = self.amplitudes
             g_scaled = np.zeros_like(avg_responses)
             for amp_idx in range(self.num_amplitudes):
@@ -1185,7 +1185,7 @@ class RealtimeSSSAnalyzerWidget(QWidget):
             # Directly use accumulated_results and apply phase corrections
             valid_indices = np.where(self.block_counts > 0)[0]
             self.H_freqs = []
-            phase_corrections = [1.0, 1j, -1.0, -1j, 1.0]
+            phase_corrections = [(1j) ** p for p in range(P)]
             for p in range(P):
                 H_p = np.zeros(max_blocks, dtype=complex)
                 if len(valid_indices) > 0:
@@ -1268,7 +1268,10 @@ class RealtimeSSSAnalyzerWidget(QWidget):
             H_p_clean[mask_nan] = 0.0
 
             mags = np.abs(H_p_clean)
-            phases = np.unwrap(np.angle(H_p_clean))
+            valid_mask = ~mask_nan
+            phases = np.zeros_like(H_p_clean, dtype=float)
+            if np.any(valid_mask):
+                phases[valid_mask] = np.unwrap(np.angle(H_p_clean[valid_mask]))
             mag_lin = np.interp(freqs_lin, sorted_freqs, mags, left=0.0, right=0.0)
             phase_lin = np.interp(freqs_lin, sorted_freqs, phases, left=0.0, right=0.0)
             H_lin = mag_lin * np.exp(1j * phase_lin)


### PR DESCRIPTION
### 🎯 What:
Fixed two critical bugs in the `RealtimeSSSAnalyzerWidget` that caused runtime crashes and silent data corruption:
1. **Hardcoded Phase Extrapolation:** An `IndexError` occurred when analyzing with `max_harmonic` $> 5$ due to a hardcoded `phase_corrections` list.
2. **Phase Distortion via Padding:** A bug in frequency mapping caused the phase `np.unwrap` function to operate across $0.0$ padded NaN regions, severely distorting the reconstructed continuous phase trajectories.

### ⚠️ Risk:
- Using a high harmonic order (e.g. 6 or more) caused the application GUI loop to instantly crash and halt calculation.
- Applying `np.unwrap` to $0.0$ phase points corrupted the phase relationships for any mapped frequencies that encountered a gap. This resulted in fundamentally flawed impulse response (kernel) reconstructions and exported models.

### 🛡️ Solution:
- Replaced the hardcoded phase array with a robust mathematical expansion: `[(1j) ** p for p in range(P)]`.
- Refactored the phase unwrap step to isolate valid points using a boolean mask `valid_mask = ~mask_nan`, applying `np.unwrap` strictly over the continuous valid phase sequence before injecting the $0.0$ bounds back for the Inverse FFT.

---
*PR created automatically by Jules for task [7139617234172065603](https://jules.google.com/task/7139617234172065603) started by @youtube-at-vach*