### PR TITLE
Translate and verify technical documentation

### DIFF
--- a/tech_docs/implementation/feedforward_compensation.md
+++ b/tech_docs/implementation/feedforward_compensation.md
@@ -1,125 +1,183 @@
-# Hammerstein Feedforward Distortion Compensation (Iterative LICFF)
+# Hammerstein Feedforward Compensation (LICFF)
 
-This document details the feedforward distortion compensation algorithm based on the Hammerstein model. It is designed to linearize a nonlinear system (such as an audio power amplifier or speaker transducer) by applying a predistorted compensation signal at the system's input. The implementation details are based on `scratch/test_ff_compensation_simulation.py`.
+This document describes the current `LICFFEngine` implementation used by the Feedforward Compensator. LICFF means Linear-Inverse Compensated Feedforward: the engine first compensates the linear model response, then iteratively subtracts an input-referred estimate of the modeled nonlinear output.
 
-## Overview
+The implementation is in [`src/gui/widgets/feedforward_compensator.py`](../../src/gui/widgets/feedforward_compensator.py). It operates on a loaded forward Parallel Hammerstein model, such as the JSON exported by the Nonlinear Analyzer.
 
-A Hammerstein system consists of a static nonlinearity followed by a linear dynamic system. In many physical systems, the dominant distortion is well-approximated by this structure.
+## 1. Model representation
 
-To linearize such a system, we inject a compensation signal $u_{comp}$ such that the system output $y$ is as close as possible to the target linear response $y_{ref} = L(u_{in})$.
+The loader requires five time-domain kernels: `h1` through `h5`. In the current implementation they are used directly as power-series kernels:
 
-The **Iterative Linear-Inverse Compensated Feedforward (Iterative LICFF)** algorithm achieves this by iteratively estimating the nonlinear distortion components and projecting them back to the input side through a regularized linear inverse filter.
+$$
+q_0=0,
+\qquad
+q_p=h_p\quad (p=1,\ldots,5).
+$$
 
----
+There is no Chebyshev-to-power-series conversion in `LICFFEngine`. This is an important distinction from the amplitude-separation mathematics used by the Nonlinear Analyzer: the feedforward engine expects the exported kernels in the representation already used by its forward model.
 
-## 1. Model Representation
+An optional relative threshold can zero high-order kernels whose peak is below the selected fraction of the `h1` peak. The threshold is applied before scaling.
 
-The system is characterized using a **Parallel Hammerstein model** with kernels up to the 5th order ($h_1$ to $h_5$), typically measured using methods like Synchronized Swept-Sine (SSS).
+### Kernel normalization
 
-### Chebyshev to Power Series Conversion
+The engine computes the peak magnitude of the linear kernel spectrum:
 
-The measured kernels $h_1 \dots h_5$ represent coefficients of Chebyshev polynomials (which are orthogonal under sinusoidal excitation). To facilitate arbitrary signal simulation, we convert these Chebyshev coefficients into standard power series kernels $q_0 \dots q_5$:
+$$
+G_{\mathrm{scale}}=\max_f|Q_1(f)|.
+$$
 
-$$ q_0 = -0.5 h_2 + 0.125 h_4 $$
-$$ q_1 = h_1 - 0.75 h_3 + 0.3125 h_5 $$
-$$ q_2 = h_2 - h_4 $$
-$$ q_3 = h_3 - 1.25 h_5 $$
-$$ q_4 = h_4 $$
-$$ q_5 = h_5 $$
+If that value is near zero, it falls back to 1. All kernels are divided by this scale before the FFT buffers are built:
 
-Here:
+$$
+q_{p,\mathrm{sc}}=q_p/G_{\mathrm{scale}}.
+$$
 
-* $q_1(t)$ represents the **true linear dynamic response** (impulse response).
-* $q_2 \dots q_5$ represent the nonlinear power series kernels.
-* $q_0$ represents the static DC offset kernel.
+The scaled `q0` sum is retained as a constant output offset. For models exported by the current Nonlinear Analyzer, `q0` is initialized to zero.
 
-### Normalization
+## 2. Frequency-domain model and anti-aliasing
 
-To prevent numerical instability and ensure consistent scaling, the kernels are normalized by the peak frequency response magnitude of the linear kernel $q_1$:
+For an input block $x$, the forward model forms the linear term directly and evaluates powers $x^2$ through $x^5$ after oversampling by $L=8$ through frequency-domain zero-padding:
 
-$$ G_{scale} = \max_f |Q_1(f)| $$
-$$ q_{p, sc} = \frac{q_p}{G_{scale}} \quad (p = 0 \dots 5) $$
+$$
+Y(f)=X(f)Q_1(f)+
+\sum_{p=2}^{5}\mathcal{F}\{x(t)^p\}_{\mathrm{dealiased}}Q_p(f).
+$$
 
-All subsequent calculations are performed on these scaled kernels.
+The oversampled signal is transformed to the time domain, raised to the required power, transformed back, and truncated to the original positive-frequency bins. The modeled output is:
 
----
+$$
+y_{\mathrm{model}}(t)=\mathcal{F}^{-1}\{Y(f)\}+\sum_nq_{0,\mathrm{sc}}[n].
+$$
 
-## 2. Forward Model Simulation
+The `nonlinear_spectrum()` helper omits the linear term and returns only orders 2–5 plus the constant offset when converted back to time domain. The Nyquist bin is forced to be real before inverse transformation.
 
-The output $y(t)$ of the Hammerstein model for a given input $x(t)$ is computed in the frequency domain as:
+## 3. Inverse-filter design
 
-$$ y(t) = \mathcal{F}^{-1} \left\{ \sum_{p=0}^{5} \mathcal{F}\{x(t)^p\} \cdot Q_p(f) \right\} $$
+The engine builds length-dependent FFT buffers for the model kernels and an active-band filter. The active band defaults to 60 Hz–17 kHz and has cosine transitions:
 
-### Anti-Aliasing (Oversampled Power Evaluation)
+- Below `f_min`, the transition runs from 0 at 10 Hz to 1 at `f_min`.
+- Above `f_max`, the transition runs to 0 at `min(0.95 * Nyquist, 1.2 * f_max)`.
 
-Calculating $x(t)^p$ in discrete time generates high-frequency components that can cause aliasing if they exceed the Nyquist frequency ($f_s / 2$). To prevent this:
+Let $B(f)$ be this band filter and $A_1(f)=|Q_1(f)|$. Optional octave smoothing changes the magnitude used for inversion but preserves the phase of $Q_1$:
 
-1. The input signal $x(t)$ is oversampled by a factor $L = 8$ via zero-padding in the frequency domain.
-2. The power $x_{up}(t)^p$ is computed in the oversampled time domain.
-3. The spectrum is filtered and downsampled back to the original sample rate before multiplying with the kernel frequency response $Q_p(f)$.
+$$
+\widetilde{A}_1(f)=
+\begin{cases}
+\text{smoothed magnitude of }Q_1(f), & \text{if smoothing is enabled},\\
+A_1(f), & \text{otherwise}.
+\end{cases}
+$$
 
----
+The regularized raw inverse is:
 
-## 3. Linear Inverse Filter ($F_{inv}$) Design
+$$
+F_{\mathrm{raw}}(f)=
+\frac{Q_1^*(f)}{|Q_1(f)|}
+\frac{\widetilde{A}_1(f)}{\widetilde{A}_1(f)^2+\epsilon_f(f)},
+$$
 
-The linear inverse filter $F_{inv}$ maps an output-referred distortion signal back to the input. It is the regularized inverse of the linear kernel $Q_1(f)$:
+where the first factor preserves the conjugate phase and $\epsilon_f$ is:
 
-$$ F_{inv}(f) = \frac{Q_1^*(f)}{|Q_1(f)|^2 + \epsilon_f(f)} \cdot H_{bp}(f) $$
+$$
+\epsilon_f(f)=\epsilon_{\mathrm{in}}+
+(0.5-\epsilon_{\mathrm{in}})(1-B(f)).
+$$
 
-Where:
+The regularization mode determines $\epsilon_{\mathrm{in}}$:
 
-* $Q_1^*(f)$ is the complex conjugate of $Q_1(f)$.
-* $H_{bp}(f)$ is a bandpass filter (`bp_filter`) restricting the inversion to the active band of the transducer (e.g., 60 Hz to 17 kHz). Inversion outside this band is restricted to avoid amplifying noise or out-of-band signals.
-* $\epsilon_f(f)$ is a frequency-dependent regularization parameter (Tikhonov regularization) that prevents extreme gains at frequencies where the response is weak (e.g., notches or band edges):
-  $$ \epsilon_f(f) = \epsilon_{in} + (\epsilon_{out} - \epsilon_{in}) \cdot (1 - H_{bp}(f)) $$
-  With $\epsilon_{in} = 10^{-6}$ inside the passband, and $\epsilon_{out} = 0.5$ in the transition/stopbands.
+- `auto_broadband`: solve for a 3 dB maximum passband boost.
+- `auto_tones`: solve for a 20 dB maximum passband boost.
+- `manual_boost`: solve for the user-selected maximum boost in dB.
+- `manual_tikhonov`: use the user-selected Tikhonov value directly.
 
----
+The nonlinear feedback filter is active only inside the band:
 
-## 4. Compensation Algorithm (Iterative LICFF)
+$$
+F_{\mathrm{inv,nl}}(f)=F_{\mathrm{raw}}(f)B(f).
+$$
 
-Instead of using a complex analytical inverse of the Hammerstein nonlinearity (which is mathematically difficult and prone to instability), the algorithm uses an iterative feedback-like structure to compute the predistorted input $u_{comp}$.
+The linear filter has a selectable out-of-band policy:
 
-Let the target linear output be:
-$$ y_{ref} = L(u_{in}) = \mathcal{F}^{-1}\{ \mathcal{F}\{u_{in}\} \cdot Q_1 \} $$
+$$
+F_{\mathrm{inv,lin}}(f)=
+\begin{cases}
+F_{\mathrm{raw}}(f)B(f)+F_{\mathrm{thru}}(f)(1-B(f)), & \texttt{bypass\_aligned},\\
+F_{\mathrm{raw}}(f)B(f)+1\cdot(1-B(f)), & \texttt{bypass\_pure},\\
+F_{\mathrm{raw}}(f)B(f), & \texttt{cut},
+\end{cases}
+$$
 
