### PR TITLE
feat(gui): Add split state support to BNIMMeterWidget

### DIFF
--- a/src/gui/widgets/bnim_meter.py
+++ b/src/gui/widgets/bnim_meter.py
@@ -24,6 +24,7 @@ from src.core.localization import tr
 from src.core.fft_manager import fft_manager
 from src.measurement_modules.base import MeasurementModule
 from src.gui.widgets.compactable_interface import CompactableWidgetInterface
+from src.gui.widgets.splittable_interface import SplittableWidgetInterface
 
 
 class BNIMMeter(MeasurementModule):
@@ -437,10 +438,11 @@ class BNIMMeter(MeasurementModule):
         self.neural_map = (self.neural_map * self.decay) + (coincidence * (1.0 - self.decay))
 
 
-class BNIMMeterWidget(QWidget, CompactableWidgetInterface):
+class BNIMMeterWidget(QWidget, CompactableWidgetInterface, SplittableWidgetInterface):
     def __init__(self, module: BNIMMeter):
         QWidget.__init__(self)
         CompactableWidgetInterface.__init__(self)
+        SplittableWidgetInterface.__init__(self)
         self.module = module
         self.init_ui()
 
@@ -462,7 +464,9 @@ class BNIMMeterWidget(QWidget, CompactableWidgetInterface):
         layout = QHBoxLayout()
 
         # --- Left: Display ---
-        display_layout = QVBoxLayout()
+        self.display_widget = QWidget()
+        display_layout = QVBoxLayout(self.display_widget)
+        display_layout.setContentsMargins(0, 0, 0, 0)
 
         self.plot_widget = pg.PlotWidget()
         self.plot_widget.setBackground("#050505")
@@ -489,7 +493,7 @@ class BNIMMeterWidget(QWidget, CompactableWidgetInterface):
 
         self.plot_widget.addItem(self.img_item)
 
-        layout.addLayout(display_layout, stretch=3)
+        layout.addWidget(self.display_widget, stretch=3)
 
         # --- Right: Controls ---
         self.controls_group = QGroupBox(tr("BNIM Controls"))
@@ -767,7 +771,27 @@ class BNIMMeterWidget(QWidget, CompactableWidgetInterface):
         self.plot_widget.setXRange(-itd, itd)
         self.plot_widget.setYRange(fmin, fmax)
 
+    def get_display_widget(self) -> QWidget:
+        """Returns the display sub-widget (plot area and ITD label)."""
+        return self.display_widget
+
+    def get_control_widget(self) -> QWidget:
+        """Returns the controls sub-widget (settings panel)."""
+        return self.controls_group
+
+    def restore_split_panels(self) -> None:
+        """Re-inserts display_widget and controls_group into the main layout after split reattach."""
+        layout = self.layout()
+        if layout is None:
+            return
+        layout.addWidget(self.display_widget, stretch=3)
+        layout.addWidget(self.controls_group, stretch=1)
+        self.display_widget.show()
+        self.controls_group.show()
+
     def update_compact_layout(self):
         compact = self.is_compact_mode()
         if hasattr(self, "controls_group"):
-            self.controls_group.setHidden(compact)
+            is_split = self.controls_group.parent() is not self
+            if not is_split:
+                self.controls_group.setHidden(compact)

--- a/tests/logic_verification/gui/test_bnim_meter_split.py
+++ b/tests/logic_verification/gui/test_bnim_meter_split.py
@@ -1,0 +1,67 @@
+import sys
+import os
+import unittest
+from unittest.mock import MagicMock
+import pytest
+
+pytest.importorskip("PyQt6")
+
+if "sounddevice" not in sys.modules:
+    sys.modules["sounddevice"] = MagicMock()
+
+os.environ["QT_QPA_PLATFORM"] = "offscreen"
+
+from PyQt6.QtWidgets import QApplication, QWidget
+from src.gui.widgets.bnim_meter import BNIMMeter, BNIMMeterWidget
+from src.gui.widgets.splittable_interface import SplittableWidgetInterface
+from src.gui.widgets.detachable_wrapper import DetachableWidgetWrapper
+
+
+class TestBNIMMeterSplit(unittest.TestCase):
+    def setUp(self):
+        self.app = QApplication.instance()
+        if self.app is None:
+            self.app = QApplication(sys.argv)
+
+        self.mock_engine = MagicMock()
+        self.mock_engine.sample_rate = 48000
+
+        self.module = BNIMMeter(self.mock_engine)
+        self.widget = BNIMMeterWidget(self.module)
+
+    def test_splittable_interface_implementation(self):
+        self.assertIsInstance(self.widget, SplittableWidgetInterface)
+
+        display_widget = self.widget.get_display_widget()
+        control_widget = self.widget.get_control_widget()
+
+        self.assertIsInstance(display_widget, QWidget)
+        self.assertIsInstance(control_widget, QWidget)
+        self.assertEqual(display_widget, self.widget.display_widget)
+        self.assertEqual(control_widget, self.widget.controls_group)
+
+    def test_detachable_wrapper_split_flow(self):
+        wrapper = DetachableWidgetWrapper(self.widget, "BNIM Meter")
+        self.assertTrue(wrapper.is_splittable)
+        self.assertIsNotNone(wrapper.split_btn)
+        self.assertTrue(wrapper.split_btn.isEnabled())
+
+        # Transition to State C (Split)
+        wrapper.split()
+        self.assertTrue(wrapper.is_split)
+        self.assertIsNotNone(wrapper.split_display_window)
+        self.assertIsNotNone(wrapper.split_control_window)
+
+        # Ensure compact mode check handles split state safely
+        self.widget.set_compact_mode(True)
+        self.assertTrue(self.widget.is_compact_mode())
+
+        # Reattach all back to State A
+        wrapper.reattach_all()
+        self.assertFalse(wrapper.is_split)
+        self.assertEqual(self.widget.display_widget.parent(), self.widget)
+        self.assertEqual(self.widget.controls_group.parent(), self.widget)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implement State C (split window mode) support for `BNIMMeterWidget`.

## Changes
- Wrapped `BNIMMeterWidget` display components into `self.display_widget`.
- Implemented `SplittableWidgetInterface` (`get_display_widget`, `get_control_widget`, `restore_split_panels`).
- Added safety checks in `update_compact_layout()` when controls panel is detached/split.
- Added unit tests in `tests/logic_verification/gui/test_bnim_meter_split.py`.

## Verification
- Passed `tests/logic_verification/gui/test_bnim_meter_split.py`
- Passed `scripts/check_ui_size_limits.py`
- Passed `ruff check`
- Passed full test suite (`pytest`)

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>