### PR TITLE
Add split mode to spectrum analyzer

### DIFF
--- a/src/gui/widgets/spectrum_analyzer.py
+++ b/src/gui/widgets/spectrum_analyzer.py
@@ -26,6 +26,7 @@ from typing import List
 from src.core.comparison_manager import ComparisonTrace
 from src.gui.widgets.compactable_interface import CompactableWidgetInterface
 from src.gui.widgets.comparable_interface import ComparableWidgetInterface
+from src.gui.widgets.splittable_interface import SplittableWidgetInterface
 
 
 logger = logging.getLogger(__name__)
@@ -628,13 +629,19 @@ class SpectrumAnalyzer(MeasurementModule):
         }
 
 
-class SpectrumAnalyzerWidget(QWidget, CompactableWidgetInterface, ComparableWidgetInterface):
+class SpectrumAnalyzerWidget(
+    QWidget,
+    CompactableWidgetInterface,
+    ComparableWidgetInterface,
+    SplittableWidgetInterface,
+):
     _SI_PREFIXES = {-15: "f", -12: "p", -9: "n", -6: "µ", -3: "m", 0: "", 3: "k", 6: "M", 9: "G"}
 
     def __init__(self, module: SpectrumAnalyzer):
         QWidget.__init__(self)
         CompactableWidgetInterface.__init__(self)
         ComparableWidgetInterface.__init__(self)
+        SplittableWidgetInterface.__init__(self)
         self.module = module
 
         # Cache variables for plot comparison
