### PR TITLE
Enable split-panel support for spectrogram widget

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -169,6 +169,6 @@ Linux ではそのまま **PortAudio** バックエンドでも通常利用で�
 
 ### 🤖 AI パートナー
 
-- OpenAI: GPT-4.1, GPT-5, GPT-5.1 Codex Max, GPT-5.2, GPT-5.2 Codex, GPT-5.3-Codex, GPT-5.4, GPT-5.5
+- OpenAI: GPT-4.1, GPT-5, GPT-5.1 Codex Max, GPT-5.2, GPT-5.2 Codex, GPT-5.3-Codex, GPT-5.4, GPT-5.5, GPT-5.6
 - Google: Gemini 2.5 Pro, Gemini 3 Pro, Gemini 3 Flash, Gemini 3.1 Pro, Gemini 3.5 Frash
 - Anthropic: Claude 4.5 Sonnet

--- a/README.md
+++ b/README.md
@@ -168,6 +168,6 @@ You are free to copy, modify, distribute, and use it for any commercial or non-c
 
 ### 🤖 AI Models
 
-- OpenAI: GPT-4.1, GPT-5, GPT-5.1 Codex Max, GPT-5.2, GPT-5.2 Codex, GPT-5.3-Codex, GPT-5.4, GPT-5.5
+- OpenAI: GPT-4.1, GPT-5, GPT-5.1 Codex Max, GPT-5.2, GPT-5.2 Codex, GPT-5.3-Codex, GPT-5.4, GPT-5.5, GPT-5.6
 - Google: Gemini 2.5 Pro, Gemini 3 Pro, Gemini 3 Flash, Gemini 3.1 Pro, Gemini 3.5 Flash
 - Anthropic: Claude 4.5 Sonnet

--- a/src/gui/widgets/spectrogram.py
+++ b/src/gui/widgets/spectrogram.py
@@ -22,6 +22,7 @@ from src.core.analysis import get_cached_window
 from src.core.localization import tr
 from src.measurement_modules.base import MeasurementModule
 from src.gui.widgets.compactable_interface import CompactableWidgetInterface
+from src.gui.widgets.splittable_interface import SplittableWidgetInterface
 from src.core.fft_manager import fft_manager, WARMUP_SIZES
 from src.gui.styles import STYLE_TOGGLE_BTN_DARK, STYLE_TOGGLE_BTN_LIGHT
 
@@ -223,10 +224,11 @@ class Spectrogram(MeasurementModule):
         outdata.fill(0)
 
 
-class SpectrogramWidget(QWidget, CompactableWidgetInterface):
+class SpectrogramWidget(QWidget, CompactableWidgetInterface, SplittableWidgetInterface):
     def __init__(self, module: Spectrogram):
         QWidget.__init__(self)
         CompactableWidgetInterface.__init__(self)
+        SplittableWidgetInterface.__init__(self)
         self.module = module
         self.log_spectrogram_buffer = None
         self._last_raw_buffer_id = None
@@ -243,11 +245,31 @@ class SpectrogramWidget(QWidget, CompactableWidgetInterface):
         self.module.stop_analysis()
         super().closeEvent(event)
 
+    def get_display_widget(self) -> QWidget:
+        """Return the spectrogram plot and histogram panel for split mode."""
+        return self.display_widget
+
+    def get_control_widget(self) -> QWidget:
+        """Return the settings panel for split mode."""
+        return self.controls_group
+
+    def restore_split_panels(self) -> None:
+        """Restore the normal top-controls, bottom-display layout after reattachment."""
+        layout = self.layout()
+        if layout is None:
+            return
+
+        layout.addWidget(self.controls_group)
+        layout.addWidget(self.display_widget)
+        self.controls_group.show()
+        self.display_widget.show()
+
     def init_ui(self):
         layout = QVBoxLayout()
         self.controls_group = self._init_controls()
+        self.display_widget = self._init_plot()
         layout.addWidget(self.controls_group)
-        layout.addWidget(self._init_plot())
+        layout.addWidget(self.display_widget)
         self.setLayout(layout)
 
     def _init_controls(self) -> QGroupBox:
@@ -699,6 +721,10 @@ class SpectrogramWidget(QWidget, CompactableWidgetInterface):
     def update_compact_layout(self):
         compact = self.is_compact_mode()
         if hasattr(self, "controls_group"):