-### Step-by-Step Iterative Loop
+where:
 
-1. **Initialization ($k=0$):**
-   Initialize the compensated signal as the bandpass-filtered target input:
-   $$ u_{comp}^{(0)} = u_{in} * h_{bp} $$
+$$
+F_{\mathrm{thru}}(f)=\frac{Q_1^*(f)}{|Q_1(f)|}
+$$
 
-2. **Iteration ($k = 1 \dots N_{iters}$):**
-   For each iteration (typically $N_{iters} = 3$ is sufficient):
+is the unit-gain, phase-aligned bypass.
 
-   a. **Estimate Nonlinear Distortion:**
-      Compute the nonlinear distortion components $y_{nl}$ produced by the current compensated input $u_{comp}^{(k-1)}$:
-      $$ y_{nl} = \text{NonlinearForwardModel}(u_{comp}^{(k-1)}) $$
-      $$ y_{nl}(t) = \mathcal{F}^{-1} \left\{ \mathcal{F}\{1\} \cdot Q_0(f) + \sum_{p=2}^{5} \mathcal{F}\{(u_{comp}^{(k-1)})^p\} \cdot Q_p(f) \right\} $$
+## 4. LICFF compensation algorithm
 
-   b. **Project Distortion to Input:**
-      Filter the output-referred distortion $y_{nl}$ through the linear inverse filter $F_{inv}$ to estimate the input-referred compensation signal $y_{comp\_nl}$:
-      $$ y_{comp\_nl} = \mathcal{F}^{-1} \left\{ \mathcal{F}\{y_{nl}\} \cdot F_{inv} \right\} $$
+Given an input block $u_{\mathrm{in}}$, the engine first computes the base linear compensation:
 
-   c. **Update Compensated Signal:**
-      Subtract the compensation signal from the target input to pre-compensate for the upcoming distortion:
-      $$ u_{comp}^{(k)} = u_{in} * h_{bp} - y_{comp\_nl} $$
+$$
+u_{\mathrm{comp,lin}}=
+\mathcal{F}^{-1}\{\mathcal{F}\{u_{\mathrm{in}}\}F_{\mathrm{inv,lin}}\}.
+$$
 
-   d. **Stability Limiter (Clipping):**
-      To prevent the iteration from running into positive feedback and causing numerical blowup, the output is clipped to a safe range:
-      $$ u_{comp}^{(k)} = \max(-V_{limit}, \min(V_{limit}, u_{comp}^{(k)})) $$
-      *(Typically $V_{limit} \approx 1.5$ in simulation)*
+When `bypass_linear_eq=True`, the base is simply $u_{\mathrm{in}}$. This is the GUI's “Nonlinear Only (No Linear EQ)” mode.
 
-3. **Output Generation:**
-   The final predistorted signal $u_{comp}^{(N_{iters})}$ is sent to the physical system.
+For the ordinary nonlinear path:
 
----
+1. Initialize $u_{\mathrm{comp}}$ with $u_{\mathrm{comp,lin}}$ and clip it to $[-V_{\mathrm{limit}},V_{\mathrm{limit}}]$.
+2. Evaluate the nonlinear spectrum for the current $u_{\mathrm{comp}}$:
 
-## 5. Performance Metrics
+   $$
+   Y_{\mathrm{nl}}(f)=
+   \sum_{p=2}^{5}\mathcal{F}\{u_{\mathrm{comp}}^p\}_{\mathrm{dealiased}}Q_p(f).
+   $$
 
-To evaluate the compensation performance, two primary metrics are used:
+3. Project the output-referred nonlinear component back to the input with the nonlinear inverse:
 
-* **Total Harmonic Distortion (THD)**: Measures the suppression of specific harmonics (e.g., 2nd to 5th) under single-tone excitation.
-* **Signal-to-Distortion Ratio (SDR)**: Measures the alignment between the compensated system output and the ideal linear response for arbitrary signals (e.g., multi-tone or broadband noise). Calculated as:
-  $$ \text{SDR} = 20 \log_{10} \frac{\text{RMS}(y_{ref})}{\text{RMS}(y_{out, scaled} - y_{ref})} $$
-  Where $y_{out, scaled}$ is time-aligned and gain-normalized relative to $y_{ref}$ to ensure linear gains/delays do not penalize the metric.
+   $$
+   y_{\mathrm{comp,nl}}=
+   \mathcal{F}^{-1}\{Y_{\mathrm{nl}}F_{\mathrm{inv,nl}}\}.
+   $$
+
+4. Update and clip:
+
+   $$
+   u_{\mathrm{comp,raw}}=u_{\mathrm{comp,lin}}-y_{\mathrm{comp,nl}},
+   \qquad
+   u_{\mathrm{comp}}=\operatorname{clip}(u_{\mathrm{comp,raw}},-V_{\mathrm{limit}},V_{\mathrm{limit}}).
+   $$
+
+If `iterative=False`, the implementation performs one nonlinear update. If `iterative=True`, it repeats the update `iters` times. The compensation function's default clip limit is 1.5, while the current GUI simulation and WAV-export paths pass a clip limit of 2.0.
+
+The `linear_only=True` path returns the base linear compensation after clipping and performs no nonlinear update. The GUI exposes three modes:
+
+- `Linear & Nonlinear`: use the linear inverse and nonlinear correction.
+- `Nonlinear Only (No Linear EQ)`: bypass linear equalization but retain nonlinear correction.
+- `Linear Only`: apply only the linear inverse.
+
+## 5. Stability and processing details
+
+The engine marks a block as unstable when an intermediate result contains NaN or infinity, or exceeds ten times the clip limit in magnitude. The caller may either report this condition or abort export using the GUI's instability option. Clipping counts are also tracked per channel.
+
+Offline WAV processing uses 65536-sample blocks with 4096 samples of overlap. Input audio is resampled to the model sample rate when the rates differ by more than 1 Hz. The output is written at the model rate, and the exporter can optionally RMS-match the output to the original.
+
+The GUI defaults are an active band of 60 Hz–17 kHz, no linear smoothing, automatic 3 dB broadband regularization, iterative compensation disabled, and three iterations when iterative mode is enabled. These are UI defaults; the engine API accepts other values.
+
+## 6. What the current UI measures
+
+The simulation tab compares three forward-model spectra:
+
+- the uncompensated input,
+- the compensated input,
+- the ideal linear output from `linear_output()`.
+
+The current LICFF implementation does not calculate the THD and SDR metrics described in older versions of this document. Those metrics should not be treated as values produced by the current Feedforward Compensator.
+
+## 7. Related tests and source files
+
+- [`src/gui/widgets/feedforward_compensator.py`](../../src/gui/widgets/feedforward_compensator.py): `LICFFEngine`, GUI settings, simulation, and offline processing.
+- [`tests/logic_verification/gui/widgets/test_feedforward_compensator.py`](../../tests/logic_verification/gui/widgets/test_feedforward_compensator.py): direct kernel mapping, inverse behavior, regularization modes, clipping, instability handling, and export behavior.

--- a/tech_docs/implementation/kalman_filter.md
+++ b/tech_docs/implementation/kalman_filter.md
@@ -1,80 +1,106 @@
 # Lock-in Frequency Counter: Kalman Filter Implementation
 
-This document details the Kalman Filter implementation used in the Lock-in Frequency Counter module (`src/gui/widgets/lock_in_frequency_counter.py`) to estimate the NCO (Numerically Controlled Oscillator) frequency and its uncertainty.
+This document describes the one-dimensional Kalman filter used by [`src/gui/widgets/lock_in_frequency_counter.py`](../../src/gui/widgets/lock_in_frequency_counter.py) to smooth the NCO frequency while the frequency-locked loop (FLL) is enabled.
 
-## Overview
+## 1. Role of the filter
 
-The goal is to provide a precise and stable frequency readout from a noisy feedback loop (FLL). To achieve this, we use a 1-Dimensional Kalman Filter to estimate the "true" frequency state from the noisy updates provided by the PID controller.
+The frequency counter estimates a frequency deviation from a block of input samples. When FLL lock is enabled, a PID controller converts that deviation into a new NCO-frequency command. The Kalman filter smooths those commands and provides an internal covariance estimate.
 
-We further enhance the visual stability of the readout using a post-filter moving average.
+The filter is not used to produce the unlocked display value: while FLL lock is disabled, the module reports the configured NCO frequency and sets the displayed uncertainty to zero.
 
-## 1. Kalman Filter Model
+## 2. One-dimensional constant-value model
 
-We use a simple **Constant Value Model** (0th order derivative). We assume the true frequency is constant (or slowly varying) and that any rapid changes are due to measurement noise (jitter in the loop).
+The state contains only the NCO frequency:
 
-### State Vector
+$$
+x_k=[f_k].
+$$
 
-$$ x_k = [f_k] $$
-Where $f_k$ is the frequency at time $k$.
+The constant-value prediction is:
 
-### System Model (Prediction)
+$$
+x_{k|k-1}=x_{k-1|k-1},
+\qquad
+P_{k|k-1}=P_{k-1|k-1}+Q.
+$$
 
-We assume the frequency does not change by itself between steps, except for some small process noise (drift).
-$$ x_{k|k-1} = x_{k-1|k-1} $$
-$$ P_{k|k-1} = P_{k-1|k-1} + Q $$
+The PID-updated NCO command is the measurement:
 
-* $P$: Estimation Error Covariance (Uncertainty squared).
-* $Q$: Process Noise Covariance (How much we think the true frequency wanders).
+$$
+z_k=f_{\mathrm{NCO,command}}.
+$$
 
-### Measurement Model (Update)
+The scalar update is:
 
