### PR TITLE
⚡ Use set for membership check in impedance analyzer

### DIFF
--- a/src/gui/widgets/impedance_analyzer.py
+++ b/src/gui/widgets/impedance_analyzer.py
@@ -640,10 +640,10 @@ class ImpedanceSweepWorker(QThread):
                 self.module.wait_for_buffer(self._cancel_event)
                 if self.is_cancelled:
                     break
-                self.module.process_data(ignore_calibration=self.cal_mode in ("open", "short", "load"))
+                self.module.process_data(ignore_calibration=self.cal_mode in {"open", "short", "load"})
 
             # During calibration capture, always store the uncalibrated impedance.
-            if self.cal_mode in ("open", "short", "load"):
+            if self.cal_mode in {"open", "short", "load"}:
                 z = self.module.meas_z_raw
             else:
                 z = self.module.meas_z_complex


### PR DESCRIPTION
💡 **What:**
Replaced the `tuple` `("open", "short", "load")` with a `set` literal `{"open", "short", "load"}` in `ImpedanceSweepWorker.run()` for the `self.cal_mode in ...` membership checks.

🎯 **Why:**
Using a set literal `{"open", "short", "load"}` allows CPython to optimize the constant set into a `frozenset` at compile time, improving the membership check performance from O(N) linear time to O(1) constant time. This is especially beneficial as this check happens inside the worker's processing loop.

📊 **Measured Improvement:**
A quick microbenchmark of `timeit('cal_mode in ("open", "short", "load")')` vs `timeit('cal_mode in {"open", "short", "load"}')` showed that the overhead is negligible either way (a few nanoseconds). However, relying on set literals for constant lookup tables is an idiomatic Python best practice for O(1) membership checking and prevents unintended linear scaling if more elements were ever added.

---
*PR created automatically by Jules for task [17095910229665686080](https://jules.google.com/task/17095910229665686080) started by @youtube-at-vach*