### PR TITLE
🧹 Remove deprecated `calculate_chebyshev_matrix` method

### DIFF
--- a/src/core/nonlinear_analyzer_core.py
+++ b/src/core/nonlinear_analyzer_core.py
@@ -191,18 +191,6 @@ def deconvolve_signal(recorded_signal, sss_signal, regularization=1e-4):
     return g
 
 
-def calculate_chebyshev_matrix(num_amplitudes, norm_v, P=5):
-    """
-    Deprecated/Legacy compatibility method.
-    Previously constructed separation matrix M and computed its pseudo-inverse M_pinv.
-    Now we implement Chebyshev transform directly using algebraic equations.
-    """
-    norm_v_arr = np.asarray(norm_v)
-    M = norm_v_arr[:, np.newaxis] ** np.arange(1, P + 1)
-    M_pinv = np.linalg.pinv(M)
-    return M, M_pinv
-
-
 def process_amplitude_responses(
     responses_meas,
     responses_ref,


### PR DESCRIPTION
🎯 **What:** Removed the unused and deprecated `calculate_chebyshev_matrix` method from `src/core/nonlinear_analyzer_core.py`.
💡 **Why:** This legacy compatibility method was clearly documented as obsolete, and an exhaustive search confirmed it is no longer referenced anywhere in the codebase or test suite. Removing it reduces technical debt and improves overall file maintainability.
✅ **Verification:** Ran a full test suite with `pytest` locally and verified that tests pass. Pre-commit tools (`ruff check --fix` and `ruff format`) were also executed ensuring formatting rules were met. Code review verified that removing this dead code is a safe operation. 
✨ **Result:** A cleaner `nonlinear_analyzer_core.py` module devoid of unneeded, legacy algebraic fallback structures.

---
*PR created automatically by Jules for task [6101788265217308575](https://jules.google.com/task/6101788265217308575) started by @youtube-at-vach*