-The PID loop gives us a "new frequency" update, which we treat as a noisy measurement of the true state.
-$$ z_k = f_{PID} $$
-$$ x_k = x_{k|k-1} + K_k (z_k - x_{k|k-1}) $$
-$$ P_k = (1 - K_k) P_{k|k-1} $$
+$$
+K_k=\frac{P_{k|k-1}}{P_{k|k-1}+R},
+$$
 
-Where Kalman Gain $K_k$ is:
-$$ K_k = \frac{P_{k|k-1}}{P_{k|k-1} + R} $$
+$$
+x_k=x_{k|k-1}+K_k(z_k-x_{k|k-1}),
+\qquad
+P_k=(1-K_k)P_{k|k-1}.
+$$
 
-* $R$: Measurement Noise Covariance (How noisy the PID loop is).
+On the first update after construction or reset, the implementation initializes `x` directly from the measurement and sets `P` to `R`. A reset sets the first-run flag and restores `P` to 1.0.
 
-## 2. Adaptive Parameter Estimation
+## 3. Process-noise schedule (`Q`)
 
-To make the filter robust without requiring manual tuning of variance values, we implement adaptive estimation for $Q$ and $R$.
+The UI setting `Avg Count (KF-Q & Display)` controls both the process-noise schedule and the display-history length. With count $N$:
 
-### Q (Process Noise) - "Stiffness"
+$$
+Q=\frac{10^{-6}}{N^2}.
+$$
 
-The Process Noise $Q$ determines how "stiff" the filter is.
+The default count is 10, which gives $Q=10^{-8}$. A count of 100 gives $Q=10^{-10}$. A larger count therefore assumes a more stable NCO, produces stronger Kalman smoothing, and also retains a longer display history. A smaller count responds more quickly to new commands.
 
-* **High Q**: The filter expects the frequency to change rapidly. It trusts new measurements more. Fast response, low smoothing.
-* **Low Q**: The filter expects the frequency to be constant. It ignores short-term fluctuations. Slow response, high smoothing.
+This is a deterministic mapping from the user setting, not an online estimate of process noise.
 
-We map the user-facing **"Avg Count"** setting to $Q$:
-$$ Q \propto \frac{1}{(\text{Avg Count})^2} $$
-Increasing the "Avg Count" makes the filter "stiffer" (smoother).
+## 4. Adaptive measurement noise (`R`)
 
-### R (Measurement Noise) - "Confidence"
+While the FLL is locked, the controller performs the following steps for each valid frequency estimate:
 
-The Measurement Noise $R$ represents the actual jitter in the system. If we assume a fixed $R$ that is too high or too low, our uncertainty estimate ($P$, and thus the displayed digits) will be wrong.
+1. Compute the PID correction from the measured frequency deviation.
+2. Add the correction to the current NCO frequency.
+3. Clamp the command to 20–20,000 Hz.
+4. Append the clamped command to a history buffer with a maximum length of 20.
 
-We estimate $R$ dynamically using the variance of the recent input history (buffer of $N=20$ samples):
-$$ R_k \approx \text{Var}(z_{k-N}...z_k) $$
+After at least two commands are available, the measurement-noise covariance is updated as:
 
-This ensures that:
+$$
+R=\operatorname{Var}(f_{\mathrm{NCO,command,history}})+10^{-12}.
+$$
 
-1. When the loop is unstable/hunting, $R$ increases $\rightarrow$ Filter trusts measurements less $\rightarrow$ Uncertainty ($P$) increases $\rightarrow$ Display shows fewer digits.
-2. When the loop is locked and stable, $R$ decreases $\rightarrow$ Filter tightens $\rightarrow$ Uncertainty ($P$) decreases $\rightarrow$ Display shows more digits.
+Thus, the code estimates the jitter of recent PID/NCO commands, not the variance of the raw audio samples. A hunting loop normally increases `R`, so the Kalman gain decreases. A stable loop normally decreases `R`, so the filter can follow the command more closely.
 
-## 3. Display Smoothing
+## 5. Display averaging and uncertainty
 
-While the Kalman Filter provides the optimal estimate of the state, the raw state estimate $x_k$ can still jitter slightly, which can be annoying for a human reading a digital display.
+The instantaneous Kalman estimate is stored in a second history buffer whose maximum length is the current Avg Count. The UI uses this post-Kalman history for the displayed frequency:
 
-To solve this ("Scientifically Valid Smoothing"), we interpret the text display not as the *instantaneous* state, but as the **statistical mean of the recent state**.
+$$
+f_{\mathrm{display}}=\operatorname{mean}(x_{k-N+1},\ldots,x_k),
+$$
 
-We maintain a history buffer of the Kalman Filter estimates (length = Avg Count):
+$$
+\sigma_{\mathrm{display}}
+ =\operatorname{std}(x_{k-N+1},\ldots,x_k).
+$$
 
-1. **Displayed Value**: $\mu = \text{Mean}(History)$
-2. **Displayed Uncertainty**: $\sigma = \text{StdDev}(History)$
-3. **Decimal Places**: Calculated from $\sigma$ (e.g., if $\sigma = 10^{-4}$, we show roughly 4-5 decimal places).
+The displayed uncertainty label uses $\sigma_{\mathrm{display}}$, the standard deviation of the filtered history. The raw Kalman standard deviation $\sqrt{P_k}$ is also retained internally as `nco_std`, but it is not the value shown in that label.
 
-This provides a readout that is both statistically grounded and visually stable.
+The frequency spin box chooses decimal places from the displayed standard deviation:
+
+$$
+\text{places}=-\lfloor\log_{10}(\sigma_{\mathrm{display}})\rfloor,
+$$
+
+bounded by 0–12 places, with a default of 5 when the standard deviation is zero or unavailable.
+
+## 6. Related smoothing in the plots
+
+The frequency-deviation plot has a separate exponential moving average controlled by a fixed two-second time constant. The plot smoothing slider then optionally applies a simple moving average to the stored plot data. These plot operations are separate from the Kalman filter and from the NCO display-history average.
+
+## 7. Related source and tests
+
+- [`src/gui/widgets/lock_in_frequency_counter.py`](../../src/gui/widgets/lock_in_frequency_counter.py): `KalmanFilter1D`, PID/FLL update path, adaptive `R`, display averaging, and formatting.
+- [`tests/logic_verification/gui/widgets/test_kalman_filter_1d.py`](../../tests/logic_verification/gui/widgets/test_kalman_filter_1d.py): first update, reset, and uncertainty behavior.

--- a/tech_docs/implementation/latency_estimation.md
+++ b/tech_docs/implementation/latency_estimation.md
@@ -1,110 +1,93 @@
-# システムレイテンシーの推定と測定精度検証
+# System Latency Estimation and Measurement Precision
 
-本ドキュメントでは、MeasureLab におけるオーディオ入出力系統の物理的な遅延（ラウンドトリップレイテンシー）の測定手法、その数学的原理、および異なるスイープ信号を用いた実機検証で得られた知見についてまとめます。
+This document describes the latency-estimation paths currently implemented in MeasureLab, the sub-sample peak detector they share, and how the resulting delay is used by the nonlinear analyzer.
 
----
+## 1. Why latency estimation matters
 
-## 1. レイテンシー推定の必要性
+The recorded response is delayed relative to the generated excitation by the audio I/O path, device buffering, and any physical loopback wiring. A delay error becomes a frequency-dependent phase error:
 
-同期正弦波スイープ（SSS: Synchronized Sine Sweep）を用いた非線形システム測定（Hammerstein モデルなどの同定）において、再生信号と録音信号の間の物理的な遅延（レイテンシー）をサンプル未満（サブサンプル）の精度で同定・補正することは極めて重要です。
+$$
+\Delta\phi(f) = -2\pi f\,\Delta t.
+$$
 
-遅延補正が不十分な場合、以下の問題が発生します。
+The error therefore becomes increasingly visible at high frequencies. In a swept-sine measurement, the reference and measured channels must also remain aligned when harmonic impulse responses are gated and separated.
 
-- **位相特性の歪み**: わずかな遅延のズレが周波数の高域において巨大な位相回転（グループ遅延の誤差）として現れます。
-- **高調波成分の分離失敗**: 位相の同期が崩れるため、 Novak の手法に基づく線形応答と高調波応答（$h_1 \sim h_5$）の分離境界が設計値からズレて重なり合い、正確な歪み同定ができなくなります。
+## 2. Implemented calibration paths
 
----
+MeasureLab currently contains two related latency-calibration implementations. They should not be conflated.
 
-## 2. レイテンシー測定のアルゴリズム
+### 2.1 Nonlinear Analyzer calibration
 
-### 2.1. 測定手順
+`NonlinearAnalyzer.calibrate_latency()` in [`src/gui/widgets/nonlinear_analyzer.py`](../../src/gui/widgets/nonlinear_analyzer.py) uses a short logarithmic chirp:
 
-レイテンシー測定は以下の手順で実行されます。
+1. Generate a 0.5 s logarithmic chirp from 20 Hz to 10 kHz at amplitude 0.3.
+2. Append 0.5 s of zeros so that delayed samples can still be recorded.
+3. Play and record the signal in one audio session.
+4. Cross-correlate the selected measurement channel with the time-reversed chirp:
 
-1. **測定用スイープ信号 $s(t)$ の出力**:
-   極めて短時間（デフォルトでは 0.25 秒、位相同期により実際は約 0.475 秒）の Novak SSS スイープを再生します。
-2. **ループバック録音信号 $y(t)$ の取得**:
-   再生と同時に、入力チャンネルからループバックされた音声信号を録音します。
-3. **インパルス応答（IR）の抽出**:
-   録音信号 $y(t)$ と送信信号 $s(t)$ の間で周波数領域デコンボリューションを実行し、システムのインパルス応答 $h(t)$ を抽出します。
-4. **サブサンプルピークの検出**:
-   インパルス応答 $h(t)$ のピーク位置を、FFT アップサンプリング（補間）を用いてサンプル間の小数点以下（サブサンプル精度）まで求めます。
+   $$
+   c[n] = y[n] * \operatorname{reverse}(s)[n].
+   $$
 
