### PR TITLE
🧪 [Add test coverage for RealtimeSSSEngine.generate_output_block]

### DIFF
--- a/tests/core/test_realtime_sss_core.py
+++ b/tests/core/test_realtime_sss_core.py
@@ -408,3 +408,45 @@ def test_engine_reset_analysis_history():
     assert engine._hist_theta == []
     assert engine._hist_signal == []
     assert engine._hist_ref == []
+
+def test_engine_generate_output_block():
+    engine = RealtimeSSSEngine(
+        sample_rate=48000,
+        sweep_duration=1.0,
+        start_freq=50,
+        end_freq=15000,
+        output_amplitude=0.5,
+        max_harmonic=3,
+    )
+    engine.prepare_sweep()
+    engine.set_latency(0)
+
+    frames = 1024
+    outdata_block = np.zeros((frames, 2))  # 2 channels
+
+    # 1. Early block containing sweep data
+    engine.generate_output_block(outdata_block, 0)
+
+    # Check that outdata_block is not empty
+    assert np.any(np.abs(outdata_block) > 0)
+
+    # Check that it was copied to both channels
+    assert np.array_equal(outdata_block[:, 0], outdata_block[:, 1])
+
+    # 2. Boundary block partially spanning sweep data and silence
+    # block index where the sweep ends
+    boundary_block_index = engine.sweep_samples // frames
+    engine.generate_output_block(outdata_block, boundary_block_index)
+
+    out_samples_written = min(frames, engine.sweep_samples - boundary_block_index * frames)
+
+    if out_samples_written > 0:
+        assert np.any(np.abs(outdata_block[:out_samples_written, :]) > 0)
+    if out_samples_written < frames:
+        assert np.all(outdata_block[out_samples_written:, :] == 0.0)
+
+    # 3. Post-sweep blocks containing only silence
+    post_sweep_index = engine.sweep_samples // frames + 1
+    outdata_block.fill(1.0) # fill with ones so we can see if it was zeroed
+    engine.generate_output_block(outdata_block, post_sweep_index)
+    assert np.all(outdata_block == 0.0)


### PR DESCRIPTION
🎯 **What:** The untested public method `RealtimeSSSEngine.generate_output_block` in `src/core/realtime_sss_core.py` was missing test coverage.
📊 **Coverage:** The new test `test_engine_generate_output_block` in `tests/core/test_realtime_sss_core.py` covers three critical scenarios:
1. Early block containing sweep data, verifying signal generation and multi-channel copying.
2. Boundary block partially spanning sweep data and silence, verifying the transition, bounds-checking, and zero-padding.
3. Post-sweep blocks containing only silence, verifying that the buffer is properly zeroed out.
✨ **Result:** Increased test coverage and improved reliability of the `RealtimeSSSEngine` module by explicitly testing the signal generation and buffer manipulation edge cases.

---
*PR created automatically by Jules for task [12102164921795988108](https://jules.google.com/task/12102164921795988108) started by @youtube-at-vach*