@@ -646,6 +653,25 @@ class SpectrumAnalyzerWidget(QWidget, CompactableWidgetInterface, ComparableWidg
         self.timer = QTimer()
         self.timer.timeout.connect(self.update_plot)
         self.timer.setInterval(30)
+
+    def get_display_widget(self) -> QWidget:
+        """Return the information labels and spectrum plot for split mode."""
+        return self.display_widget
+
+    def get_control_widget(self) -> QWidget:
+        """Return the analysis settings panel for split mode."""
+        return self.controls_group
+
+    def restore_split_panels(self) -> None:
+        """Restore the normal top-controls, bottom-display layout after reattachment."""
+        layout = self.layout()
+        if layout is None:
+            return
+
+        layout.addWidget(self.controls_group)
+        layout.addWidget(self.display_widget, stretch=1)
+        self.controls_group.show()
+        self.display_widget.show()
 
     def init_ui(self):
         layout = QVBoxLayout()
@@ -814,6 +840,10 @@ class SpectrumAnalyzerWidget(QWidget, CompactableWidgetInterface, ComparableWidg
         self.controls_group.setLayout(main_controls_layout)
         layout.addWidget(self.controls_group)
 
+        self.display_widget = QWidget()
+        display_layout = QVBoxLayout(self.display_widget)
+        display_layout.setContentsMargins(0, 0, 0, 0)
+
         # --- Info Display ---
         info_layout = QHBoxLayout()
 
@@ -828,7 +858,7 @@ class SpectrumAnalyzerWidget(QWidget, CompactableWidgetInterface, ComparableWidg
         info_layout.addWidget(self.cursor_label)
 
         info_layout.addStretch()
-        layout.addLayout(info_layout)
+        display_layout.addLayout(info_layout)
 
         # --- Plot ---
         self.plot_widget = pg.PlotWidget()
@@ -888,7 +918,8 @@ class SpectrumAnalyzerWidget(QWidget, CompactableWidgetInterface, ComparableWidg
 
         self.plot_widget.setClipToView(True)
 
-        layout.addWidget(self.plot_widget)
+        display_layout.addWidget(self.plot_widget)
+        layout.addWidget(self.display_widget, stretch=1)
         self.setLayout(layout)
 
     def apply_min_max_envelope(self, freqs, magnitude, x_range_log, width_px):
@@ -1434,7 +1465,9 @@ class SpectrumAnalyzerWidget(QWidget, CompactableWidgetInterface, ComparableWidg
     def update_compact_layout(self):
         compact = self.is_compact_mode()
         if hasattr(self, "controls_group"):
-            self.controls_group.setHidden(compact)
+            is_split = self.controls_group.parent() is not self
+            if not is_split:
+                self.controls_group.setHidden(compact)
         if hasattr(self, "overall_label"):
             self.overall_label.setHidden(compact)
         if hasattr(self, "cursor_label"):

--- a/tests/benchmarks/gui/benchmark_spectrum_analyzer_split.py
+++ b/tests/benchmarks/gui/benchmark_spectrum_analyzer_split.py
@@ -1,0 +1,251 @@
+"""Manual State A/State C rendering benchmark for Spectrum Analyzer.
+
+Run from the repository root. This intentionally is not a pytest performance
+assertion because GUI timing on shared CI runners is too noisy for a stable gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from statistics import median
+from unittest.mock import MagicMock
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+import numpy as np
+from PyQt6.QtWidgets import QApplication
+
+from src.gui.widgets.detachable_wrapper import DetachableWidgetWrapper
+from src.gui.widgets.spectrum_analyzer import SpectrumAnalyzer, SpectrumAnalyzerWidget
+
+
+@dataclass(frozen=True)
+class BenchmarkCase:
+    name: str
+    bins: int
+    channel_mode: str = "Average"
+    octave_smoothing: str = "None"
+    peak_hold: bool = False
+    rta_mode: bool = False
+    iterations: int = 30
+    warmup: int = 5
+
+
+@dataclass(frozen=True)
+class BenchmarkResult:
+    state: str
+    case: str
+    median_ms: float
+    p95_ms: float
+    viewport_width: float
+    viewport_height: float
+    rendered_points: int
+
+
+CASES = (
+    BenchmarkCase("interactive", bins=2049, iterations=60, warmup=10),
+    BenchmarkCase("dense-dual-peak", bins=32769, channel_mode="Dual", peak_hold=True),
+    BenchmarkCase("large-envelope", bins=524289, iterations=8, warmup=2),
+    BenchmarkCase(
+        "rta-third-octave",
+        bins=32769,
+        octave_smoothing="1/3 Octave",
+        rta_mode=True,
+        iterations=15,
+        warmup=3,
+    ),
+)
+
+
+def _make_engine() -> MagicMock:
+    engine = MagicMock()
+    engine.sample_rate = 48000
+    engine.calibration = MagicMock()
+    engine.calibration.input_sensitivity = 1.0
+    engine.calibration.output_gain = 1.0
+    engine.calibration.get_input_offset_db.return_value = 0.0
+    engine.calibration.get_spl_offset_db.return_value = None
+    engine.register_callback.return_value = 1
+    return engine
+
+
+def _configure_case(module: SpectrumAnalyzer, case: BenchmarkCase) -> None:
+    freqs = np.linspace(0.0, 24000.0, case.bins, dtype=np.float64)
+    base = -72.0 + 8.0 * np.sin(np.linspace(0.0, 30.0, case.bins, dtype=np.float64))
+    if case.channel_mode == "Dual":
+        magnitude = np.column_stack((base, base - 3.0))
+    else:
+        magnitude = base
+
+    peak_magnitude = magnitude.copy() if case.peak_hold else None
+    payload = {
+        "freqs": freqs,
+        "magnitude": magnitude,
+        "overall_weighted_db": -24.0,
+        "peak_magnitude": peak_magnitude,
+    }
+
+    module.is_running = True
+    module.analysis_mode = "Spectrum"
+    module.channel_mode = case.channel_mode
+    module.octave_smoothing = case.octave_smoothing
+    module.peak_hold = case.peak_hold
+    module.rta_mode = case.rta_mode
+    module.process_queue = lambda: None
+    module.compute_spectrum = lambda: payload
+
+
+def _resize_for_plot_size(
+    app: QApplication,
+    host,
+    widget: SpectrumAnalyzerWidget,
+    target_width: int = 1000,
+    target_height: int = 520,
+) -> tuple[float, float]:
+    host.resize(1200, 900)
+    host.show()
+    app.processEvents()
+    for _ in range(5):
+        current_width = float(widget.plot_widget.plotItem.vb.width())
+        current_height = float(widget.plot_widget.plotItem.vb.height())
+        if abs(current_width - target_width) <= 1.0 and abs(current_height - target_height) <= 1.0:
+            break
+        host.resize(
+            max(400, host.width() + round(target_width - current_width)),
+            max(300, host.height() + round(target_height - current_height)),
+        )
+        app.processEvents()
+    return (
+        float(widget.plot_widget.plotItem.vb.width()),
+        float(widget.plot_widget.plotItem.vb.height()),
+    )
+
+
+def _rendered_points(widget: SpectrumAnalyzerWidget) -> int:
+    if widget.module.rta_mode:
+        bars = (widget.rta_bar_main, widget.rta_bar_left, widget.rta_bar_right)
+        return max((len(bar.opts.get("x", ())) for bar in bars if bar.isVisible()), default=0)
+
+    curves = (widget.plot_curve, widget.plot_curve_2, widget.peak_curve)
+    return max((len(curve.xData) for curve in curves if curve.xData is not None), default=0)
+
+
+def _object_identities(widget: SpectrumAnalyzerWidget) -> dict[str, int]:
+    names = (
+        "timer",
+        "plot_widget",
+        "proxy",
+        "v_line",
+        "h_line",
+        "plot_curve",
+        "plot_curve_2",
+        "peak_curve",
+        "rta_bar_main",
+        "rta_bar_left",
+        "rta_bar_right",
+        "controls_group",
+        "display_widget",
+    )
+    return {name: id(getattr(widget, name)) for name in names if hasattr(widget, name)}
+
+
+def _measure_case(
+    app: QApplication,
+    host,
+    widget: SpectrumAnalyzerWidget,
+    state: str,
+    case: BenchmarkCase,
+) -> BenchmarkResult:
+    _configure_case(widget.module, case)
+    viewport_width, viewport_height = _resize_for_plot_size(app, host, widget)
+
+    for _ in range(case.warmup):
+        widget.update_plot()
+        app.processEvents()
+
+    samples_ms = []
+    for _ in range(case.iterations):
+        started = time.perf_counter_ns()
+        widget.update_plot()
+        app.processEvents()
+        samples_ms.append((time.perf_counter_ns() - started) / 1_000_000.0)
+
+    return BenchmarkResult(
+        state=state,
+        case=case.name,
+        median_ms=median(samples_ms),
+        p95_ms=float(np.percentile(samples_ms, 95)),
+        viewport_width=viewport_width,
+        viewport_height=viewport_height,
+        rendered_points=_rendered_points(widget),
+    )
+
+
+def _print_results(results: list[BenchmarkResult]) -> None:
+    print("state,case,median_ms,p95_ms,viewport_width,viewport_height,rendered_points")
+    for result in results:
+        print(
+            f"{result.state},{result.case},{result.median_ms:.3f},{result.p95_ms:.3f},"
+            f"{result.viewport_width:.1f},{result.viewport_height:.1f},{result.rendered_points}"
+        )
+
+    by_key = {(result.state, result.case): result for result in results}
+    for case in CASES:
+        normal = by_key.get(("A", case.name))
+        split = by_key.get(("C", case.name))
+        if normal is None or split is None:
+            continue
+        median_limit = normal.median_ms + max(normal.median_ms * 0.05, 0.2)
+        p95_limit = normal.p95_ms + max(normal.p95_ms * 0.05, 0.2)
+        status = "PASS" if split.median_ms <= median_limit and split.p95_ms <= p95_limit else "REVIEW"
+        print(
+            f"{status}: {case.name} A->C "
+            f"median={split.median_ms - normal.median_ms:+.3f} ms, "
+            f"p95={split.p95_ms - normal.p95_ms:+.3f} ms"
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--state-a-only",
+        action="store_true",
+        help="Measure only the current normal hierarchy (used for the pre-change baseline).",
+    )
+    args = parser.parse_args()
+
+    app = QApplication.instance() or QApplication([])
+    module = SpectrumAnalyzer(_make_engine())
+    widget = SpectrumAnalyzerWidget(module)
+    wrapper = DetachableWidgetWrapper(widget, "Spectrum Analyzer Benchmark")
+    identities = _object_identities(widget)
+
+    results = [_measure_case(app, wrapper, widget, "A", case) for case in CASES]
+
+    if not args.state_a_only and wrapper.is_splittable:
+        wrapper.split()
+        app.processEvents()
+        if identities != _object_identities(widget):
+            raise AssertionError("Split recreated a performance-sensitive object")
+        results.extend(
+            _measure_case(app, wrapper.split_display_window, widget, "C", case) for case in CASES
+        )
+
+        wrapper.reattach_all()
+        app.processEvents()
+        if identities != _object_identities(widget):
+            raise AssertionError("Reattach recreated a performance-sensitive object")
+
+    _print_results(results)
+    wrapper.close()
+    app.processEvents()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/logic_verification/gui/test_spectrum_analyzer_split.py
+++ b/tests/logic_verification/gui/test_spectrum_analyzer_split.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+from PyQt6 import sip
+from PyQt6.QtWidgets import QWidget
+
+from src.gui.widgets.detachable_wrapper import DetachableWidgetWrapper
+from src.gui.widgets.spectrum_analyzer import SpectrumAnalyzer, SpectrumAnalyzerWidget
+from src.gui.widgets.splittable_interface import SplittableWidgetInterface
+
+
+@pytest.fixture
+def spectrum_widget(qapp):
+    engine = MagicMock()
+    engine.sample_rate = 48000
+    engine.calibration = MagicMock()
+    engine.calibration.input_sensitivity = 1.0
+    engine.calibration.output_gain = 1.0
+    engine.calibration.get_input_offset_db.return_value = 0.0
+    engine.calibration.get_spl_offset_db.return_value = None
+    engine.register_callback.return_value = 1
+
+    widget = SpectrumAnalyzerWidget(SpectrumAnalyzer(engine))
+    yield widget
+    if not sip.isdeleted(widget):
+        widget.timer.stop()
+        widget.close()
+        widget.deleteLater()
+    qapp.processEvents()
+
+
+@pytest.fixture
+def spectrum_wrapper(spectrum_widget, qapp):
+    wrapper = DetachableWidgetWrapper(spectrum_widget, "Spectrum Analyzer")
+    wrapper.show()
+    yield wrapper
+    if not sip.isdeleted(wrapper):
+        if wrapper.is_split:
+            wrapper.reattach_all()
+        elif wrapper.is_detached:
+            wrapper.reattach()
+        spectrum_widget.setParent(None)
+        wrapper.close()
+        wrapper.deleteLater()
+    qapp.processEvents()
+
+
+def _performance_objects(widget: SpectrumAnalyzerWidget) -> dict[str, object]:
+    names = (
+        "timer",
+        "plot_widget",
+        "proxy",
+        "v_line",
+        "h_line",
+        "plot_curve",
+        "plot_curve_2",
+        "peak_curve",
+        "rta_bar_main",
+        "rta_bar_left",
+        "rta_bar_right",
+        "controls_group",
+        "display_widget",
+    )
+    return {name: getattr(widget, name) for name in names}
+
+
+def _configure_live_result(widget: SpectrumAnalyzerWidget) -> None:
+    freqs = np.linspace(0.0, 24000.0, 4097)
+    magnitude = -60.0 + 4.0 * np.sin(np.linspace(0.0, 20.0, len(freqs)))
+    widget.module.is_running = True
+    widget.module.process_queue = MagicMock()
+    widget.module.compute_spectrum = MagicMock(
+        return_value={
+            "freqs": freqs,
+            "magnitude": magnitude,
+            "overall_weighted_db": -24.0,
+            "peak_magnitude": None,
+        }
+    )
+
+
+def test_spectrum_analyzer_implements_split_interface(spectrum_widget):
+    assert isinstance(spectrum_widget, SplittableWidgetInterface)
+    assert isinstance(spectrum_widget.get_display_widget(), QWidget)
+    assert isinstance(spectrum_widget.get_control_widget(), QWidget)
+    assert spectrum_widget.get_display_widget() is spectrum_widget.display_widget
+    assert spectrum_widget.get_control_widget() is spectrum_widget.controls_group
+
+
+def test_split_live_update_and_reattach_preserve_rendering_objects(spectrum_widget, spectrum_wrapper, qtbot):
+    wrapper = spectrum_wrapper
+    objects_before = _performance_objects(spectrum_widget)
+    original_layout = spectrum_widget.layout()
+
+    spectrum_widget.timer.start()
+    assert spectrum_widget.timer.isActive()
+
+    wrapper.split()
+    qtbot.wait(1)
+
+    assert wrapper.is_split
+    assert spectrum_widget.display_widget.parent() is wrapper.split_display_window
+    assert spectrum_widget.controls_group.parent() is wrapper.split_control_window
+    assert spectrum_widget.timer.isActive()
+    assert _performance_objects(spectrum_widget) == objects_before
+
+    spectrum_widget.set_compact_mode(True)
+    assert not spectrum_widget.controls_group.isHidden()
+    assert spectrum_widget.overall_label.isHidden()
+    assert spectrum_widget.cursor_label.isHidden()
+
+    spectrum_widget.avg_slider.setValue(50)
+    assert spectrum_widget.module.averaging == pytest.approx(0.5)
+
+    _configure_live_result(spectrum_widget)
+    spectrum_widget.update_plot()
+    spectrum_widget.module.process_queue.assert_called_once_with()
+    spectrum_widget.module.compute_spectrum.assert_called_once_with()
+    assert spectrum_widget.plot_curve.xData is not None
+    assert len(spectrum_widget.plot_curve.xData) > 0
+
+    wrapper.reattach_all()
+    qtbot.wait(1)
+
+    assert not wrapper.is_split
+    assert spectrum_widget.timer.isActive()
+    assert _performance_objects(spectrum_widget) == objects_before
+    assert spectrum_widget.display_widget.parent() is spectrum_widget
+    assert spectrum_widget.controls_group.parent() is spectrum_widget
+    assert original_layout.itemAt(0).widget() is spectrum_widget.controls_group
+    assert original_layout.itemAt(1).widget() is spectrum_widget.display_widget
+    assert not spectrum_widget.is_compact_mode()
+    assert not spectrum_widget.overall_label.isHidden()
+    assert not spectrum_widget.cursor_label.isHidden()
+
+
+def test_closing_one_split_window_restores_state_a(spectrum_widget, spectrum_wrapper, qtbot):
+    wrapper = spectrum_wrapper
+    wrapper.split()
+    qtbot.wait(1)
+
+    wrapper.split_control_window.close()
+    qtbot.wait(1)
+
+    assert not wrapper.is_split
+    assert wrapper.split_display_window is None
+    assert wrapper.split_control_window is None
+    assert spectrum_widget.controls_group.parent() is spectrum_widget
+    assert spectrum_widget.display_widget.parent() is spectrum_widget
+
+
+def test_detached_state_can_transition_to_split(spectrum_widget, spectrum_wrapper, qtbot):
+    wrapper = spectrum_wrapper
+
+    wrapper.detach()
+    qtbot.wait(1)
+    assert wrapper.is_detached
+
+    wrapper.split()
+    qtbot.wait(1)
+
+    assert not wrapper.is_detached
+    assert wrapper.is_split
+    assert spectrum_widget.display_widget.parent() is wrapper.split_display_window
+    assert spectrum_widget.controls_group.parent() is wrapper.split_control_window
+
+    wrapper.reattach_all()
+    spectrum_widget.last_freqs = np.array([20.0, 1000.0])
+    spectrum_widget.last_mags = np.array([-40.0, -20.0])
+    assert spectrum_widget.get_comparable_data()


### PR DESCRIPTION
## Summary

- add `SplittableWidgetInterface` support to `SpectrumAnalyzerWidget`
- separate the existing controls and display hierarchy without recreating the plot, curves, RTA bars, signal proxy, or refresh timer
- keep the controls window visible when compact mode is enabled during split mode
- add split lifecycle, live update, object identity, and detached-to-split regression tests
- add a manual State A/State C rendering benchmark with matched viewport dimensions

## Impact

Spectrum Analyzer can now use the existing Split state to place its display and controls in independent windows. The rendering hot path and 30 ms update interval are unchanged.

## Validation

- `1019 passed, 6 skipped, 29 subtests passed`
- targeted split/regression suite: `19 passed`
- Ruff and `git diff --check`: passed
- UI size limit verification: passed
- matched-viewport performance benchmark: all four cases passed the review threshold, with identical State A/State C rendered point counts
