### PR TITLE
🧪 [Add unit tests for ConfigManager.save_config]

### DIFF
--- a/tests/logic_verification/core/test_config_manager.py
+++ b/tests/logic_verification/core/test_config_manager.py
@@ -236,5 +236,41 @@ class TestConfigManager(unittest.TestCase):
         cm.set_dithering_enabled(False)
         self.assertFalse(cm.is_dithering_enabled())
 
+
+    def test_save_config(self):
+        cm = self.ConfigManager(config_filename=self.config_path)
+
+        # Test force_sync=True
+        with patch.object(cm, "shutdown") as mock_shutdown:
+            cm.save_config(force_sync=True)
+            mock_shutdown.assert_called_once()
+            self.assertIsNone(cm._save_timer)  # Unchanged
+
+        # Test force_sync=False with no existing timer
+        with patch("src.core.config_manager.threading.Timer") as mock_timer:
+            mock_timer_instance = MagicMock()
+            mock_timer.return_value = mock_timer_instance
+
+            cm.save_config(force_sync=False)
+
+            mock_timer.assert_called_once_with(1.0, cm._flush_config)
+            mock_timer_instance.start.assert_called_once()
+            self.assertEqual(cm._save_timer, mock_timer_instance)
+
+        # Test force_sync=False with existing timer
+        existing_timer = MagicMock()
+        cm._save_timer = existing_timer
+
+        with patch("src.core.config_manager.threading.Timer") as mock_timer:
+            new_timer_instance = MagicMock()
+            mock_timer.return_value = new_timer_instance
+
+            cm.save_config(force_sync=False)
+
+            existing_timer.cancel.assert_called_once()
+            mock_timer.assert_called_once_with(1.0, cm._flush_config)
+            new_timer_instance.start.assert_called_once()
+            self.assertEqual(cm._save_timer, new_timer_instance)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
🎯 **What:** The `ConfigManager.save_config` public method was completely untested in `tests/logic_verification/core/test_config_manager.py`. It contained conditional logic relying on `force_sync` that needed coverage.

📊 **Coverage:** The tests now fully cover:
- `save_config(force_sync=True)` which explicitly calls `shutdown()`.
- `save_config(force_sync=False)` which starts a debounce threading timer.
- `save_config(force_sync=False)` when an active debounce timer already exists, successfully cancelling it before scheduling the next one.

✨ **Result:** 100% test coverage for `ConfigManager.save_config`, ensuring proper debounce synchronization and preventing future regressions in configuration saving.

---
*PR created automatically by Jules for task [3510887891505522016](https://jules.google.com/task/3510887891505522016) started by @youtube-at-vach*