### PR TITLE
🧪 [Add test for JsonTraceExporter.default_extension]

### DIFF
--- a/tests/core/export/test_json_exporter.py
+++ b/tests/core/export/test_json_exporter.py
@@ -49,3 +49,7 @@ def test_export_traces_success():
     assert parsed_json["traces"][0]["id"] == "test_1"
     assert parsed_json["traces"][0]["x_data"] == [0.0, 1.0, 2.0]
     assert parsed_json["traces"][0]["y_data"] == [1.0, 2.0, 3.0]
+
+def test_default_extension():
+    exporter = JsonTraceExporter()
+    assert exporter.default_extension == ".mlcomp"


### PR DESCRIPTION
🎯 **What:** Added a missing unit test for the `default_extension` property of the `JsonTraceExporter` class in `tests/core/export/test_json_exporter.py` which was completely untested previously.

📊 **Coverage:** The new test initializes `JsonTraceExporter` and asserts that the `default_extension` property correctly returns the `.mlcomp` extension string.

✨ **Result:** Test coverage for `src/core/export/json_exporter.py` is improved, ensuring the `default_extension` behaves as expected and catching potential future regressions.

---
*PR created automatically by Jules for task [11548668321160222971](https://jules.google.com/task/11548668321160222971) started by @youtube-at-vach*