### PR TITLE
📝 [Docs] Update Lock-in Modeler documentation for new features

### DIFF
--- a/docs/widgets/lock_in_modeler.en.md
+++ b/docs/widgets/lock_in_modeler.en.md
@@ -43,3 +43,5 @@ The Lock-in Modeler performs real-time frequency response and distortion sweeps 
 * **Asynchronous Calculation**: Runs the heavy SSS math in a background thread to keep the UI responsive.
 * **Unwrap Phase**: Toggles phase unwrapping for phase plots. When enabled, phase transitions over ±180 degrees are smoothed out into a continuous curve.
 * **Relative to Fundamental**: When enabled, the magnitude and phase of the harmonics are plotted relative to the fundamental frequency response, rather than as absolute values.
+* **Show Raw Lock-in (Unprocessed)**: When enabled, displays the raw, unprocessed data points from the lock-in amplifier before any smoothing or interpolation is applied.
+* **Graph Smoothing**: Provides options (e.g., None, Low Smoothing, Medium Smoothing, High Smoothing) to apply smoothing to the plotted measurement curves for easier reading of the data trends.

--- a/docs/widgets/lock_in_modeler.md
+++ b/docs/widgets/lock_in_modeler.md
@@ -43,3 +43,5 @@ Lock-in Modelerは、Synchronized Swept Sine (SSS) 信号とデジタルロッ�
 * **Asynchronous Calculation**: 重いSSS計算をバックグラウンドのスレッドで実行し、UIの応答性を保ちます。
 * **Unwrap Phase**: 位相プロットのアンラップ（折り返し解除）を切り替えます。有効にすると、±180度を超える位相の変化が連続的な曲線として滑らかに表示されます。
 * **Relative to Fundamental**: 有効にすると、高調波の振幅と位相が絶対値ではなく、基本波の周波数特性に対する相対値としてプロットされます。
+* **Show Raw Lock-in (Unprocessed)**: 有効にすると、スムージングや補間が適用される前の、ロックインアンプからの生の未処理データポイントを表示します。
+* **Graph Smoothing**: 測定曲線をプロットする際にスムージング（例：None, Low Smoothing, Medium Smoothing, High Smoothing）を適用し、データの傾向を読み取りやすくするオプションを提供します。


### PR DESCRIPTION
**What:**
Added missing documentation for the "Show Raw Lock-in (Unprocessed)" and "Graph Smoothing" features in the Lock-in Modeler widget for both English and Japanese markdown files.

**Why:**
This is part of the daily 24-hour maintenance task to ensure documentation consistency (Task B). The translation checks (Task A) passed without issues, so the task progressed to syncing the documentation with the new features added in recent commits (`20d077dd`).

**Verification:**
1. Verified markdown syntax via `npx markdownlint-cli2`.
2. Passed the full project UI test suite (`pytest`) in a headless PyQt6 environment (`QT_QPA_PLATFORM=offscreen`).
3. Confirmed no widget code was modified, strictly adhering to the constraint to only edit documentation.

---
*PR created automatically by Jules for task [14545872917767648036](https://jules.google.com/task/14545872917767648036) started by @youtube-at-vach*