### PR TITLE
🧪 [Add test for set_audio_engine_64bit]

### DIFF
--- a/tests/logic_verification/core/test_config_manager.py
+++ b/tests/logic_verification/core/test_config_manager.py
@@ -115,6 +115,18 @@ class TestConfigManager(unittest.TestCase):
         cm.set_dithering_bit_depth("24")
         self.assertEqual(cm.get_dithering_bit_depth(), "24")
 
+
+    def test_audio_engine_64bit(self):
+        cm = self.ConfigManager(config_filename=self.config_path)
+
+        self.assertFalse(cm.is_audio_engine_64bit())
+        cm.set_audio_engine_64bit(True)
+        self.assertTrue(cm.is_audio_engine_64bit())
+
+        cm.config.pop("audio", None)
+        cm.set_audio_engine_64bit(False)
+        self.assertFalse(cm.is_audio_engine_64bit())
+
     def test_coreaudio_conversion_quality(self):
         cm = self.ConfigManager(config_filename=self.config_path)
 


### PR DESCRIPTION
🎯 **What:** The untested public method `ConfigManager.set_audio_engine_64bit` (and `is_audio_engine_64bit`) lacked test coverage.
📊 **Coverage:** A new test `test_audio_engine_64bit` has been added to `tests/logic_verification/core/test_config_manager.py` that verifies enabling/disabling the 64-bit engine and explicitly checks the behavior when the 'audio' configuration key is missing.
✨ **Result:** Increased testing coverage and ensured regression safety for the 64-bit audio engine configuration logic.

---
*PR created automatically by Jules for task [17771047149206980703](https://jules.google.com/task/17771047149206980703) started by @youtube-at-vach*