### PR TITLE
🧪 [Add tests for ConfigManager.get_app_root_dir]

### DIFF
--- a/tests/logic_verification/core/test_config_manager.py
+++ b/tests/logic_verification/core/test_config_manager.py
@@ -212,5 +212,12 @@ class TestConfigManager(unittest.TestCase):
                     )
 
 
+    def test_get_app_root_dir(self):
+        with patch("sys.frozen", True, create=True), patch("sys.executable", "/fake/path/to/app.exe"):
+            self.assertEqual(self.ConfigManager.get_app_root_dir(), "/fake/path/to")
+
+        with patch("sys.frozen", False, create=True), patch("src.core.config_manager.os.path.abspath", return_value="/fake/project/src/core/config_manager.py"):
+            self.assertEqual(self.ConfigManager.get_app_root_dir(), "/fake/project")
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
🎯 **What:** The testing gap for the `ConfigManager.get_app_root_dir` method (which handles the logic of running from PyInstaller frozen vs normal run) in `src/core/config_manager.py` was addressed.
📊 **Coverage:** The new tests cover scenarios where `sys.frozen` is True and False, mocking the respective file paths dynamically to ensure accurate returns.
✨ **Result:** Test suite coverage has been improved to protect `get_app_root_dir` logic from undetected breakages in regressions.

---
*PR created automatically by Jules for task [7206574692037481557](https://jules.google.com/task/7206574692037481557) started by @youtube-at-vach*