-### 2.2. デコンボリューションの数理
+   The implementation computes this with `scipy.signal.fftconvolve(..., mode="full")`.
+5. Detect the correlation peak with `find_subsample_peak()` and convert the lag to seconds. Negative results are clamped to zero.
 
-デコンボリューションは、窓関数の影響や有限長スイープに伴うスペクトルの脈動（Gibbs 振動）をキャンセルするため、周波数領域で正則化（Regularization）を用いて実行します。
+This path uses cross-correlation directly; it does not call `deconvolve_signal()`.
 
-$$H(f) = \frac{Y(f) S^*(f)}{|S(f)|^2 + \epsilon}$$
+### 2.2 Realtime SSS latency measurement
 
-ここで：
+`measure_system_latency()` in [`src/core/realtime_sss_core.py`](../../src/core/realtime_sss_core.py) uses the Novak-style SSS generator from [`src/core/nonlinear_analyzer_core.py`](../../src/core/nonlinear_analyzer_core.py):
 
-- $Y(f)$ は録音信号のFFT
-- $S(f)$ は送信スイープのFFT
-- $S^*(f)$ は $S(f)$ の複素共役
-- $\epsilon$ は正則化パラメータ。分母のゼロ除算を防ぎノイズ増幅を抑制するため、送信信号 of パワースペクトルの最大値に比例して動的に決定します（$\epsilon = 10^{-4} \times \max(|S(f)|^2)$）。
+1. Clamp the calibration band to a start frequency of at least 20 Hz and an end frequency of at least 100 Hz.
+2. Generate an SSS and its analytical inverse filter. The default requested sweep duration is 0.25 s, and the recorder adds a 0.3 s margin.
+3. Play the sweep and record the selected input channel through a temporary audio callback.
+4. Deconvolve the recording with the SSS, then locate the impulse-response peak.
+5. Clamp a negative peak to zero and return the result in samples.
 
-得られた $H(f)$ を逆高速フーリエ変換（IFFT）することで、時間領域のインパルス応答 $h(t)$ を得ます。
+The SSS deconvolution is:
 
-### 2.3. サブサンプルピーク検出の原理
+$$
+H(f) = \frac{Y(f)S^*(f)}{|S(f)|^2 + \epsilon},
+\qquad
+\epsilon = 10^{-4}\max_f |S(f)|^2 + 10^{-12}.
+$$
 
-インパルス応答 $h(t)$ の単純な離散最大値のインデックスでは、サンプリング周期（48 kHz の場合約 20.8 μs）単位の解像度しか得られません。さらなる高精度化のため、以下の手法でサブサンプルピークを検出します。
+The FFT length is the next power of two that is at least the recorded length plus the SSS length.
 
-1. **粗検出**: 離散インパルス応答の絶対値が最大となる整数インデックス $n_{\text{peak}}$ を探索します。
-2. **信号のシフトとクロップ**: ピーク周辺の境界効果を避けるため、ピークが中央（$N/2$）に来るようにロール（循環シフト）し、ピークの前後 16 サンプル（計 32 サンプル）を切り出します。切り出した信号に対して Tukey 窓を乗算し、急激な遮断を滑らかにします。
-3. **DFT アップサンプリング（100倍）**: クロップした 32 サンプルのフーリエ変換 $X(f)$ を計算し、周波数領域で 100 倍のゼロパディング（高域にゼロを挿入）を行って逆変換（IFFT）します。これにより、時間解像度が 100 倍に補間された波形が得られます。
-4. **精密検出**: 補間された波形の最大値インデックスを求め、シフト量を差し戻すことで、$0.01$ サンプル精度の遅延時間（実数値）を同定します。
+## 3. Sub-sample peak detection
 
----
+Both paths use `find_subsample_peak(ir)`:
 
-## 3. スイープ信号による測定性能の比較検証
+1. Find the integer index of the largest absolute impulse-response sample.
+2. Circularly shift the response so that this peak is at the center of the buffer.
+3. Extract a 32-sample window centered on the peak and apply a Tukey window with `alpha=0.25`.
+4. Compute a 32-point DFT, zero-pad it to 100 times the length, and take the inverse DFT.
+5. Locate the maximum of the interpolated magnitude and map it back to the original circular index.
 
-スイープ信号の特性が測定精度と安定性に与える影響を検証するため、全長（22,780 サンプル、0.475 秒）を完全に統一した 3 種類のスイープ波形について、実機（ZOOM UAC-232 アナログ物理ループバック）を用いて繰り返し測定テストを実施しました。
+The returned value is a floating-point sample index with a nominal 0.01-sample grid. This is an interpolation result, not a guarantee of 0.01-sample physical accuracy; noise, bandwidth, and peak shape still determine the actual uncertainty.
 
-### 3.1. 検証結果サマリー
+At 48 kHz, one sample is approximately 20.83 microseconds. The sub-sample result is used to avoid throwing away useful timing information during alignment.
 
-| ノイズレベル (RMS) | スイープの種類 | 平均遅延 (samples) | 標準偏差 $\sigma$ (samples) | 平均 PNR (dB) |
-| :--- | :--- | :--- | :--- | :--- |
-| **0.0 (クリア環境)** | **linear** | 8698.9000 | 0.000000 | 63.46 |
-| | **log (Novak SSS)** | **8698.9800** | **0.000000** | **71.02** |
-| | **hyperbolic** | 8698.5900 | 0.000000 | 52.94 |
-| **0.01 (弱ノイズ)** | **linear** | 8698.8965 | 0.004770 | 62.43 |
-| | **log (Novak SSS)** | **8698.9800** | **0.000000** | **70.05** |
-| | **hyperbolic** | 8698.5880 | 0.004000 | 52.81 |
-| **0.05 (強ノイズ)** | **linear** | 8698.8950 | 0.005000 | 54.74 |
-| | **log (Novak SSS)** | **8698.9765** | **0.004770** | **62.40** |
-| | **hyperbolic** | 8698.5830 | 0.012689 | 50.54 |
+## 4. Applying the calibrated delay
 
-> [!NOTE]
-> **PNR (Peak-to-Noise Ratio)** は、インパルス応答ピークのシャープさを示します。値が高いほどピーク位置が明瞭であることを意味します。
+For single-channel nonlinear measurements, `process_amplitude_responses()` applies the stored delay to every frequency bin:
 
----
+$$
+H_{\mathrm{corr}}(f)
+ = H_{\mathrm{meas}}(f)
+   \exp\left(j2\pi f\frac{\Delta t\,f_s}{f_s}\right)
+ = H_{\mathrm{meas}}(f)\exp(j2\pi f\Delta t).
+$$
 
-## 4. 調査から判明した知見
+Here, `latency_sec` is converted to samples by `latency_sec * sample_rate`. In the two-channel `XFER` and `XFER_REV` modes, the measured response is divided by the reference fundamental, so an independent latency calibration is not required for the relative transfer function.
 
-### 4.1. 双曲線スイープ（Hyperbolic Sweep）の精度低下要因
+## 5. Verification status
 
-当初、「周波数の変化率を非線形にした双曲線スイープがレイテンシー測定精度を向上させないか」という仮説が立てられました。しかし、実証実験の結果、**双曲線スイープは対数スイープやリニアスイープよりも測定精度および安定性が著しく低下する**ことが判明しました。
+The repository contains automated simulations for fractional-sample latency and peak recovery in [`tests/core/test_realtime_sss_core.py`](../../tests/core/test_realtime_sss_core.py). The current source does not contain the linear/logarithmic/hyperbolic sweep experiment or the ZOOM UAC-232 result table that appeared in an earlier version of this document. Those historical values are therefore not presented as current implementation guarantees.
 
-その物理的な原因は以下の通りです。
+## 6. Related source files
 
-1. **高周波帯域におけるエネルギー密度の低下**:
-   双曲線スイープでは、周波数の瞬時遷移速度 $df/dt$ が周波数の 2 乗（$f^2$）に比例します。そのため、高域（特に 10 kHz 以上）を通過する速度が極めて速くなり、高域の信号エネルギー密度が極端に低くなります。
-2. **デコンボリューション時のノイズ増幅**:
-   周波数領域でのデコンボリューション時、分母となる送信信号スペクトル $|S(f)|^2$ の高域ゲインが著しく小さいため、逆フィルタの特性が高域を持ち上げるスロープになります。これにより、物理測定時のアンプやAD/DAコンバーターの背景ノイズ（ホワイトノイズなど）の高域成分が大きく増幅されてしまいます。
-3. **IR波形の歪みによるジッター**:
-   高域ノイズの増幅の結果、インパルス応答のベースライン（背景ノイズ）が激しくうねり、ピーク対ノイズ比（PNR）が対数スイープ比で約 18 dB も悪化します。これがサブサンプル補間時の微小なピーク検出ジッターを誘発し、強ノイズ環境における遅延測定の標準偏差 $\sigma$ が、対数スイープの約 2.7 倍に悪化しました。
-
-### 4.2. 対数スイープ（Novak SSS）が最適である理由
-
-検証結果より、現行 of **対数スイープ（Novak SSS）** は、レイテンシー測定において最も優れた安定性を持つことが確認されました。
-
-1. **SN比の全帯域平滑化**:
-   対数スイープは周波数の対数に比例して遷移するため、エネルギー密度が周波数に反比例する（ピンクノイズと同様の）特性を持ちます。これに対する逆フィルタはオクターブあたり +3 dB（高域を持ち上げるピンクスロープ）となり、元の伝達関数のSN比特性を完璧に等化し、最もシャープなインパルス応答を得ることができます（PNR 71 dB を達成）。
-2. **高調波歪みの分離**:
-   実機の非線形歪み（アンプやスピーカーの歪みなど）成分が、インパルス応答上で線形応答の左側（時間軸における過去方向）に完全に分離されるため、歪み成分が遅延測定用のメインピーク位置に干渉することがありません。
-3. **ノイズ環境下での再現性**:
-   強ノイズ環境下（RMS 0.05）でも、遅延測定値の標準偏差は僅か **0.0048 サンプル**（48 kHz サンプリング時、時間換算で約 **100 ナノ秒**）であり、他の手法を圧倒する測定安定性を示しました。
-
-### 4.3. まとめ
-
-実機検証を通じて、再生時間が等しい場合であっても、対数スイープ（Novak SSS）がインパルス応答の PNR を最大化し、ノイズ環境下での時間方向のジッターを極限まで抑えるために最も合理的かつ数学的に最適化された波形であることが実証されました。よって、現行のレイテンシー測定システムは変更の必要がなく、最高水準の精度が維持されていると言えます。
+- [`src/gui/widgets/nonlinear_analyzer.py`](../../src/gui/widgets/nonlinear_analyzer.py): GUI calibration path and single-channel latency usage.
+- [`src/core/realtime_sss_core.py`](../../src/core/realtime_sss_core.py): realtime SSS latency calibrator.
+- [`src/core/nonlinear_analyzer_core.py`](../../src/core/nonlinear_analyzer_core.py): SSS generation, deconvolution, sub-sample peak detection, and frequency-domain delay correction.
+- [`tests/core/test_realtime_sss_core.py`](../../tests/core/test_realtime_sss_core.py): automated latency and fractional-delay tests.

