### PR TITLE
📝 [Documentation] Fix typo in transmission_analyzer.md

### DIFF
--- a/docs/widgets/transmission_analyzer.md
+++ b/docs/widgets/transmission_analyzer.md
@@ -61,7 +61,7 @@ Transmission Analyzer には、測定対象に応じて切り替え可能な2つ
 * **Reset Statistics (統計リセット)**:
     累積されたビットエラー数やエラーレート、ヒストグラムを初期化し、測定を再スタートします。
 
-### 2. アナロジ設定 (Analyzer Settings)
+### 2. アナライザー設定 (Analyzer Settings)
 
 * **Analysis Mode (測定モード)**:
     * `Digital Integrity`: ビット完全性の検証とDSP・エラー箇所の診断に特化します。


### PR DESCRIPTION
This PR fixes a typographical error in `docs/widgets/transmission_analyzer.md`.

**What was changed:**
- Changed the heading `### 2. アナロジ設定 (Analyzer Settings)` to `### 2. アナライザー設定 (Analyzer Settings)`.

**Why:**
- To fix the spelling error and ensure consistency with the English text in the parentheses.
- Aligns with the project's priority of fixing errors as the first step in documentation improvement.

---
*PR created automatically by Jules for task [8654197227153088324](https://jules.google.com/task/8654197227153088324) started by @youtube-at-vach*