### PR TITLE
📝 [Docs] Add Lock-in SNR tab documentation to Lock-in Modeler

### DIFF
--- a/docs/widgets/lock_in_modeler.en.md
+++ b/docs/widgets/lock_in_modeler.en.md
@@ -83,6 +83,8 @@ Before running any sweep, the round-trip latency of the audio input and output c
   Displays the magnitude and phase responses for the fundamental and harmonics (up to 5th-order, based on `Max Harmonic`). Harmonic characteristics can be viewed as absolute values or relative to the fundamental.
 * **Impulse Responses (Kernels) Tab**:
   Enabled after a Hammerstein (Nonlinear Model) sweep. Displays the identified 1st-order to maximum 5th-order time-domain impulse response kernels ($h_1(t)$ to $h_5(t)$).
+* **Lock-in SNR Tab**:
+  Displays the signal-to-noise ratio (SNR) in dB for the lock-in estimation, providing a dynamic metric to evaluate the reliability of the measurement data. Higher values (e.g., +40dB / +60dB) represent higher lock-in quality.
 
 ### Saving and Sharing Models
 

--- a/docs/widgets/lock_in_modeler.md
+++ b/docs/widgets/lock_in_modeler.md
@@ -83,6 +83,8 @@ Lock-in Modelerは、同期スイープサイン (Synchronized Swept Sine, SSS) 
   設定した `Max Harmonic` に応じて、基本波（Fundamental）および各高調波（2nd 〜 5th）の振幅特性（Magnitude）と位相特性（Phase）が表示されます。表示オプションにより、基本波に対する相対特性として見ることも可能です。
 * **Impulse Responses (Kernels) タブ**:
   非線形モデル（Hammerstein）測定完了後に有効化されます。同定された 1次から最大5次までの時間領域インパルス応答カーネル（$h_1(t)$ 〜 $h_5(t)$）を表示します。
+* **Lock-in SNR タブ**:
+  ロックイン推定のSNR（信号対雑音比）をdB単位で表示し、測定データの信頼性を動的に評価します。値が高いほど（例：+40dB / +60dB）ロックイン品質が高いことを示します。
 
 ### モデルの保存と共有
 


### PR DESCRIPTION
🎯 **What:**
Added missing documentation for the new `Lock-in SNR Tab` feature in the Lock-in Modeler widget, which was introduced in a recent PR but omitted from the docs.

💡 **Why:**
The 24-hour maintenance check identified this feature addition via git logs. Keeping documentation strictly synchronized with implemented features ensures users are aware of the new functionality (SNR reliability evaluation) and how to interpret it.

✅ **Verification:**
Confirmed that `scripts/check_trn_keys.py` passes (no missing translations). Checked `git log` to find the missing feature, updated both `.md` and `.en.md` correctly without modifying codebase logic, and passed `npx markdownlint-cli2` checks on the modified files. Full test suite run passed (with one pre-existing timeout unrelated to documentation).

✨ **Result:**
The documentation is now fully consistent with the application's current feature set.

---
*PR created automatically by Jules for task [15579282014056070959](https://jules.google.com/task/15579282014056070959) started by @youtube-at-vach*