### PR TITLE
📝 [Docs] Translate new strings and update lock-in modeler docs

### DIFF
--- a/docs/widgets/lock_in_modeler.en.md
+++ b/docs/widgets/lock_in_modeler.en.md
@@ -31,9 +31,9 @@ Before running any sweep, the round-trip latency of the audio input and output c
 
 * **Sweep Mode**: Choose between three measurement modes:
     * `Sweep Measurement (Default)`: Performs a standard frequency sweep, plotting the magnitude and phase responses for the fundamental and configured harmonics.
-    * `Nonlinear Model`: Identifies a Hammerstein nonlinear model by automatically performing multiple sweeps at different test amplitude levels to resolve higher-order kernels.
-    * `Predistortion Sweep`: Performs iterative sweeps while applying a predistortion signal (using an Inverse Hammerstein model) to actively cancel the nonlinear distortion of the system under test.
-* **Start Freq / End Freq (Hz)**: Sets the frequency boundaries for the sweep (20.0 Hz to 20,000.0 Hz).
+    * `Nonlinear Model (Forward)`: Identifies a Hammerstein nonlinear model by automatically performing multiple sweeps at different test amplitude levels to resolve higher-order kernels using a standard forward model.
+    * `Nonlinear Model (Parallel Complex)`: Identifies a Hammerstein nonlinear model using a Parallel Complex Hammerstein structure, capable of capturing more intricate nonlinear behaviors.
+* **Start Freq / End Freq (Hz)**: Sets the frequency boundaries for the sweep (2.0 Hz up to the Nyquist frequency).
 * **Duration (s)**: The duration of a single sweep cycle (2.0 s to 600.0 s).
 * **Amplitude (dBFS)**: Sets the output signal level in dBFS (-100.0 dBFS to 0.0 dBFS).
 * **Max Harmonic**: Sets the highest harmonic order to analyze alongside the fundamental (1st to 5th).
@@ -46,15 +46,13 @@ Before running any sweep, the round-trip latency of the audio input and output c
     * **Time-Synchronized Averaging (TSA)**:
         * **Cycles**: Number of cycles to average (1-100).
         * **Rejection Threshold**: Standard deviation threshold for outlier rejection.
-    * **Predistortion Settings**:
-        * **Predistortion Iters**: The number of iterative updates (1-10) per amplitude level to refine the inverse distortion filter.
-        * **Learning Rate (mu)**: The step size (0.01 - 1.0) for the predistortion update algorithm. Smaller values increase stability but require more iterations.
 
 ### Display Tab
 
 * **Show Relative to Fundamental**: When enabled, the magnitude and phase of the harmonics are plotted relative to the fundamental frequency response (in dB / degrees) rather than as absolute values.
 * **Unwrap Phase**: When enabled, phase transitions over $\pm 180$ degrees are smoothed out into a continuous curve instead of wrapping.
 * **Show Raw Lock-in (Unprocessed)**: When enabled, displays the raw, unprocessed data points from the lock-in amplifier before any smoothing or interpolation is applied (disabled in Hammerstein mode).
+* **Display Data**: In Hammerstein mode, selects whether to display the overall 'Model Kernels' or the individual response at specific test amplitudes.
 * **Graph Smoothing**: Selects the smoothing level (None, Low, Medium, or Heavy) for the plotted curves, applying a Savitzky-Golay filter.
 
 ### Routing Tab

--- a/docs/widgets/lock_in_modeler.md
+++ b/docs/widgets/lock_in_modeler.md
@@ -31,9 +31,9 @@ Lock-in Modelerは、同期スイープサイン (Synchronized Swept Sine, SSS) 
 
 * **Sweep Mode (スイープモード)**: 3つの測定モードから選択します。
     * `Sweep Measurement (Default)`: 標準のスイープ測定を行い、基本波および設定された高調波の応答をプロットします。
