### PR TITLE
feat(gui): 騒音計にスプリットモード (State C) を追加

### DIFF
--- a/src/gui/widgets/sound_level_meter.py
+++ b/src/gui/widgets/sound_level_meter.py
@@ -24,6 +24,7 @@ from src.core.localization import tr
 from src.core.analysis import AudioCalc
 from src.measurement_modules.base import MeasurementModule
 from src.gui.widgets.compactable_interface import CompactableWidgetInterface
+from src.gui.widgets.splittable_interface import SplittableWidgetInterface
 
 
 logger = logging.getLogger(__name__)
@@ -535,10 +536,11 @@ class SoundLevelMeter(MeasurementModule):
         return centers, probs
 
 
-class SoundLevelMeterWidget(QWidget, CompactableWidgetInterface):
+class SoundLevelMeterWidget(QWidget, CompactableWidgetInterface, SplittableWidgetInterface):
     def __init__(self, module: SoundLevelMeter):
         QWidget.__init__(self)
         CompactableWidgetInterface.__init__(self)
+        SplittableWidgetInterface.__init__(self)
         self.module = module
 
         # State tracking for optimization
@@ -565,6 +567,7 @@ class SoundLevelMeterWidget(QWidget, CompactableWidgetInterface):
         # --- Sidebar ---
         self.sidebar = QWidget()
         self.sidebar.setFixedWidth(250)
+        self.control_widget = self.sidebar
         sidebar_layout = QVBoxLayout()
         sidebar_layout.setContentsMargins(10, 10, 10, 10)
 
@@ -634,6 +637,7 @@ class SoundLevelMeterWidget(QWidget, CompactableWidgetInterface):
 
         # --- Main Content Area ---
         content_area = QWidget()
+        self.display_widget = content_area
         content_layout = QVBoxLayout()
         content_layout.setContentsMargins(10, 10, 10, 10)
 
@@ -758,6 +762,24 @@ class SoundLevelMeterWidget(QWidget, CompactableWidgetInterface):
         main_layout.addWidget(self.sidebar)
         main_layout.addWidget(content_area)
         self.setLayout(main_layout)
+
+    def get_display_widget(self) -> QWidget:
+        """Returns the display sub-widget (main display and tabs area)."""
+        return self.display_widget
+
+    def get_control_widget(self) -> QWidget:
+        """Returns the controls sub-widget (sidebar settings panel)."""
+        return self.control_widget
+
+    def restore_split_panels(self) -> None:
+        """Re-inserts display_widget and control_widget into the main layout after split reattach."""
+        layout = self.layout()
+        if layout is None:
+            return
+        layout.addWidget(self.control_widget)
+        layout.addWidget(self.display_widget)
+        self.control_widget.show()
+        self.display_widget.show()
 
     def _create_big_display(self, title, color):
         container = QWidget()
@@ -902,8 +924,12 @@ class SoundLevelMeterWidget(QWidget, CompactableWidgetInterface):
 
     def update_compact_layout(self):
         compact = self.is_compact_mode()
+        # In split mode sidebar/control_widget lives in its own window (parent != self).
+        # Only hide it when it is still embedded in this widget.
         if hasattr(self, "sidebar"):
-            self.sidebar.setHidden(compact)
+            is_split = self.sidebar.parent() is not self
+            if not is_split:
+                self.sidebar.setHidden(compact)
         if hasattr(self, "tabs"):
             self.tabs.setHidden(compact)
 

--- a/tests/logic_verification/gui/test_sound_level_meter.py
+++ b/tests/logic_verification/gui/test_sound_level_meter.py
@@ -2,7 +2,8 @@ import numpy as np
 import scipy.signal
 import pytest
 from unittest.mock import MagicMock
-from src.gui.widgets.sound_level_meter import SoundLevelMeter
+from src.gui.widgets.sound_level_meter import SoundLevelMeter, SoundLevelMeterWidget
+from src.gui.widgets.splittable_interface import SplittableWidgetInterface
 
 
 class MockAudioEngine:
@@ -249,3 +250,25 @@ class TestSoundLevelMeterWeighting:
         assert abs(diff - 19.1) < 1.5, (
             f"Callback A-weighting check failed. 1kHz: {level_1k_db}, 100Hz: {level_100_db}, Diff: {diff}"
         )
+
+
+class TestSoundLevelMeterSplittable:
+    def test_splittable_interface(self, qapp):
+        engine = MockAudioEngine()
+        slm = SoundLevelMeter(engine)
+        widget = SoundLevelMeterWidget(slm)
+
+        assert isinstance(widget, SplittableWidgetInterface)
+        display_w = widget.get_display_widget()
+        control_w = widget.get_control_widget()
+
+        assert display_w is not None
+        assert control_w is not None
+        assert display_w == widget.display_widget
+        assert control_w == widget.control_widget
+
+        # Test restore_split_panels execution
+        widget.restore_split_panels()
+        assert not display_w.isHidden()
+        assert not control_w.isHidden()
+


### PR DESCRIPTION
## 概要
騒音計 (`SoundLevelMeterWidget`) に新しいスプリットモード (State C) を実装しました。
オシロスコープ等の実装に基づき、`SplittableWidgetInterface` を継承・実装してディスプレイ部とコントロール部の独立ウィンドウ分離表示に対応しました。

## 主な変更点
1. **`SoundLevelMeterWidget` への `SplittableWidgetInterface` 実装:**
   - `get_display_widget()`, `get_control_widget()`, `restore_split_panels()` を実装。
2. **レイアウトとプロパティ整理:**
   - メイン表示・タブエリアを `display_widget`、サイドバーコントロールを `control_widget` として参照を保持。
3. **コンパクトモードの安全保護:**
   - スプリット時にサイドバーが親ウィジェットから分離されている場合を想定した保護処理を追加。
4. **テスト追加:**
   - `TestSoundLevelMeterSplittable` 単体テストを追加。