### PR TITLE
fix: resolve scalloping loss in distortion analyzer and lock-in modeler race

### DIFF
--- a/src/core/analysis.py
+++ b/src/core/analysis.py
@@ -865,8 +865,8 @@ class AudioCalc:
                 p = 0.5 * (alpha - gamma) / denom
                 p = np.clip(p, -0.5, 0.5)
                 max_freq = freqs[peak_idx] + p * (freqs[1] - freqs[0])
-                # Optional: Refine amplitude estimate
-                # max_amplitude = beta - 0.25 * (alpha - gamma) * p
+                # Refine amplitude estimate to correct scalloping loss
+                max_amplitude = beta - 0.25 * (alpha - gamma) * p
 
         return max_freq, max_amplitude
 
@@ -899,6 +899,20 @@ class AudioCalc:
             if is_valid:
                 h_peak_idx = h_min + amplitude_spectrum[h_min:h_max].argmax()
                 h_amp = amplitude_spectrum[h_peak_idx]
+                h_freq_refined = freqs[h_peak_idx]
+
+                # Parabolic Interpolation to refine frequency and amplitude (correcting scalloping loss)
+                if 0 < h_peak_idx < len(amplitude_spectrum) - 1:
+                    alpha = amplitude_spectrum[h_peak_idx - 1]
+                    beta = amplitude_spectrum[h_peak_idx]
+                    gamma = amplitude_spectrum[h_peak_idx + 1]
+
+                    denom = alpha - 2 * beta + gamma
+                    if denom != 0:
+                        p = 0.5 * (alpha - gamma) / denom
+                        p = np.clip(p, -0.5, 0.5)
+                        h_freq_refined = freqs[h_peak_idx] + p * (freqs[1] - freqs[0])
+                        h_amp = beta - 0.25 * (alpha - gamma) * p
 
                 relative_amp = h_amp / max_amplitude if max_amplitude > 0 else 0
                 amp_db = 20 * np.log10(relative_amp + 1e-12)
@@ -906,7 +920,7 @@ class AudioCalc:
                 harmonic_results.append(
                     {
                         "order": int(i),
-                        "frequency": float(freqs[h_peak_idx]),
+                        "frequency": float(h_freq_refined),
                         "amplitude_dbr": float(amp_db),
                         "amplitude_linear": float(h_amp),
                     }

--- a/src/gui/widgets/lock_in_modeler.py
+++ b/src/gui/widgets/lock_in_modeler.py
@@ -215,34 +215,33 @@ class LockInModeler(MeasurementModule):
                     outdata.fill(0)
                     return
 
-            if self.current_block_idx >= self.max_blocks:
-                with self.lock:
+                if self.current_block_idx >= self.max_blocks:
                     self.state = "WAITING"
-                outdata.fill(0)
-                return
+                    outdata.fill(0)
+                    return
 
-            # Extract target input channel
-            sig_in = np.zeros((frames, 1))
-            if indata.shape[1] > sig_ch:
-                sig_in[:, 0] = indata[:, sig_ch]
-            elif indata.shape[1] > 0:
-                sig_in[:, 0] = indata[:, 0]
-
-            # Extract reference input channel if in XFER mode
-            ref_in = None
-            if input_mode == "XFER":
-                ref_in = np.zeros((frames, 1))
-                if indata.shape[1] > ref_ch:
-                    ref_in[:, 0] = indata[:, ref_ch]
+                # Extract target input channel
+                sig_in = np.zeros((frames, 1))
+                if indata.shape[1] > sig_ch:
+                    sig_in[:, 0] = indata[:, sig_ch]
                 elif indata.shape[1] > 0:
-                    ref_in[:, 0] = indata[:, 0]
+                    sig_in[:, 0] = indata[:, 0]
 
-            # 1. Output Generation (Lightweight)
-            self.engine.generate_output_block(outdata, self.current_block_idx)
-            # 2. Add raw data to background processing queue
-            self.input_queue.put((self.current_block_idx, self.current_sweep_idx, sig_in, ref_in, self.max_blocks))
+                # Extract reference input channel if in XFER mode
+                ref_in = None
+                if input_mode == "XFER":
+                    ref_in = np.zeros((frames, 1))
+                    if indata.shape[1] > ref_ch:
+                        ref_in[:, 0] = indata[:, ref_ch]
+                    elif indata.shape[1] > 0:
+                        ref_in[:, 0] = indata[:, 0]
 
-            self.current_block_idx += 1
+                # 1. Output Generation (Lightweight)
+                self.engine.generate_output_block(outdata, self.current_block_idx)
+                # 2. Add raw data to background processing queue
+                self.input_queue.put((self.current_block_idx, self.current_sweep_idx, sig_in, ref_in, self.max_blocks))
+
+                self.current_block_idx += 1
 
         self.callback_id = self.audio_engine.register_callback(callback)
 


### PR DESCRIPTION
## Description
This PR resolves two silent bugs identified during the QA audit:
1. **Scalloping Loss in Distortion Analysis**:
   - Enables parabolic amplitude refinement in `AudioCalc._analyze_fundamental` (uncommented the calculation).
   - Introduces parabolic interpolation refinement for the detected peak bin of each harmonic in `AudioCalc._analyze_harmonics_list`.
   - This eliminates window scalloping loss (up to 1.4 dB attenuation), ensuring mathematically accurate THD/THD+N distortion results.
2. **Race Condition in Lock-in Modeler**:
   - Wraps the real-time audio thread callback operations (`self.current_block_idx` checks/increments and queue operations) inside `with self.lock:`.
   - This resolves a critical race condition with the UI thread's `on_sweep_finished` method that resets the index, preventing potential sweep halts or index corruption.

## Verification
- Passed unit tests: `test_analyze_harmonics.py` and `test_distortion.py` (`16 passed in 2.50s`).
- Passed full test suite: `./.venv/bin/pytest -q` (`976 passed in 70.70s`).
- Passed UI size constraints check: `check_ui_size_limits.py` (`Verification Passed!`).