-    * `Nonlinear Model`: ハマーシュタインモデル同定を行います。異なるテスト振幅レベルで自動的に複数回のスイープを実行し、高次カーネルを同定します。
-    * `Predistortion Sweep`: 事前歪み信号（Inverse Hammersteinモデル）を適用しながら反復スイープを行い、測定対象システムの非線形歪みを能動的にキャンセルします。
-* **Start Freq / End Freq (開始/終了周波数)**: スイープする周波数の範囲を 20.0 Hz から 20,000.0 Hz の間で指定します。
+    * `Nonlinear Model (Forward)`: 標準のフォワードモデルを使用し、異なるテスト振幅レベルで自動的に複数回のスイープを実行して高次カーネルを同定します。
+    * `Nonlinear Model (Parallel Complex)`: 複雑な非線形挙動を捉えることができる、並列複素ハマーシュタイン構造（Parallel Complex Hammerstein structure）を用いて非線形モデルを同定します。
+* **Start Freq / End Freq (開始/終了周波数)**: スイープする周波数の範囲を 2.0 Hz からナイキスト周波数（サンプリング周波数の半分）の間で指定します。
 * **Duration (スイープ時間)**: 1回のスイープ時間を秒単位（2.0 s 〜 600.0 s）で設定します。
 * **Amplitude (振幅)**: 出力信号のレベルを dBFS 単位（-100.0 dBFS 〜 0.0 dBFS）で設定します。
 * **Max Harmonic (最大高調波次数)**: 解析する最高高調波次数（1次〜5次）を設定します。
@@ -46,15 +46,13 @@ Lock-in Modelerは、同期スイープサイン (Synchronized Swept Sine, SSS) 
     * **Time-Synchronized Averaging (TSA)**:
         * **Cycles (サイクル数)**: 平均化するサイクル数（1〜100）。
         * **Rejection Threshold (棄却閾値)**: 外れ値を除外するための標準偏差の閾値。
-    * **Predistortion Settings (事前歪み設定)**:
-        * **Predistortion Iters (事前歪み反復回数)**: 各振幅レベルにおいて、逆歪みフィルタを精密化するための反復更新回数（1〜10）。
-        * **Learning Rate (mu) (学習率)**: 事前歪み更新アルゴリズムのステップサイズ（0.01〜1.0）。小さな値は安定性を高めますが、より多くの反復回数を必要とします。
 
 ### Display（表示設定）タブ
 
 * **Show Relative to Fundamental (基本波相対表示)**: 有効にすると、各高調波の振幅および位相が絶対値ではなく、基本波の応答に対する相対値（dB / 度）としてプロットされます。
 * **Unwrap Phase (位相アンラップ)**: 有効にすると、$\pm 180$ 度を超える位相の変化を折り返さずに連続的な曲線として滑らかにプロットします。
 * **Show Raw Lock-in (Unprocessed) (未処理データ表示)**: 有効にすると、平滑化や補間を適用する前の、ロックインアンプから得られた生の測定ブロックデータを表示します（ハマーシュタイン同定モード時は無効化されます）。
+* **Display Data (表示データ)**: ハマーシュタインモードにおいて、全体の「Model Kernels」を表示するか、特定のテスト振幅での個別の応答を表示するかを選択します。
 * **Graph Smoothing (グラフ平滑化)**: 描画するプロット曲線の平滑化レベルを選択します（None, Low, Medium, High）。内部で Savitzky-Golay フィルタが適用されます。
 
 ### Routing（ルーティング）タブ

--- a/src/assets/lang/es.json
+++ b/src/assets/lang/es.json
@@ -157,7 +157,7 @@
     "Amplitude Steps (Max Order 5):": "Pasos de amplitud (Orden máx. 5):",
     "Amplitude Steps:": "Pasos de amplitud:",
     "Amplitude Sweep": "Barrido de amplitud",
