### PR TITLE
🧪 [test] Add test coverage for JsonTraceExporter properties

### DIFF
--- a/tests/core/export/test_json_exporter.py
+++ b/tests/core/export/test_json_exporter.py
@@ -49,3 +49,13 @@ def test_export_traces_success():
     assert parsed_json["traces"][0]["id"] == "test_1"
     assert parsed_json["traces"][0]["x_data"] == [0.0, 1.0, 2.0]
     assert parsed_json["traces"][0]["y_data"] == [1.0, 2.0, 3.0]
+
+def test_format_id():
+    exporter = JsonTraceExporter()
+    assert exporter.format_id == "json"
+
+def test_properties():
+    exporter = JsonTraceExporter()
+    assert exporter.name == "MeasureLab Comparison Files (*.mlcomp)"
+    assert exporter.file_filter == "MeasureLab Comparison Files (*.mlcomp *.json)"
+    assert exporter.default_extension == ".mlcomp"


### PR DESCRIPTION
🎯 **What:** The `JsonTraceExporter` class had an untested public property `format_id`. Added test coverage for this property, as well as the other properties: `name`, `file_filter`, and `default_extension`.
📊 **Coverage:** The tests now fully verify the expected strings for all public properties of `JsonTraceExporter` in `tests/core/export/test_json_exporter.py`.
✨ **Result:** Improved test coverage for the JSON exporter module, ensuring property values are correctly set and preventing accidental changes in the future.

---
*PR created automatically by Jules for task [11594267085953455857](https://jules.google.com/task/11594267085953455857) started by @youtube-at-vach*