--- a/tech_docs/implementation/lock_in_amplifier.md
+++ b/tech_docs/implementation/lock_in_amplifier.md
@@ -1,94 +1,120 @@
-# Lock-in Amplifier: Measurement Principles & Limitations
+# Lock-in Amplifier: Measurement Principle and Reference Requirements
 
-This document describes the operating principles of the software Lock-in Amplifier (`src/gui/widgets/lock_in_amplifier.py`) and explains why a hardware reference loopback is strictly required for accurate phase measurements.
+This document describes the software Lock-in Amplifier implemented in [`src/gui/widgets/lock_in_amplifier.py`](../../src/gui/widgets/lock_in_amplifier.py), including its phase reference, demodulation path, and operating modes.
 
-## 1. Measurement Principle
+## 1. Measurement principle
 
-The Lock-in Amplifier extracts the amplitude and phase of a signal at a specific frequency by mixing the input signal with a reference sine wave (Local Oscillator) and integrating the result.
+For a sinusoidal signal
 
-### Dual-Phase Demodulation
+$$
+V_{\mathrm{sig}}(t)=A_{\mathrm{sig}}\cos(\omega t+\phi_{\mathrm{sig}}),
+$$
 
-We use "Dual-Phase" demodulation to recover both magnitude and phase independent of the signal's alignment with the reference.
+the lock-in detector projects the signal onto an orthogonal complex oscillator:
 
-Given an input signal $V_{sig}(t) = A_{sig} \sin(\omega t + \phi_{sig})$ and a reference frequency $\omega$, we generate two orthogonal reference signals:
+$$
+z_{\mathrm{sig}}=2\,\operatorname{mean}\left(V_{\mathrm{sig}}(t)w(t)e^{-j\omega t}\right)/\operatorname{mean}(w),
+$$
 
-* **In-Phase Reference (I):** $\sin(\omega t + \phi_{ref})$
-* **Quadrature Reference (Q):** $\cos(\omega t + \phi_{ref})$
+where the implementation uses a Hann window $w(t)$. The complex result encodes the in-phase and quadrature components:
 
-The mixing process involves multiplying the signal by these references and applying a Low-Pass Filter (LPF) (or averaging over integer cycles):
+$$
+X=\operatorname{Re}(z_{\mathrm{sig}}),
+\qquad
+Y=\operatorname{Im}(z_{\mathrm{sig}}),
+$$
 
-$$ X = \text{Mean}( V_{sig}(t) \cdot \sin(\omega t + \phi_{ref}) ) \propto A_{sig} \cos(\phi_{sig} - \phi_{ref}) $$
-$$ Y = \text{Mean}( V_{sig}(t) \cdot \cos(\omega t + \phi_{ref}) ) \propto A_{sig} \sin(\phi_{sig} - \phi_{ref}) $$
+$$
+R=\sqrt{X^2+Y^2},
+\qquad
+\theta=\operatorname{atan2}(Y,X).
+$$
 
-From $X$ and $Y$, we calculate:
+`R` is the estimated sinusoidal peak magnitude. `theta` is meaningful only relative to the phase reference used to rotate the signal phasor.
 
-* **Magnitude:** $R = \sqrt{X^2 + Y^2} \propto A_{sig}$
-* **Phase:** $\theta = \arctan(Y / X) = \phi_{sig} - \phi_{ref}$
+The detector supports a harmonic ratio $n/d$. The signal is demodulated at:
 
-Ideally, if $\phi_{ref}$ is known and constant (e.g., $\phi_{ref} = 0$), then $\theta$ gives us $\phi_{sig}$.
+$$
+f_{\mathrm{demod}}=f_{\mathrm{ref}}\frac{n}{d}.
+$$
 
-## 2. The "Undefined Phase" Problem
+The GUI permits numerator and denominator values from 1 to 63.
 
-In a standard PC audio environment, the Operating System and Audio Driver (ALSA/PulseAudio/WASAPI) manage the input and output streams. Crucially, **there is no guaranteed fixed phase relationship between the Output Buffer (DAC) and the Input Buffer (ADC).**
+## 2. Reference-channel processing
 
-### Why this happens
+The module always reads a signal channel and a reference channel from its input ring buffer. The default channels are signal = Left (Ch 1) and reference = Right (Ch 2). A reference RMS level below 0.001 (approximately -60 dBFS for a full-scale reference) is treated as no reference: the displayed magnitude, phase, X, Y, and reference frequency are cleared and the averaging history is discarded.
 
-1. **Buffered I/O:** Audio is processed in blocks. The exact time $t_{generate}$ when a sample is written to the output buffer is separated from the time $t_{capture}$ when a corresponding sample is read from the input buffer by a variable system latency $\Delta t_{latency}$.
-2. **Undefined Latency:** $\Delta t_{latency}$ depends on buffer sizes, driver state, and OS scheduling. It varies every time the stream is started and potentially drifts or jitters during operation.
+When a reference is present, the implementation:
 
-### Impact on Measurement
+1. Estimates the reference frequency with an AR(2) single-tone estimator.
+2. Projects the fundamental reference component with the same Hann-windowed complex projection.
+3. Tracks the reference phase across ring-buffer updates using the absolute sample index and phase unwrapping.
+4. Scales the tracked phase by $n/d$ to construct the requested fractional-harmonic reference phasor.
+5. Rotates the measured signal phasor by the conjugate of that reference phasor.
 
-In "Internal Mode", the software generates the output sine wave mathematically:
-$$ V_{out}(t) = \sin(\omega t_{software}) $$
+In simplified form, the final rotation is:
 
-And it demodulates the input using the same software timebase:
-$$ Ref(t) = \sin(\omega t_{software}) $$
+$$
+z_{\mathrm{result}}=z_{\mathrm{sig}}\,e^{-j\phi_{\mathrm{ref}}n/d}.
+$$
 
-However, the physical signal arriving at the ADC is:
-$$ V_{in}(t) = \sin(\omega (t_{software} - \Delta t_{latency}) + \phi_{DUT}) $$
+For the fundamental, the code also compensates the projection's Hann-window scalloping loss using the time-domain reference RMS estimate.
 
-The measured phase becomes:
-$$ \theta_{measured} = \phi_{DUT} - \omega \cdot \Delta t_{latency} $$
+## 3. Internal and external modes
 
-Since $\Delta t_{latency}$ is unknown and undefined, **the measured phase is effectively random**. It will change every time you restart the measurement.
+The UI labels external mode as `External Mode (No Output)`. The difference is how the output is handled:
 
-> **Note:** Magnitude accuracy is generally preserved because latency only affects the phase term $\omega \cdot \Delta t_{latency}$, not the amplitude $A_{sig}$, provided the sampling rates are locked (which they are on a single audio interface).
+- **Internal mode:** the audio callback generates a continuous cosine at the configured frequency and amplitude on the selected output channel(s). The input reference channel is still analyzed and its measured phasor is still used for phase correction. In this mode, the code forces the reference frequency to the configured generator frequency and sets the displayed coherence to 1.0.
+- **External mode:** the callback does not generate output. The user supplies the excitation and a reference signal externally, and the input reference channel is analyzed normally.
 
-## 3. Solution: External Reference Loopback
+The current implementation does not provide a software-only phase fallback when the reference input is absent. A nonzero reference input is required for any result. For an absolute phase measurement of a physical DUT, the reference input should be a physical copy of the excitation delivered to the DUT, for example:
 
-To solve this, we must measure the **actual physical phase** of the excitation signal.
+1. Split the excitation output.
+2. Connect one branch to the DUT input.
+3. Connect the other branch to the reference input.
+4. Connect the DUT output to the signal input.
 
-**Configuration:**
+If both paths share the same excitation-path delay, the measured phase is approximately:
 
-1. **Output (Ch 1):** Connect to DUT Input.
-2. **Output (Ch 1) Split:** Connect also to **Reference Input (Ch 2)**.
-3. **Input (Ch 1):** Connect to DUT Output.
+$$
+\theta_{\mathrm{result}}
+ = (\phi_{\mathrm{latency}}+\phi_{\mathrm{DUT}})
+   -\phi_{\mathrm{latency}}
+ =\phi_{\mathrm{DUT}}.
+$$
 
-The Lock-in Amplifier then analyzes the Reference Input (Ch 2) to establish the reference phasor.
+Without a physical reference that represents the excitation at the DUT, the phase is only relative to whatever waveform is present on the selected reference channel. It should not be interpreted as an absolute DUT phase.
 
-* **Ref Input sees:** $A_{ref} \sin(\omega t + \phi_{latency})$
-* **Sig Input sees:** $A_{sig} \sin(\omega t + \phi_{latency} + \phi_{DUT})$
+## 4. Filtering and averaging
 
-By locking to the Ref Input (calculating $\phi_{ref} = \phi_{latency}$), the demodulation cancels out the latency:
+The default integration buffer contains 65,536 samples. After demodulation, the complex baseband result can pass through a cascaded one-pole IIR low-pass filter. The order is selectable from 0 (off) to 8 and defaults to 4. Its time constant defaults to the buffer duration, or can be set explicitly.
 