-            self.controls_group.setHidden(compact)
+            # In split mode the controls live in their own window. Compact mode applies
+            # only to the display window, so do not hide the detached controls.
+            is_split = self.controls_group.parent() is not self
+            if not is_split:
+                self.controls_group.setHidden(compact)
         if hasattr(self, "hist"):
             self.hist.setVisible(not compact)

--- a/tests/logic_verification/gui/test_spectrogram_split.py
+++ b/tests/logic_verification/gui/test_spectrogram_split.py
@@ -1,0 +1,72 @@
+import os
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("PyQt6")
+
+if "sounddevice" not in sys.modules:
+    sys.modules["sounddevice"] = MagicMock()
+
+os.environ["QT_QPA_PLATFORM"] = "offscreen"
+
+from PyQt6.QtWidgets import QApplication, QWidget
+from PyQt6 import sip
+
+from src.gui.widgets.detachable_wrapper import DetachableWidgetWrapper
+from src.gui.widgets.spectrogram import Spectrogram, SpectrogramWidget
+from src.gui.widgets.splittable_interface import SplittableWidgetInterface
+
+
+@pytest.fixture
+def spectrogram_widget():
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication(sys.argv)
+
+    engine = MagicMock()
+    engine.sample_rate = 48000
+    widget = SpectrogramWidget(Spectrogram(engine))
+
+    yield widget
+
+    if not sip.isdeleted(widget):
+        widget.close()
+        widget.deleteLater()
+
+
+def test_spectrogram_implements_split_interface(spectrogram_widget):
+    assert isinstance(spectrogram_widget, SplittableWidgetInterface)
+    assert isinstance(spectrogram_widget.get_display_widget(), QWidget)
+    assert isinstance(spectrogram_widget.get_control_widget(), QWidget)
+    assert spectrogram_widget.get_display_widget() is spectrogram_widget.display_widget
+    assert spectrogram_widget.get_control_widget() is spectrogram_widget.controls_group
+
+
+def test_spectrogram_split_and_reattach_restores_vertical_layout(spectrogram_widget):
+    wrapper = DetachableWidgetWrapper(spectrogram_widget, "Spectrogram")
+
+    assert wrapper.is_splittable
+    assert wrapper.split_btn is not None
+    assert wrapper.split_btn.isEnabled()
+
+    wrapper.split()
+
+    assert wrapper.is_split
+    assert wrapper.split_display_window is not None
+    assert wrapper.split_control_window is not None
+    assert spectrogram_widget.display_widget.parent() is wrapper.split_display_window
+    assert spectrogram_widget.controls_group.parent() is wrapper.split_control_window
+
+    spectrogram_widget.set_compact_mode(True)
+    assert not spectrogram_widget.controls_group.isHidden()
+
+    wrapper.reattach_all()
+
+    layout = spectrogram_widget.layout()
+    assert not wrapper.is_split
+    assert spectrogram_widget.display_widget.parent() is spectrogram_widget
+    assert spectrogram_widget.controls_group.parent() is spectrogram_widget
+    assert layout.itemAt(0).widget() is spectrogram_widget.controls_group
+    assert layout.itemAt(1).widget() is spectrogram_widget.display_widget


### PR DESCRIPTION
## Summary

- enable the Spectrogram widget to use the existing split-window workflow
- separate the settings panel and spectrogram display into independent windows, restoring their vertical layout on reattach
- preserve the controls window while compact mode is active in split mode
- add split and reattach GUI coverage for the Spectrogram widget

## Why

The Spectrogram widget was not connected to the shared split-panel interface, unlike other analysis widgets. This makes its controls and display difficult to place independently.

## Validation

- `./.venv/bin/ruff check src/gui/widgets/spectrogram.py tests/logic_verification/gui/test_spectrogram_split.py`
- `./.venv/bin/python -m pytest -q tests/logic_verification/gui/test_spectrogram_split.py tests/logic_verification/gui/test_spectrogram.py tests/logic_verification/gui/test_spectrogram_integration.py tests/logic_verification/gui/test_compact_modes.py`
- `./.venv/bin/python scripts/check_ui_size_limits.py`