### PR TITLE
feat(gui): Add split state support to RawTimeSeriesWidget

### DIFF
--- a/src/gui/widgets/raw_time_series.py
+++ b/src/gui/widgets/raw_time_series.py
@@ -19,6 +19,7 @@ from src.core.localization import tr
 from src.core.utils import format_si
 from src.measurement_modules.base import MeasurementModule
 from src.gui.widgets.compactable_interface import CompactableWidgetInterface
+from src.gui.widgets.splittable_interface import SplittableWidgetInterface
 
 
 class RawTimeSeries(MeasurementModule):
@@ -156,10 +157,11 @@ class RawTimeSeries(MeasurementModule):
         return t, data
 
 
-class RawTimeSeriesWidget(QWidget, CompactableWidgetInterface):
+class RawTimeSeriesWidget(QWidget, CompactableWidgetInterface, SplittableWidgetInterface):
     def __init__(self, module: RawTimeSeries):
         QWidget.__init__(self)
         CompactableWidgetInterface.__init__(self)
+        SplittableWidgetInterface.__init__(self)
         self.module = module
 
         self._last_frame = None  # (t, data)
@@ -170,11 +172,31 @@ class RawTimeSeriesWidget(QWidget, CompactableWidgetInterface):
         self.timer.timeout.connect(self._update_plot)
         self.timer.setInterval(100)  # ~10 fps is enough for multi-minute scrolling
 
+    def get_display_widget(self) -> QWidget:
+        """Returns the display sub-widget (plot area)."""
+        return self.display_widget
+
+    def get_control_widget(self) -> QWidget:
+        """Returns the controls sub-widget (settings panel)."""
+        return self.right_widget
+
+    def restore_split_panels(self) -> None:
+        """Re-inserts display_widget and right_widget into the main layout after split reattach."""
+        layout = self.layout()
+        if layout is None:
+            return
+        layout.addWidget(self.display_widget, stretch=1)
+        layout.addWidget(self.right_widget)
+        self.display_widget.show()
+        self.right_widget.show()
+
     def _init_ui(self):
         root = QHBoxLayout(self)
 
         # Left: plots
-        left = QVBoxLayout()
+        self.display_widget = QWidget()
+        left = QVBoxLayout(self.display_widget)
+        left.setContentsMargins(0, 0, 0, 0)
 
         self.plots = pg.GraphicsLayoutWidget()
 
@@ -214,7 +236,7 @@ class RawTimeSeriesWidget(QWidget, CompactableWidgetInterface):
             p.setDownsampling(mode="peak")
 
         left.addWidget(self.plots)
-        root.addLayout(left, stretch=1)
+        root.addWidget(self.display_widget, stretch=1)
 
         # Right: controls
         self.right_widget = QWidget()
@@ -434,4 +456,6 @@ class RawTimeSeriesWidget(QWidget, CompactableWidgetInterface):
     def update_compact_layout(self):
         compact = self.is_compact_mode()
         if hasattr(self, "right_widget"):
-            self.right_widget.setHidden(compact)
+            is_split = self.right_widget.parent() is not self
+            if not is_split:
+                self.right_widget.setHidden(compact)

--- a/tests/logic_verification/gui/test_raw_time_series_split.py
+++ b/tests/logic_verification/gui/test_raw_time_series_split.py
@@ -1,0 +1,69 @@
+import sys
+import os
+import unittest
+from unittest.mock import MagicMock
+import pytest
+
+pytest.importorskip("PyQt6")
+
+if "sounddevice" not in sys.modules:
+    sys.modules["sounddevice"] = MagicMock()
+
+os.environ["QT_QPA_PLATFORM"] = "offscreen"
+
+from PyQt6.QtWidgets import QApplication, QWidget
+from src.gui.widgets.raw_time_series import RawTimeSeries, RawTimeSeriesWidget
+from src.gui.widgets.splittable_interface import SplittableWidgetInterface
+from src.gui.widgets.detachable_wrapper import DetachableWidgetWrapper
+
+
+class TestRawTimeSeriesSplit(unittest.TestCase):
+    def setUp(self):
+        self.app = QApplication.instance()
+        if self.app is None:
+            self.app = QApplication(sys.argv)
+
+        self.mock_engine = MagicMock()
+        self.mock_engine.sample_rate = 48000
+        self.mock_engine.calibration = MagicMock()
+        self.mock_engine.calibration.input_sensitivity = 1.0
+
+        self.module = RawTimeSeries(self.mock_engine)
+        self.widget = RawTimeSeriesWidget(self.module)
+
+    def test_splittable_interface_implementation(self):
+        self.assertIsInstance(self.widget, SplittableWidgetInterface)
+
+        display_widget = self.widget.get_display_widget()
+        control_widget = self.widget.get_control_widget()
+
+        self.assertIsInstance(display_widget, QWidget)
+        self.assertIsInstance(control_widget, QWidget)
+        self.assertEqual(display_widget, self.widget.display_widget)
+        self.assertEqual(control_widget, self.widget.right_widget)
+
+    def test_detachable_wrapper_split_flow(self):
+        wrapper = DetachableWidgetWrapper(self.widget, "Raw Time Series")
+        self.assertTrue(wrapper.is_splittable)
+        self.assertIsNotNone(wrapper.split_btn)
+        self.assertTrue(wrapper.split_btn.isEnabled())
+
+        # Transition to State C (Split)
+        wrapper.split()
+        self.assertTrue(wrapper.is_split)
+        self.assertIsNotNone(wrapper.split_display_window)
+        self.assertIsNotNone(wrapper.split_control_window)
+
+        # Ensure compact mode check handles split state safely
+        self.widget.set_compact_mode(True)
+        self.assertTrue(self.widget.is_compact_mode())
+
+        # Reattach all back to State A
+        wrapper.reattach_all()
+        self.assertFalse(wrapper.is_split)
+        self.assertEqual(self.widget.display_widget.parent(), self.widget)
+        self.assertEqual(self.widget.right_widget.parent(), self.widget)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds support for **State C (Split Window Mode)** to `RawTimeSeriesWidget` (生時系列ウィジット).

### Changes
1. **Display Sub-widget Refactoring**: Wrapped the plot panel in `RawTimeSeriesWidget._init_ui()` into `self.display_widget = QWidget()`.
2. **`SplittableWidgetInterface` Implementation**: Inherited `SplittableWidgetInterface` and implemented `get_display_widget()`, `get_control_widget()`, and `restore_split_panels()`.
3. **Compact Mode Guard**: Updated `update_compact_layout()` to check `self.right_widget.parent() is not self` so that control visibility is not wrongly toggled when controls are detached into an independent window.
4. **Unit Tests**: Added `tests/logic_verification/gui/test_raw_time_series_split.py` to verify interface implementation and split/reattach behavior with `DetachableWidgetWrapper`.

## Verification
- `pytest -q tests/logic_verification/gui/test_raw_time_series_split.py` (Passed)
- `python scripts/check_ui_size_limits.py` (Passed)
- `ruff check` (Passed)