### PR TITLE
docs: update lock-in modeler docs with REF Phase Lock Only feature

### DIFF
--- a/docs/widgets/lock_in_modeler.en.md
+++ b/docs/widgets/lock_in_modeler.en.md
@@ -65,6 +65,7 @@ Before running any sweep, the round-trip latency of the audio input and output c
     * `Single Ch (Right Input)`: Absolute measurement using the right input channel only.
     * `2-Ch Relative (Ref=Left, Meas=Right)`: Dual-channel Transfer Function (XFER) mode. Measures the ratio between the left channel (reference) and right channel (measurement). This cancels out systemic response variations and nonlinearity in the test gear.
     * `2-Ch Relative (Ref=Right, Meas=Left)`: Dual-channel Transfer Function mode with the right channel as reference and the left as measurement.
+* **REF Phase Lock Only (Absolute)**: Available only in 2-Ch Relative modes. When enabled, the reference channel is used strictly for phase synchronization (correcting time delays/phase drift), while the magnitude response is calculated as an absolute measurement of the measurement channel rather than a relative ratio.
 
 ### Advanced Tab
 

--- a/docs/widgets/lock_in_modeler.md
+++ b/docs/widgets/lock_in_modeler.md
@@ -65,6 +65,7 @@ Lock-in Modelerは、同期スイープサイン (Synchronized Swept Sine, SSS) 
     * `Single Ch (Right Input)`: 右入力チャンネルのみを使用して絶対測定を行います。
     * `2-Ch Relative (Ref=Left, Meas=Right)`: 左を入出力監視用のリファレンス、右を測定用として、2チャンネルの比（伝達関数 $H(f)$）を測定します。システム自体の非線形歪みや周波数特性のうねりを相殺できます。
     * `2-Ch Relative (Ref=Right, Meas=Left)`: 右をリファレンス、左を測定用とする伝達関数測定モードです。
+* **REF Phase Lock Only (Absolute) (REF位相同期のみ)**: 2-Ch Relativeモード時のみ有効です。これを有効にすると、リファレンスチャンネルは位相の同期（時間遅れや位相ドリフトの補正）にのみ使用され、振幅特性については相対比ではなく測定チャンネルの絶対レベルとして算出されます。
 
 ### Advanced（詳細設定）タブ
 


### PR DESCRIPTION
This PR updates the lock-in modeler documentation to include the new `REF Phase Lock Only (Absolute)` feature added to the widget in a recent commit. The documentation is updated in both English and Japanese to maintain consistency. The translation check was also run and no missing translations were found.

---
*PR created automatically by Jules for task [8183823187340438360](https://jules.google.com/task/8183823187340438360) started by @youtube-at-vach*