-$$ \theta_{result} = (\phi_{latency} + \phi_{DUT}) - \phi_{latency} = \phi_{DUT} $$
+The filtered complex result is appended to a history buffer. The displayed result is the complex mean of the most recent `averaging_count` values, with a GUI range of 1–300:
 
-### Code Implementation Details
+$$
+z_{\mathrm{display}}=\operatorname{mean}(z_1,\ldots,z_N),
+\qquad
+R_{\mathrm{display}}=|z_{\mathrm{display}}|,
+\qquad
+\theta_{\mathrm{display}}=\arg(z_{\mathrm{display}}).
+$$
 
-In `src/gui/widgets/lock_in_amplifier.py`:
+The module also reports the standard deviation of the magnitudes and an unwrapped phase standard deviation over the averaging history.
 
-* **Internal Mode (No Ref Loopback):**
-    * The code detects low signal on the Reference channel.
-    * This forces the reference phase to be 0 relative to the *current software buffer*.
-    * **Result:** Magnitude is correct. Phase is unstable/undefined relative to the DUT.
+## 5. Calibration and frequency sweeps
 
-* **External Mode (With Ref Loopback):**
-    * The code calculates the fundamental phasor of the Reference channel.
-    * `ref_unit = ref_c_fund / |ref_c_fund|`
-    * The Signal is multiplied by the conjugate of this phasor (`sig_c * conj(ref_unit)`).
-    * **Result:** Accurate Phase and Magnitude relative to the excitation signal.
+When calibration is enabled, the audio calibration map supplies a magnitude correction and phase correction at the generator frequency. The engine applies the magnitude correction in linear scale and subtracts the phase correction from the displayed phase.
 
-## 4. Summary
+The frequency-response sweep reuses the same lock-in processing for each configured test frequency. It therefore inherits the reference-channel requirement and the distinction between absolute and relative phase described above.
 
-* **Without REF Loopback:** You are measuring "Signal vs Software Timer". Phase includes arbitrary system latency. **Not suitable for Impedance or Phase measurements.**
-* **With REF Loopback:** You are measuring "Signal vs Excitation". Latency cancels out. **Required for accurate measurement.**
+## 6. Implementation notes
+
+- Output generation uses a continuous phase accumulator to avoid discontinuities between audio blocks.
+- A Hann window reduces spectral leakage when the buffer does not contain an integer number of cycles.
+- Reference frequency is estimated with the relation $r[n-1]+r[n+1]=2\cos(\omega)r[n]$ rather than a Hilbert transform.
+- If the reference is lost, stale averaged values are cleared instead of being held on screen.
+
+## 7. Related source files
+
+- [`src/gui/widgets/lock_in_amplifier.py`](../../src/gui/widgets/lock_in_amplifier.py): output generation, reference estimation, demodulation, filtering, averaging, and calibration.
+- [`src/gui/widgets/lock_in_frequency_counter.py`](../../src/gui/widgets/lock_in_frequency_counter.py): separate lock-in frequency-counter implementation and FLL/Kalman processing.

--- a/tech_docs/implementation/sss_measurement.md
+++ b/tech_docs/implementation/sss_measurement.md
@@ -1,176 +1,216 @@
-# 同期スイープサイン（SSS）法および平行ハマーシュタインモデル（PHM）測定の技術仕様
+# Synchronized Swept-Sine (SSS) and Parallel Hammerstein Measurement
 
-本ドキュメントでは、MeasureLab の `Nonlinear Analyzer` において実装されている、**同期スイープサイン（Synchronized Swept Sine: SSS）法**および**平行ハマーシュタインモデル（Parallel Hammerstein Model: PHM）**を用いた非線形システム測定とカーネル分離のアルゴリズムおよび実装仕様について解説します。
+This document describes the Synchronized Swept-Sine (SSS) measurement and Parallel Hammerstein Model (PHM) kernel-separation pipeline implemented by MeasureLab's `Nonlinear Analyzer`.
 
----
+## 1. Overview
 
-## 1. 概要
+The analyzer uses a logarithmic SSS together with a stepped excitation-amplitude scan. It extracts a fundamental kernel (`h1`) and nonlinear kernels through the fifth order (`h2` through `h5`). The amplitude scan separates the kernels from the amplitude-dependent harmonic responses; the resulting frequency responses are reported over the requested measurement band.
 
-非線形音響・電気音響システムの伝達特性を同定するため、本システムでは指数スイープ（Logarithmic Swept Sine）を用いた SSS 法と、入力振幅を段階的に走査する PHM を組み合わせています。
-これにより、システムが持つ線形応答（基本波応答 $h_1$）だけでなく、2次から5次までの高調波歪み応答（非線形カーネル $h_2$ 〜 $h_5$）を、励起振幅に依存しない純粋な時間領域のインパルス応答（および周波数領域の伝達関数）として個別に分離・抽出します。
+The implementation is split between the measurement controller and the signal-processing core:
 
----
+- [`src/gui/widgets/nonlinear_analyzer.py`](../../src/gui/widgets/nonlinear_analyzer.py) builds the playback sequence, records one continuous session, aligns and averages each amplitude step, and invokes the core processor.
+- [`src/core/nonlinear_analyzer_core.py`](../../src/core/nonlinear_analyzer_core.py) generates the SSS, deconvolves the responses, gates the harmonic impulse responses, applies phase/fractional-delay correction, separates the kernels, and applies calibration.
 
-## 2. 測定・処理の全体フロー
-
-測定処理は大きく分けて、以下の7つのステップで実行されます。
+## 2. Processing flow
 
 ```mermaid
 graph TD
-    A[Step 1: 励起信号生成と振幅スキャンの設定] --> B[Step 2: 同期再生・録音とジッターアライメント TSA]
-    B --> C[Step 3: インパルス応答のデコンボリューション]
-    C --> D[Step 4: 各次数高調波応答の切り出しと分数遅延・位相補正]
-    D --> E[Step 5: 周波数ドメイン Chebyshev 逆変換と最小二乗カーネル分離]
-    E --> F[Step 6: 系統的スイープ位相キャリブレーション]
-    F --> G[Step 7: XFER相対伝達関数補正または遅延補正と出力]
+    A[Step 1: Generate SSS and amplitude schedule] --> B[Step 2: Play, record, and align TSA repetitions]
+    B --> C[Step 3: Regularized frequency-domain deconvolution]
+    C --> D[Step 4: Gate harmonic impulse responses and correct phase]
+    D --> E[Step 5: Frequency-domain Chebyshev separation]
+    E --> F[Step 6: Systematic complex calibration]
+    F --> G[Step 7: XFER or latency correction and output]
 ```
 
-### Step 1: 励起信号生成と振幅スキャンの設定
+### Step 1: SSS generation and amplitude schedule
 
-1. **周波数帯域の設定**:
-   測定帯域 $f_{\text{start}}$ から $f_{\text{end}}$ に対し、過渡応答の歪みを避けるため以下のガードバンド（マージン）を設けてスイープパラメータを算出します。
-   * 開始マージン: $f_{\text{start\_margin}} = \max(2.0, f_{\text{start}} / 1.3)$
-   * 終了マージン: $f_{\text{end\_margin}} = \min(f_{\text{nyquist}} \times 0.95, f_{\text{end}} \times 1.15)$
+#### Frequency margins
 
-2. **指数スイープの設計**:
-   スイープ時間 $T$ に対し、位相特性 $\theta(t)$ を以下のように設計します。
-   $$\theta(t) = \frac{2\pi f_{\text{start\_margin}} T}{L} \left( e^{\frac{t L}{T}} - 1 \right) \quad \text{where} \quad L = \ln\left( \frac{f_{\text{end\_margin}}}{f_{\text{start\_margin}}} \right)$$
-   スイープ波形 $s(t) = \sin(\theta(t))$ に対し、両端のクリックノイズを防止するため、立ち上がり・立ち下がりに $2\%$ 幅の Tukey 窓を適用します。
+For an ascending sweep, the core uses:
 
-3. **振幅スキャンの設定**:
-   ユーザーが設定した最大振幅 $\text{Amp}_{\text{max}}$ (dBFS) から、線形スケールで $0.2 \times \text{Amp}_{\text{max}}$ から $1.0 \times \text{Amp}_{\text{max}}$ までを等間隔に走査する $N_{\text{amps}}$ 段階（デフォルトで5〜10段階）の振幅 $R_j$ を設定します。
+$$
+f_1 = \max(2.0, f_{\mathrm{start}}/1.3),
+\qquad
+f_2 = \min(0.95f_{\mathrm{Nyquist}}, 1.15f_{\mathrm{end}}).
+$$
 
-### Step 2: 同期再生・録音とジッターアライメント (TSA)
+For a descending sweep, the margins are reversed:
 
-各振幅ステップ $R_j$ について、設定された加算平均回数（TSA Averages）分だけ再生・録音を同期して行います。
+$$
+f_1 = \min(0.95f_{\mathrm{Nyquist}}, 1.15f_{\mathrm{start}}),
+\qquad
+f_2 = \max(2.0, f_{\mathrm{end}}/1.3).
+$$
 
-1. **サブサンプル精度アライメント（独自実装）**:
-   オーディオデバイスのバッファリングに起因するジッターによる高域の減衰を防ぐため、1回目の測定波形を基準に、2回目以降の測定波形とのジッター遅延を算出し、周波数領域で分数サンプルレベルの補正をかけてから加算平均化を行います。
+The margins keep the requested sweep away from the extreme band edges. The code supports both sweep directions.
 
-2. **平均化された応答の取得**:
-   アライメント済みの信号を加算平均して、S/N 比を高めた録音信号 $y_j(t)$ および参照用ループバック信号 $x_j(t)$ を得ます。
+#### Phase-synchronized logarithmic sweep
 
-### Step 3: インパルス応答のデコンボリューション
+Let the requested duration be $\widetilde{T}$ and define:
 
