### PR TITLE
🧪 [Add test coverage for multitone TDN with 3+ tones]

### DIFF
--- a/tests/logic_verification/analysis/test_multitone_tdn.py
+++ b/tests/logic_verification/analysis/test_multitone_tdn.py
@@ -54,6 +54,27 @@ class TestMultitoneTDN(unittest.TestCase):
         expected_tdn = np.sqrt(0.01 / 2.0)
         self.assertAlmostEqual(result["tdn"], expected_tdn * 100, places=4)
 
+    def test_calculate_multitone_tdn_three_or_more_tones(self):
+        """
+        Test with 3 or more tones to cover the specific branching logic
+        for calculating max_widths for intermediate tones.
+        """
+        self.mag[200] = 1.0
+        self.mag[500] = 1.0
+        self.mag[800] = 1.0
+
+        # Noise at 350 Hz
+        self.mag[350] = 0.1
+
+        # Tone energy = 1^2 + 1^2 + 1^2 = 3.0
+        # Noise energy = 0.1^2 = 0.01
+        # TDN = sqrt(0.01 / 3.0)
+
+        result = AudioCalc.calculate_multitone_tdn(self.mag, self.freqs, [200, 500, 800])
+
+        expected_tdn = np.sqrt(0.01 / 3.0)
+        self.assertAlmostEqual(result["tdn"], expected_tdn * 100, places=4)
+
     def test_calculate_multitone_tdn_no_noise(self):
         """
         Test with only tones (perfect signal).


### PR DESCRIPTION
🎯 **What:** The `calculate_multitone_tdn` function had a testing gap where the specific logic block that restricts the frequency search width for intermediate tones (when 3 or more tones are present) was never executed in tests.
📊 **Coverage:** A new test `test_calculate_multitone_tdn_three_or_more_tones` was added to cover this scenario by providing 3 tone frequencies and calculating their expected TD+N.
✨ **Result:** Test coverage for `src/core/analysis.py` increased, specifically fully covering the `if len(tone_freqs_arr) > 2:` block (line 1148), improving code reliability for multitone analysis.

---
*PR created automatically by Jules for task [9285337284094348874](https://jules.google.com/task/9285337284094348874) started by @youtube-at-vach*