### PR TITLE
feat: Add split mode (State C) support to Goniometer

### DIFF
--- a/src/gui/widgets/goniometer.py
+++ b/src/gui/widgets/goniometer.py
@@ -23,6 +23,7 @@ from src.core.audio_engine import AudioEngine
 from src.core.localization import tr
 from src.measurement_modules.base import MeasurementModule
 from src.gui.widgets.compactable_interface import CompactableWidgetInterface
+from src.gui.widgets.splittable_interface import SplittableWidgetInterface
 
 
 logger = logging.getLogger(__name__)
@@ -121,10 +122,11 @@ class Goniometer(MeasurementModule):
         outdata.fill(0)
 
 
-class GoniometerWidget(QWidget, CompactableWidgetInterface):
+class GoniometerWidget(QWidget, CompactableWidgetInterface, SplittableWidgetInterface):
     def __init__(self, module: Goniometer):
         QWidget.__init__(self)
         CompactableWidgetInterface.__init__(self)
+        SplittableWidgetInterface.__init__(self)
         self.module = module
         self.init_ui()
 
@@ -138,7 +140,9 @@ class GoniometerWidget(QWidget, CompactableWidgetInterface):
         layout = QHBoxLayout()
 
         # --- Left: Display ---
-        display_layout = QVBoxLayout()
+        self.display_widget = QWidget()
+        display_layout = QVBoxLayout(self.display_widget)
+        display_layout.setContentsMargins(0, 0, 0, 0)
 
         # 1. Goniometer Plot
         self.plot_widget = pg.PlotWidget()
@@ -185,7 +189,7 @@ class GoniometerWidget(QWidget, CompactableWidgetInterface):
         corr_layout.addWidget(QLabel("+1"))
         display_layout.addWidget(self.corr_container)
 
-        layout.addLayout(display_layout, stretch=3)
+        layout.addWidget(self.display_widget, stretch=3)
 
         # --- Right: Controls ---
         self.controls_group = QGroupBox(tr("Controls"))
@@ -609,9 +613,29 @@ class GoniometerWidget(QWidget, CompactableWidgetInterface):
                 "QPushButton:checked:hover { background-color: #ffbbbb; }"
             )
 
+    def get_display_widget(self) -> QWidget:
+        """Returns the display sub-widget (plot area and correlation meter)."""
+        return self.display_widget
+
+    def get_control_widget(self) -> QWidget:
+        """Returns the controls sub-widget (settings panel)."""
+        return self.controls_group
+
+    def restore_split_panels(self) -> None:
+        """Re-inserts display_widget and controls_group into the main layout after split reattach."""
+        layout = self.layout()
+        if layout is None:
+            return
+        layout.addWidget(self.display_widget, stretch=3)
+        layout.addWidget(self.controls_group, stretch=1)
+        self.display_widget.show()
+        self.controls_group.show()
+
     def update_compact_layout(self):
         compact = self.is_compact_mode()
         if hasattr(self, "controls_group"):
-            self.controls_group.setHidden(compact)
+            is_split = self.controls_group.parent() is not self
+            if not is_split:
+                self.controls_group.setHidden(compact)
         if hasattr(self, "corr_container"):
             self.corr_container.setHidden(compact)

--- a/tests/logic_verification/gui/test_goniometer_split.py
+++ b/tests/logic_verification/gui/test_goniometer_split.py
@@ -1,0 +1,69 @@
+import sys
+import os
+import unittest
+from unittest.mock import MagicMock
+import pytest
+
+pytest.importorskip("PyQt6")
+
+if "sounddevice" not in sys.modules:
+    sys.modules["sounddevice"] = MagicMock()
+
+os.environ["QT_QPA_PLATFORM"] = "offscreen"
+
+from PyQt6.QtWidgets import QApplication, QWidget
+from src.gui.widgets.goniometer import Goniometer, GoniometerWidget
+from src.gui.widgets.splittable_interface import SplittableWidgetInterface
+from src.gui.widgets.detachable_wrapper import DetachableWidgetWrapper
+
+
+class TestGoniometerSplit(unittest.TestCase):
+    def setUp(self):
+        self.app = QApplication.instance()
+        if self.app is None:
+            self.app = QApplication(sys.argv)
+
+        self.mock_engine = MagicMock()
+        self.mock_engine.sample_rate = 48000
+        self.mock_engine.calibration = MagicMock()
+        self.mock_engine.calibration.input_sensitivity = 1.0
+
+        self.module = Goniometer(self.mock_engine)
+        self.widget = GoniometerWidget(self.module)
+
+    def test_splittable_interface_implementation(self):
+        self.assertIsInstance(self.widget, SplittableWidgetInterface)
+
+        display_widget = self.widget.get_display_widget()
+        control_widget = self.widget.get_control_widget()
+
+        self.assertIsInstance(display_widget, QWidget)
+        self.assertIsInstance(control_widget, QWidget)
+        self.assertEqual(display_widget, self.widget.display_widget)
+        self.assertEqual(control_widget, self.widget.controls_group)
+
+    def test_detachable_wrapper_split_flow(self):
+        wrapper = DetachableWidgetWrapper(self.widget, "Goniometer")
+        self.assertTrue(wrapper.is_splittable)
+        self.assertIsNotNone(wrapper.split_btn)
+        self.assertTrue(wrapper.split_btn.isEnabled())
+
+        # Transition to State C (Split)
+        wrapper.split()
+        self.assertTrue(wrapper.is_split)
+        self.assertIsNotNone(wrapper.split_display_window)
+        self.assertIsNotNone(wrapper.split_control_window)
+
+        # Ensure compact mode check handles split state safely
+        self.widget.set_compact_mode(True)
+        self.assertTrue(self.widget.is_compact_mode())
+
+        # Reattach all back to State A
+        wrapper.reattach_all()
+        self.assertFalse(wrapper.is_split)
+        self.assertEqual(self.widget.display_widget.parent(), self.widget)
+        self.assertEqual(self.widget.controls_group.parent(), self.widget)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Summary

Adds State C (Split Mode) support to the Goniometer widget, aligning it with the split window capability already present in the Oscilloscope and Raw Time Series modules.

### Motivation

Allow users to detach and separate the Goniometer display area (Lissajous plot and Phase Correlation Meter) from its controls panel into independent windows for flexible multi-monitor or focused analysis layouts.

### Approach

- **Display Panel Isolation**: Wrapped the plot and correlation meter layout inside a dedicated `display_widget` (`QWidget`) within `GoniometerWidget.init_ui()`.
- **Interface Implementation**: Implemented `SplittableWidgetInterface` on `GoniometerWidget` (`get_display_widget`, `get_control_widget`, `restore_split_panels`) to integrate with `DetachableWidgetWrapper`.
- **Compact Layout Guard**: Added a check in `update_compact_layout()` to prevent hiding the controls panel when it is reparented into a split window.
- **Testing**: Added unit tests in `tests/logic_verification/gui/test_goniometer_split.py` verifying interface implementation, split/reattach lifecycle, and compact mode behavior.