### PR TITLE
docs: unify OS-specific headings in quickstart guide

### DIFF
--- a/docs/quickstart.en.md
+++ b/docs/quickstart.en.md
@@ -22,13 +22,13 @@ Using this loopback connection first allows you to test whether the basic input 
 MeasureLab works on Windows and Linux.
 Please download the latest version for your OS from the [Releases](https://github.com/youtube-at-vach/MeasureLab/releases) page.
 
-### For Windows
+### Windows
 
 1. Download `MeasureLab-<version>-windows-x64-onefile.zip` (or `onedir.zip`).
 2. Extract the ZIP file.
 3. Double-click `MeasureLab.exe` in the folder to run it.
 
-### For Linux
+### Linux
 
 1. Download `MeasureLab-<version>-linux-x86_64.AppImage`.
 2. Grant execution permission to the file.
@@ -43,7 +43,7 @@ Please download the latest version for your OS from the [Releases](https://githu
    ./MeasureLab-*-linux-x86_64.AppImage
    ```
 
-### For macOS (Apple Silicon / Intel)
+### macOS
 
 1. Download `MeasureLab-<version>-macos-arm64.dmg` for Apple Silicon or `MeasureLab-<version>-macos-x64.dmg` for Intel Macs.
 2. **Gatekeeper Bypass**:
@@ -83,7 +83,7 @@ Please select from the **Themes** combo box.
 After starting, first configure the audio input/output settings.
 Open the **Settings** widget (gear icon) from the left menu.
 
-### For Windows
+### Windows
 
 Select the audio interface you want to use from the device list.
 
@@ -91,7 +91,7 @@ Select the audio interface you want to use from the device list.
 - **WASAPI**: Recommended setting if there is no dedicated driver or when using standard Windows functions.
 - **MME / DirectSound**: Large latency, not very suitable for measurement.
 
-### For Linux
+### Linux
 
 When performing high-precision measurements in a Linux environment, we strongly recommend using **JACK** or **PipeWire**.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -22,13 +22,13 @@
 MeasureLab は Windows および Linux で動作します。
 [Releases](https://github.com/youtube-at-vach/MeasureLab/releases) ページから、お使いの OS に合わせた最新バージョンをダウンロードしてください。
 
-### Windows の場合
+### Windows
 
 1. `MeasureLab-<version>-windows-x64-onefile.zip`（または `onedir.zip`）をダウンロードします。
 2. ZIP ファイルを解凍します。
 3. フォルダ内の `MeasureLab.exe` をダブルクリックして実行します。
 
-### Linux の場合
+### Linux
 
 1. `MeasureLab-<version>-linux-x86_64.AppImage` をダウンロードします。
 2. ファイルに実行権限を付与します。
@@ -43,7 +43,7 @@ MeasureLab は Windows および Linux で動作します。
    ./MeasureLab-*-linux-x86_64.AppImage
    ```
 
-### macOS の場合 (Apple Silicon / Intel)
+### macOS
 
 1. Apple Silicon の場合は `MeasureLab-<version>-macos-arm64.dmg`、Intel Mac の場合は `MeasureLab-<version>-macos-x64.dmg` をダウンロードします。
 2. **ゲートキーパーの回避**:
@@ -83,7 +83,7 @@ Settings ウィジットでは、使いやすいように UI の言語や配色�
 起動したら、まずはオーディオ入出力の設定を行います。
 左側のメニューから **Settings** ウィジット（歯車アイコン）を開いてください。
 
-### Windows の場合
+### Windows
 
 デバイスリストから使用するオーディオインターフェースなどを選択します。
 
@@ -91,7 +91,7 @@ Settings ウィジットでは、使いやすいように UI の言語や配色�
 - **WASAPI**: 専用ドライバがない場合や、Windows 標準の機能を使う場合の推奨設定です。
 - **MME / DirectSound**: 遅延が大きく、測定にはあまり向きません。
 
-### Linux の場合
+### Linux
 
 Linux 環境で高精度な測定を行う場合、**JACK** または **PipeWire** の使用を強く推奨します。
 


### PR DESCRIPTION
This PR unifies the OS-specific heading formats in `docs/quickstart.md` and `docs/quickstart.en.md` to ensure structural consistency and readability.

The following changes were applied symmetrically across both languages:
- **English**: Changed `### For Windows`, `### For Linux`, `### For macOS (Apple Silicon / Intel)` to `### Windows`, `### Linux`, and `### macOS`.
- **Japanese**: Changed `### Windows の場合`, `### Linux の場合`, `### macOS の場合 (Apple Silicon / Intel)` to `### Windows`, `### Linux`, and `### macOS`.

These modifications improve information accessibility by removing redundant introductory wording, resulting in a cleaner and lower-cognitive-load interface for the reader.

---
*PR created automatically by Jules for task [5394905431582643339](https://jules.google.com/task/5394905431582643339) started by @youtube-at-vach*