-録音信号 $y_j(t)$ と、元のスイープ信号 $s(t)$ （振幅 1.0）を用いて、周波数ドメインで正則化（Regularization）を適用したデコンボリューションを行い、生のインパルス応答 $g_j(t)$ を抽出します。
+$$
+L = \frac{k}{f_1},
+\qquad
+k = \operatorname{round}\left(\frac{f_1\widetilde{T}}{\ln(f_2/f_1)}\right),
+\qquad
+T = L\ln(f_2/f_1).
+$$
 
-$$G_j(f) = \frac{Y_j(f) \cdot S^*(f)}{|S(f)|^2 + \epsilon}$$
+The integer $k$ is forced away from zero when necessary. The generated phase is:
 
-$$g_j(t) = \text{IFFT}(G_j(f))$$
+$$
+\theta(t) = 2\pi k\exp(t/L),
+\qquad
+s(t) = \sin(\theta(t)),
+\qquad 0 \leq t < T.
+$$
 
-ここで $\epsilon$ は SSS 信号の自己相関パワースペクトルの最大値に対する正則化係数（デフォルト: $10^{-4}$）です。
+The actual sample count is `round(sample_rate * T)`. A Tukey window with `alpha=0.02` is applied to the SSS and to the analytical inverse filter. The inverse-filter envelope is proportional to $\exp(t/(2L))$, giving the intended +3 dB-per-octave slope, and the inverse filter is time-reversed and normalized using the peak of its direct convolution with the SSS.
 
-### Step 4: 各次数高調波応答の切り出しと補正 (Gating)
+#### Amplitude schedule
 
-指数スイープの性質により、非線形歪み（$k$ 次高調波応答）のインパルス応答は、基本波（1次）のピーク位置 $t_1$ から時間軸の負の方向（過去方向）に向かって、次の予測位置 $t_{k,\text{exact}}$ に分離して現れます。
-$$t_{k,\text{exact}} = t_1 - L \ln(k) \cdot f_s \quad (\text{samples})$$
+The GUI treats the maximum amplitude as a peak dBFS value:
 
-1. **時間ゲートの適用**:
-   予測位置を中心にプリ 10 ms、ポスト 20 ms（合計 30 ms）の区間を modular wrap-around（巡回境界）を考慮しつつ切り出し、Tukey 窓（alpha=0.1）を乗算します。
+$$
+A_{\max} = 10^{\mathrm{amplitude\_dBFS}/20},
+\qquad
+R_j = \operatorname{linspace}(0.2, 1.0, N_{\mathrm{amps}})_j A_{\max}.
+$$
 
-2. **分数遅延・位相補正（独自実装）**:
-   予測されたピーク位置 $t_{k,\text{exact}}$ と、実際に切り出した整数インデックス $t_k = \text{round}(t_{k,\text{exact}})$ の間の微小な分数遅延差 $\Delta t_k = t_{k,\text{exact}} - t_k$ を、周波数ドメインで位相シフトすることでキャンセルします。また、SSS 法の理論に基づく各次数固有の位相回転（$k=2$ は $+90^\circ$、$k=3$ は $+180^\circ$、$k=4$ は $-90^\circ$）を補正します。
+The module defaults are a maximum level of -6 dBFS, five amplitude steps, and three time-synchronized averages per step. The GUI permits 5–10 amplitude steps and 1–20 averages.
 
-### Step 5: Chebyshev 逆変換と最小二乗カーネル分離（独自実装）
+### Step 2: Playback, recording, and time-synchronized averaging
 
-各振幅ステップ $R_j$ における $k$ 次高調波応答 $g_{j,k}(t)$ は、システムが持つハマーシュタインカーネル $H_p(f)$ の非線形結合によって構成されます。
-これを周波数領域において、振幅 $R_j$ に基づく最小二乗推定（Chebyshev 逆展開）を用いて解き、振幅依存性のない純粋なハマーシュタインカーネル $H_1(f) \dots H_5(f)$ に分離します。高次の歪み成分から順に、低次へ与える高次高調波の影響を差し引きながら再帰的に算出されます。
+The controller creates one continuous playback buffer. For each amplitude step, it places `averages` copies of the sweep back-to-back, with 0.5 s of zero padding after each sweep. An optional 1 s silent tail is appended for noise-floor measurement.
 
-### Step 6: 系統的スイープ位相キャリブレーション（独自実装）
+For each repetition, the alignment channel is deconvolved with the analytical inverse filter and its sub-sample peak is measured. The first repetition at that amplitude is the reference. Later repetitions are shifted in the frequency domain by the measured fractional delay before all channels are accumulated and divided by the number of averages.
 
-SSS 法および窓関数、FFT 処理に伴って必然的に発生する、系統的な位相特性のズレを完全に相殺するためのキャリブレーションを行います。
+The alignment channel is the reference input in `XFER` and `XFER_REV` modes, and the measurement input in single-channel modes. When input and output devices differ, the controller also estimates clock drift from the first and last sweep blocks. It applies windowed-sinc resampling only when the estimated drift is greater than 1 ppm and less than 1000 ppm in magnitude.
 
-1. **シミュレーションによる基準測定**:
-   あらかじめ決定された多項式非線形システムモデルに対し、遅延ゼロの理想的なデジタルループバックシミュレーションを実行し、同様のカーネル分離処理から系統的位相誤差 $\theta_{\text{cal}, k}(f)$ を取得します。
+### Step 3: Regularized deconvolution
 
-2. **測定位相からの減算**:
-   実測された各カーネルの位相応答から $\theta_{\text{cal}, k}(f)$ を減算し、平坦な位相を持つ理想的な分離応答を復元します。
+For each amplitude step, the averaged reference and measurement signals are deconvolved with the unit-amplitude SSS:
 
-> [!NOTE]
-> **キャリブレーション用多項式係数（a_cal）と測定精度に関する技術的補足**
->
-> * **次数間リークによる位相の残留誤差:**  
->   指数スイープ信号の有限長スイープおよびインパルス応答切り出し時の時間ゲート（Tukey窓）処理に伴い、Chebyshev次数分離（バックサブスティテューション）の際に各次数間で微小な相互干渉（リーク）が発生します。キャリブレーション系のダミーモデル係数 `a_cal`（デフォルトはすべて正値）と測定対象の実特性（符号反転や振幅比率）が異なる場合、このリークの現れ方に非対称性が生じるため、補正後にも数分の1度〜1度未満の微小な位相差（例：2次高調波で約 $0.11^\circ$）が残留します。もし `a_cal` を対象の実特性と完全に一致させれば、この位相誤差は理論上 $0.00^\circ$ に収束します。
-> * **振幅誤差の残留:**  
->   本キャリブレーション処理は「位相」のみを補正対象としており、「振幅」は補正しません。そのため、有限長スイープに起因するスペクトルリップル（定常位相近似の誤差）や時間ゲート窓によるスペクトル漏れ込みが、振幅に微小な誤差（約 $0.08$ dB 程度）として残留します。
-> * **実機測定における物理的意義:**  
->   $2 \text{ kHz}$ における $0.11^\circ$ の位相誤差は、時間遅延に換算すると **約 0.15 マイクロ秒（150ナノ秒）** にすぎず、実機ハードウェアのAD/DAクロックジッターやアナログノイズ揺らぎよりもはるかに小さい値です。したがって、実歪み特性が事前には未知である実機測定において、この固定の `a_cal` による補正は極めて頑健かつ実用十分な精度を担保しています。
+$$
+G_j(f) = \frac{Y_j(f)S^*(f)}{|S(f)|^2+\epsilon},
+\qquad
+\epsilon = 10^{-4}\max_f |S(f)|^2 + 10^{-12}.
+$$
 
-### Step 7: XFER 相対伝達関数補正または遅延補正
+The FFT length is the next power of two that is at least the recorded length plus the SSS length. The inverse FFT produces the raw impulse response used by the gating stage.
 
-1. **2チャンネル伝達関数モード (XFER / XFER_REV)**:
-   参照チャンネルの 1次カーネル応答 $H_{\text{ref}, 1}(f)$ を基準として、測定チャンネルの各カーネル $H_{\text{meas}, p}(f)$ とのクロススペクトル伝達関数を計算します。これにより、サウンドカード自体の不要な周波数特性やジッターが完全にキャンセルされます。
-   $$H_{\text{xfer}, p}(f) = \frac{H_{\text{meas}, p}(f) \cdot H_{\text{ref}, 1}^*(f)}{|H_{\text{ref}, 1}(f)|^2 + \alpha}$$
+### Step 4: Harmonic gating and phase correction
 
-2. **シングルチャンネルモード**:
-   事前に測定したループバックレイテンシ（`calibrate_latency`）を用いて、周波数領域で直線位相を減算することにより、伝達関数の位相を補正します。
+After deconvolution, the predicted location for order $k$ is based on the fundamental peak $t_1$:
 
----
+$$
+t_{k,\mathrm{exact}} = t_1 - L\ln(k)f_s.
+$$
 
-## 3. 独自実装・重要アルゴリズムの詳細
+The baseline peak is taken from the maximum-amplitude reference response in XFER modes and from the maximum-amplitude measurement response in single-channel modes. For each order:
 
-### 3.1 FFT アップサンプリングによるサブサンプル精度アライメント
+1. Round the predicted location to $t_k$ and compute $\Delta t_k=t_{k,\mathrm{exact}}-t_k$.
+2. Extract indices from $t_k-0.007f_s$ through $t_k+0.013f_s$, using modular wrap-around. The gate is therefore 7 ms before and 13 ms after the predicted peak, for a total of 20 ms.
+3. Apply the order-dependent sweep phase correction in the frequency domain.
+4. Apply the fractional-delay correction:
 
-`find_subsample_peak(ir)` では、インパルス応答 `ir` のピークインデックスを単なる整数値ではなく、サブサンプル（$1/100$ サンプル）精度で検出します。
+   $$
+   G_{k,\mathrm{corr}}(f)
+   =G_k(f)\exp\left(j2\pi f\frac{\Delta t_k}{f_s}\right).
+   $$
+5. Apply a Tukey window with `alpha=0.1` after the fractional-delay correction.
 