-    "Amplitude {0} ({1:.3f} V)": "Amplitude {0} ({1:.3f} V)",
+    "Amplitude {0} ({1:.3f} V)": "Amplitud {0} ({1:.3f} V)",
     "Amplitude:": "Amplitud:",
     "Analog Transmission": "Transmisión analógica",
     "Analysis Cycles:": "Ciclos de análisis:",

--- a/src/assets/lang/ja.json
+++ b/src/assets/lang/ja.json
@@ -157,7 +157,7 @@
     "Amplitude Steps (Max Order 5):": "測定音量ステップ数 (最大5次):",
     "Amplitude Steps:": "振幅ステップ数:",
     "Amplitude Sweep": "振幅スイープ",
-    "Amplitude {0} ({1:.3f} V)": "Amplitude {0} ({1:.3f} V)",
+    "Amplitude {0} ({1:.3f} V)": "振幅 {0} ({1:.3f} V)",
     "Amplitude:": "振幅:",
     "Analog Transmission": "アナログ伝送特性",
     "Analysis Cycles:": "解析サイクル数:",

--- a/src/assets/lang/ko.json
+++ b/src/assets/lang/ko.json
@@ -157,7 +157,7 @@
     "Amplitude Steps (Max Order 5):": "진폭 단계 (최대 차수 5):",
     "Amplitude Steps:": "진폭 단계:",
     "Amplitude Sweep": "진폭 스위프",
-    "Amplitude {0} ({1:.3f} V)": "Amplitude {0} ({1:.3f} V)",
+    "Amplitude {0} ({1:.3f} V)": "진폭 {0} ({1:.3f} V)",
     "Amplitude:": "진폭:",
     "Analog Transmission": "아날로그 전송",
     "Analysis Cycles:": "분석 사이클:",

--- a/src/assets/lang/ru.json
+++ b/src/assets/lang/ru.json
@@ -157,7 +157,7 @@
     "Amplitude Steps (Max Order 5):": "Шаги амплитуды (Макс. порядок 5):",
     "Amplitude Steps:": "Шаги амплитуды:",
     "Amplitude Sweep": "Развертка амплитуды",
-    "Amplitude {0} ({1:.3f} V)": "Amplitude {0} ({1:.3f} V)",
+    "Amplitude {0} ({1:.3f} V)": "Амплитуда {0} ({1:.3f} V)",
     "Amplitude:": "Амплитуда:",
     "Analog Transmission": "Аналоговая передача",
     "Analysis Cycles:": "Циклы анализа:",

--- a/src/assets/lang/zh.json
+++ b/src/assets/lang/zh.json
@@ -157,7 +157,7 @@
     "Amplitude Steps (Max Order 5):": "幅度步长 (最大阶数 5):",
     "Amplitude Steps:": "幅度步数:",
     "Amplitude Sweep": "幅度扫描",
-    "Amplitude {0} ({1:.3f} V)": "Amplitude {0} ({1:.3f} V)",
+    "Amplitude {0} ({1:.3f} V)": "振幅 {0} ({1:.3f} V)",
     "Amplitude:": "振幅:",
     "Analog Transmission": "模拟传输",
     "Analysis Cycles:": "分析周期:",


### PR DESCRIPTION
- Translated the new `Amplitude {0} ({1:.3f} V)` UI strings into 7 languages.
- Synchronized `docs/widgets/lock_in_modeler.en.md` and `docs/widgets/lock_in_modeler.md` to reflect recent codebase changes in the last 24 hours, specifically:
  - Removed outdated predistortion sweep documentation.
  - Added details on the new `Nonlinear Model (Parallel Complex)` sweep mode.
  - Added documentation for the new `Display Data` toggle (Model Kernels vs Amplitudes).
  - Updated frequency range documentation to reflect the new dynamic Nyquist limit.

---
*PR created automatically by Jules for task [9436459332739841964](https://jules.google.com/task/9436459332739841964) started by @youtube-at-vach*