-1. インパルス応答 `ir` の最大絶対値の整数インデックス $idx_{\text{int}}$ を探索。
-2. 境界の回り込みを考慮し、ピークがバッファ中央（$N_{\text{total}} / 2$）に来るようにロールシフト。
-3. ピーク周辺 32 サンプルを切り出し、FFT を実行。
-4. 周波数領域で 100 倍のゼロパディングを行い、IFFT を実行することで時間領域での 100 倍のアップサンプリング（補間）を実現。
-5. アップサンプルされた信号のピーク位置から、元のスケールにおけるサブサンプル精度ピーク位置 $t_{\text{peak}}$ を復元。
+For an ascending sweep, the additional phase factors are $k=2\Rightarrow +j$, $k=3\Rightarrow -1$, and $k=4\Rightarrow -j$. For a descending sweep, the $k=2$ and $k=4$ factors are conjugated: $-j$, $-1$, and $+j$, respectively.
 
-この処理により、加算平均の際にジッターによって生じる超高域（10 kHz 以上）での干渉や位相の乱れを極限まで低減しています。
+### Step 5: Frequency-domain Chebyshev separation
 
-### 3.2 高調波ピークの分数遅延・位相補正
+The gated response for each order and amplitude is transformed to the frequency domain. For each frequency bin, the implementation projects the amplitude-dependent responses onto the corresponding powers of $R_j$ and subtracts higher-order leakage recursively:
 
-高調波 $k$ のピーク予測時間 $t_{k,\text{exact}}$ は通常小数になります。これを整数サンプル位置 $t_k$ で切り出すと、サンプリング周期の端数分だけ波形がずれます。
+$$
+H_5(f)=\frac{16\sum_jG_{j,5}(f)R_j^5}{\sum_jR_j^{10}},
+$$
 
-`apply_phase_correction_and_frac_delay` では、切り出した信号 $g_k(t)$ の FFT 応答 $G_k(f)$ に対して以下を適用します。
+$$
+H_4(f)=\frac{8\sum_jG_{j,4}(f)R_j^4}{\sum_jR_j^8},
+$$
 
-1. **分数サンプル遅延補正**:
-   $$G_{k,\text{corr}}(f) = G_k(f) \cdot e^{j 2 \pi f \frac{\Delta t_k}{f_s}}$$
-   （$\Delta t_k = t_{k,\text{exact}} - t_k$）
+$$
+G'_{j,3}(f)=G_{j,3}(f)-\frac{5}{16}H_5(f)R_j^5,
+\qquad
+H_3(f)=\frac{4\sum_jG'_{j,3}(f)R_j^3}{\sum_jR_j^6},
+$$
 
-2. **スイープ特有の位相復調**:
-   SSS の理論的位相シフトに対抗するため、次数 $k$ に応じて $180^\circ$ や $\pm 90^\circ$ の位相回転を加えます。
-   $$k = 2 \implies \times j, \quad k = 3 \implies \times (-1), \quad k = 4 \implies \times (-j)$$
+$$
+G'_{j,2}(f)=G_{j,2}(f)-\frac{1}{2}H_4(f)R_j^4,
+\qquad
+H_2(f)=\frac{2\sum_jG'_{j,2}(f)R_j^2}{\sum_jR_j^4},
+$$
 
-### 3.3 周波数ドメイン最小二乗法による Chebyshev 逆変換
+$$
+G'_{j,1}(f)=G_{j,1}(f)-\frac{3}{4}H_3(f)R_j^3-\frac{5}{8}H_5(f)R_j^5,
+\qquad
+H_1(f)=\frac{\sum_jG'_{j,1}(f)R_j}{\sum_jR_j^2}.
+$$
 
-平行ハマーシュタインモデルは、励起振幅 $R_j$ に対する各多項式次数の応答としてモデル化されます。
-本実装では、周波数ビンごとに各振幅ステップの応答ベクトルを最小二乗法で解き、Chebyshev カーネル $H_1(f) \dots H_5(f)$ を分離します。
+The same separation is performed independently for the measurement and reference channels. These formulas are designed to remove the modeled cross-order terms; residual leakage still depends on sweep length, gating, noise, and the system response.
 
-具体的には、最高次の 5次から順に以下のように代数的に推定します。
+### Step 6: Systematic complex calibration
 
-* **5次カーネル $H_5(f)$**:
-  $$H_5(f) = \frac{16 \sum_j G_{j,5}(f) \cdot R_j^5}{\sum_j R_j^{10}}$$
+When `calibrate_systematic=True` (the analyzer's default), the core runs the same pipeline recursively on an ideal zero-delay polynomial model with:
 
-* **4次カーネル $H_4(f)$**:
-  $$H_4(f) = \frac{8 \sum_j G_{j,4}(f) \cdot R_j^4}{\sum_j R_j^8}$$
+$$
+a_1=1.0,\quad a_2=0.1,\quad a_3=0.08,\quad a_4=0.04,\quad a_5=0.02.
+$$
 
-* **3次カーネル $H_3(f)$**:
-  $$G'_{j,3}(f) = G_{j,3}(f) - \frac{5}{16} H_5(f) R_j^5$$
-  $$H_3(f) = \frac{4 \sum_j G'_{j,3}(f) \cdot R_j^3}{\sum_j R_j^6}$$
+For each order, it compares the recovered complex response with the ideal coefficient and builds a complex calibration factor:
 
-* **2次カーネル $H_2(f)$**:
-  $$G'_{j,2}(f) = G_{j,2}(f) - \frac{1}{2} H_4(f) R_j^4$$
-  $$H_2(f) = \frac{2 \sum_j G'_{j,2}(f) \cdot R_j^2}{\sum_j R_j^4}$$
+$$
+C_p(f)=\frac{a_p}{H_{p,\mathrm{cal}}(f)+10^{-12}}.
+$$
 
-* **1次（線形）カーネル $H_1(f)$**:
-  $$G'_{j,1}(f) = G_{j,1}(f) - \frac{3}{4} H_3(f) R_j^3 - \frac{5}{8} H_5(f) R_j^5$$
-  $$H_1(f) = \frac{\sum_j G'_{j,1}(f) \cdot R_j}{\sum_j R_j^2}$$
+The factor corrects both gain and phase. It is applied to the reported frequency response, while the time-domain kernel used for display is kept separately so that the physical delay is not removed from that representation. The reference fundamental phase is calibrated separately.
 
-この再帰的な差引処理と重み付き最小二乗法により、各次数の非線形カーネルが他の次数の漏れ込み（リーケージ）なく、非常にクリーンに分離されます。
+### Step 7: XFER or single-channel correction
 
----
+In `XFER` and `XFER_REV` modes, the measurement response is converted to a relative response against the reference fundamental:
 
-## 4. 関連ソースファイル
+$$
+H_{\mathrm{xfer},p}(f)=
+\frac{H_{\mathrm{meas},p}(f)H_{\mathrm{ref},1}^*(f)}
+{|H_{\mathrm{ref},1}(f)|^2+\alpha},
+\qquad
+\alpha=10^{-7}\max_f|H_{\mathrm{ref},1}(f)|^2+10^{-12}.
+$$
 
-本ドキュメントのアルゴリズムは、以下のファイルで実装されています。
+This reduces common-path interface effects; it does not imply that every hardware imperfection is perfectly canceled. The gate offset is restored for time-domain display. For nonlinear orders (`p >= 1`), the top-level result also receives an order-dependent low-pass filter with:
 
-* **UI / 測定シーケンス制御**:
-  [nonlinear_analyzer.py](file:///Users/vach/MeasureLab/src/gui/widgets/nonlinear_analyzer.py)
-  （TSAループ、再生録音スレッド制御、測定結果のプロット更新）
-* **信号処理コアロジック**:
-  [nonlinear_analyzer_core.py](file:///Users/vach/MeasureLab/src/core/nonlinear_analyzer_core.py)
-  （アップサンプリングアライメント、ゲート処理、Chebyshev分離、系統的位相補正）
+$$
+f_{\mathrm{cut}}=\min\left(20\,\mathrm{kHz},\frac{1.15f_s}{2(p+1)}\right).
+$$
+
+In single-channel mode, the stored latency is applied as a positive phase advance:
+
+$$
+H_{\mathrm{corr}}(f)=H_{\mathrm{meas}}(f)\exp(j2\pi f\,\mathrm{latency\_sec}).
+$$
+
+The reported frequency arrays are restricted to the requested frequency band. The time-domain display uses the gate peak as time zero.
+
+## 3. Sub-sample peak detector
+
+`find_subsample_peak(ir)` uses the following implementation:
+
+1. Locate the largest absolute sample.
+2. Roll the response so the peak is at the buffer center.
+3. Extract 32 samples and apply a Tukey window with `alpha=0.25`.
+4. Zero-pad the DFT by a factor of 100 and inverse-transform it.
+5. Map the interpolated peak back to the original circular index.
+
+The result is used for both repetition alignment and harmonic peak placement. It provides a 0.01-sample interpolation grid, but the physical accuracy remains dependent on SNR and peak shape.
+
+## 4. Related tests and source files
+
+- [`src/gui/widgets/nonlinear_analyzer.py`](../../src/gui/widgets/nonlinear_analyzer.py): measurement sequence, TSA alignment, clock-drift handling, and model export.
+- [`src/core/nonlinear_analyzer_core.py`](../../src/core/nonlinear_analyzer_core.py): SSS generation, deconvolution, gating, separation, calibration, and transfer-function correction.
+- [`tests/logic_verification/measurement_modules/test_nonlinear_analyzer.py`](../../tests/logic_verification/measurement_modules/test_nonlinear_analyzer.py): kernel separation, amplitude invariance, phase, delay, and fractional-delay verification.


### PR DESCRIPTION
## Summary

- Translate all five documents under `tech_docs/implementation/` into English.
- Align the technical descriptions with the current source implementation.
- Replace outdated or unsupported claims with implementation-backed details and relative source links.

## Validation

- `39 passed` for the relevant Kalman, nonlinear analyzer, feedforward, and realtime SSS tests.
- `npx markdownlint-cli2 "tech_docs/**/*.md"`
- All relative documentation links resolve.
- `git diff --check`