### PR TITLE
Fix SPL calibration integrity and split compact window sizing

### DIFF
--- a/src/assets/lang/de.json
+++ b/src/assets/lang/de.json
@@ -1519,6 +1519,7 @@
     "SNR Limit:": "SNR-Grenze:",
     "SPDR": "SPDR",
     "SPL Calibration Wizard": "SPL-Kalibrierungsassistent",
+    "SPL calibration is not set. Values are shown in dBFS.": "Die SPL-Kalibrierung ist nicht eingerichtet. Werte werden in dBFS angezeigt.",
     "SPL Offset:": "SPL-Offset:",
     "SPL calibration saved. Offset = {0:.2f} dB (SPL = dBFS + offset)": "SPL-Kalibrierung gespeichert. Offset = {0:.2f} dB (SPL = dBFS + Offset)",
     "SR: -": "SR: -",

--- a/src/assets/lang/en.json
+++ b/src/assets/lang/en.json
@@ -1519,6 +1519,7 @@
     "SNR Limit:": "SNR Limit:",
     "SPDR": "SPDR",
     "SPL Calibration Wizard": "SPL Calibration Wizard",
+    "SPL calibration is not set. Values are shown in dBFS.": "SPL calibration is not set. Values are shown in dBFS.",
     "SPL Offset:": "SPL Offset:",
     "SPL calibration saved. Offset = {0:.2f} dB (SPL = dBFS + offset)": "SPL calibration saved. Offset = {0:.2f} dB (SPL = dBFS + offset)",
     "SR: -": "SR: -",

--- a/src/assets/lang/es.json
+++ b/src/assets/lang/es.json
@@ -1519,6 +1519,7 @@
     "SNR Limit:": "Límite SNR:",
     "SPDR": "SPDR",
     "SPL Calibration Wizard": "Asistente de calibración SPL",
+    "SPL calibration is not set. Values are shown in dBFS.": "La calibración SPL no está configurada. Los valores se muestran en dBFS.",
     "SPL Offset:": "Offset SPL:",
     "SPL calibration saved. Offset = {0:.2f} dB (SPL = dBFS + offset)": "Calibración SPL guardada. Offset = {0:.2f} dB (SPL = dBFS + offset)",
     "SR: -": "SR: -",

--- a/src/assets/lang/fr.json
+++ b/src/assets/lang/fr.json
@@ -1519,6 +1519,7 @@
     "SNR Limit:": "Limite SNR :",
     "SPDR": "SPDR",
     "SPL Calibration Wizard": "Assistant de calibration SPL",
+    "SPL calibration is not set. Values are shown in dBFS.": "La calibration SPL n’est pas configurée. Les valeurs sont affichées en dBFS.",
     "SPL Offset:": "Offset SPL :",
     "SPL calibration saved. Offset = {0:.2f} dB (SPL = dBFS + offset)": "Calibration SPL enregistrée. Offset = {0:.2f} dB (SPL = dBFS + offset)",
     "SR: -": "SR: -",

--- a/src/assets/lang/ja.json
+++ b/src/assets/lang/ja.json
@@ -1519,6 +1519,7 @@
     "SNR Limit:": "SNR制限:",
     "SPDR": "SPDR",
     "SPL Calibration Wizard": "SPLキャリブレーションウィザード",
+    "SPL calibration is not set. Values are shown in dBFS.": "SPL校正が設定されていません。値はdBFSで表示されます。",
     "SPL Offset:": "SPLオフセット:",
     "SPL calibration saved. Offset = {0:.2f} dB (SPL = dBFS + offset)": "SPLキャリブレーションを保存しました。オフセット = {0:.2f} dB (SPL = dBFS + offset)",
     "SR: -": "SR: -",

--- a/src/assets/lang/ko.json
+++ b/src/assets/lang/ko.json
@@ -1519,6 +1519,7 @@
     "SNR Limit:": "SNR 제한:",
     "SPDR": "SPDR",
     "SPL Calibration Wizard": "SPL 보정 마법사",
+    "SPL calibration is not set. Values are shown in dBFS.": "SPL 보정이 설정되지 않았습니다. 값은 dBFS로 표시됩니다.",
     "SPL Offset:": "SPL 오프셋:",
     "SPL calibration saved. Offset = {0:.2f} dB (SPL = dBFS + offset)": "SPL 보정이 저장되었습니다. 오프셋 = {0:.2f} dB (SPL = dBFS + 오프셋)",
     "SR: -": "SR: -",

--- a/src/assets/lang/pt.json
+++ b/src/assets/lang/pt.json
@@ -1519,6 +1519,7 @@
     "SNR Limit:": "Limite SNR:",
     "SPDR": "SPDR",
     "SPL Calibration Wizard": "Assistente de calibração SPL",
+    "SPL calibration is not set. Values are shown in dBFS.": "A calibração SPL não está configurada. Os valores são exibidos em dBFS.",
     "SPL Offset:": "Offset de SPL:",
     "SPL calibration saved. Offset = {0:.2f} dB (SPL = dBFS + offset)": "Calibração SPL salva. Offset = {0:.2f} dB (SPL = dBFS + offset)",
     "SR: -": "SR: -",

--- a/src/assets/lang/ru.json
+++ b/src/assets/lang/ru.json
@@ -1519,6 +1519,7 @@
     "SNR Limit:": "Предел SNR:",
     "SPDR": "SPDR",
     "SPL Calibration Wizard": "Мастер калибровки SPL",
+    "SPL calibration is not set. Values are shown in dBFS.": "Калибровка SPL не настроена. Значения отображаются в dBFS.",
     "SPL Offset:": "Смещение SPL:",
     "SPL calibration saved. Offset = {0:.2f} dB (SPL = dBFS + offset)": "Калибровка SPL сохранена. Смещение = {0:.2f} дБ (SPL = dBFS + смещение)",
     "SR: -": "SR: -",

--- a/src/assets/lang/zh.json
+++ b/src/assets/lang/zh.json
@@ -1519,6 +1519,7 @@
     "SNR Limit:": "信噪比限制:",
     "SPDR": "SPDR",
     "SPL Calibration Wizard": "SPL 校准向导",
+    "SPL calibration is not set. Values are shown in dBFS.": "未设置 SPL 校准。数值以 dBFS 显示。",
     "SPL Offset:": "SPL 偏移：",
     "SPL calibration saved. Offset = {0:.2f} dB (SPL = dBFS + offset)": "SPL 校准已保存。偏移 = {0:.2f} dB（SPL = dBFS + 偏移）",
     "SR: -": "SR: -",

--- a/src/gui/widgets/detachable_wrapper.py
+++ b/src/gui/widgets/detachable_wrapper.py
@@ -2,7 +2,7 @@ import os
 import re
 from datetime import datetime
 
-from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtCore import Qt, QTimer, pyqtSignal
 from PyQt6.QtWidgets import (
     QApplication,
     QHBoxLayout,
@@ -308,12 +308,33 @@ class DetachableWidgetWrapper(QWidget):
             return
 
         self.content_widget.set_compact_mode(checked)
+        self._schedule_compact_window_adjustment()
 
         if self.compact_btn:
             self.compact_btn.blockSignals(True)
             self.compact_btn.setChecked(checked)
             self.compact_btn.setText(tr("Full Mode") if checked else tr("Compact"))
             self.compact_btn.blockSignals(False)
+
+    @staticmethod
+    def _adjust_window_if_alive(window):
+        from PyQt6 import sip
+
+        if window is not None and not sip.isdeleted(window):
+            window.adjustSize()
+
+    def _schedule_compact_window_adjustment(self):
+        """Resize the actual top-level window after compact layout changes settle."""
+        window = None
+        if self.is_split:
+            # In split mode content_widget itself is orphaned, so its window()
+            # is not the IndependentWindow that owns the display panel.
+            window = self.split_display_window
+        elif self.is_detached:
+            window = self.independent_window
+
+        if window is not None:
+            QTimer.singleShot(0, lambda target=window: self._adjust_window_if_alive(target))
 
     def toggle_compact_from_window(self):
         if not self.is_compactable:

--- a/src/gui/widgets/sound_level_meter.py
+++ b/src/gui/widgets/sound_level_meter.py
@@ -641,6 +641,18 @@ class SoundLevelMeterWidget(QWidget, CompactableWidgetInterface, SplittableWidge
         content_layout = QVBoxLayout()
         content_layout.setContentsMargins(10, 10, 10, 10)
 
+        self.calibration_warning = QLabel(
+            "⚠ " + tr("SPL calibration is not set. Values are shown in dBFS.")
+        )
+        self.calibration_warning.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.calibration_warning.setWordWrap(True)
+        self.calibration_warning.setStyleSheet(
+            "background-color: #fff3cd; color: #664d03; "
+            "border: 1px solid #ffca2c; border-radius: 6px; "
+            "font-weight: bold; padding: 8px;"
+        )
+        content_layout.addWidget(self.calibration_warning)
+
         # 1. Main Display (Big Numbers)
         display_frame = QWidget()
         display_frame.setStyleSheet("background-color: #000; border-radius: 8px; margin-bottom: 10px;")
@@ -762,6 +774,7 @@ class SoundLevelMeterWidget(QWidget, CompactableWidgetInterface, SplittableWidge
         main_layout.addWidget(self.sidebar)
         main_layout.addWidget(content_area)
         self.setLayout(main_layout)
+        self._update_calibration_display()
 
     def get_display_widget(self) -> QWidget:
         """Returns the display sub-widget (main display and tabs area)."""
@@ -801,7 +814,31 @@ class SoundLevelMeterWidget(QWidget, CompactableWidgetInterface, SplittableWidge
         layout.addWidget(lbl_val)
         layout.addWidget(lbl_unit)
         container.setLayout(layout)
-        return {"container": container, "label": lbl_val}
+        return {"container": container, "label": lbl_val, "unit": lbl_unit}
+
+    def _get_spl_calibration_offset(self):
+        """Return a finite SPL offset, or None when absolute SPL is unavailable."""
+        try:
+            calibration = self.module.audio_engine.calibration
+            offset = calibration.get_spl_offset_db()
+            if offset is not None and np.isfinite(float(offset)):
+                return float(offset)
+        except (AttributeError, TypeError, ValueError):
+            pass
+        return None
+
+    def _update_calibration_display(self):
+        """Keep the warning banner and displayed units consistent with calibration."""
+        spl_offset = self._get_spl_calibration_offset()
+        spl_calibrated = spl_offset is not None
+        level_unit = "dB SPL" if spl_calibrated else "dBFS"
+
+        self.calibration_warning.setVisible(not spl_calibrated and not self.is_compact_mode())
+        if self.disp_lp["unit"].text() != level_unit:
+            self.disp_lp["unit"].setText(level_unit)
+            self.disp_leq["unit"].setText(level_unit)
+
+        return (spl_offset if spl_calibrated else 0.0), level_unit
 
     def on_start_toggle(self, checked):
         if checked:
@@ -850,15 +887,12 @@ class SoundLevelMeterWidget(QWidget, CompactableWidgetInterface, SplittableWidge
             self.btn_start.setChecked(False)
             self.on_start_toggle(False)
 
+        # Refresh even while stopped so calibration changes in Settings are
+        # reflected immediately in the always-running UI timer.
+        cal_db, level_unit = self._update_calibration_display()
+
         if not self.module.is_running:
             return
-
-        # Get calibration offset
-        cal_db = 0.0
-        if hasattr(self.module.audio_engine, "calibration"):
-            cal_ptr = self.module.audio_engine.calibration
-            if hasattr(cal_ptr, "get_spl_offset_db"):
-                cal_db = cal_ptr.get_spl_offset_db() or 0.0
 
         vals = self.module.results
 
@@ -885,7 +919,7 @@ class SoundLevelMeterWidget(QWidget, CompactableWidgetInterface, SplittableWidge
         vals_get = vals.get
         for key, lbl in self.metric_labels.items():
             val = vals_get(key, -np.inf)
-            text = fmt(val) + " dB"
+            text = f"{fmt(val)} {level_unit}"
             if last_metrics_get(key) != text:
                 last_metrics[key] = text
                 lbl.setText(text)
@@ -909,7 +943,7 @@ class SoundLevelMeterWidget(QWidget, CompactableWidgetInterface, SplittableWidge
                     ln_stats = self.module.calculate_ln_statistics()
                     for key, lbl in self.ln_labels.items():
                         val = ln_stats.get(key, -np.inf)
-                        lbl.setText(fmt(val) + " dB")
+                        lbl.setText(f"{fmt(val)} {level_unit}")
 
                 # For Histogram tab
                 if is_hist_tab:
@@ -932,6 +966,8 @@ class SoundLevelMeterWidget(QWidget, CompactableWidgetInterface, SplittableWidge
                 self.sidebar.setHidden(compact)
         if hasattr(self, "tabs"):
             self.tabs.setHidden(compact)
+        if hasattr(self, "calibration_warning"):
+            self._update_calibration_display()
 
         # Trigger parent window size adjustment to prevent vertical stretching
         win = self.window()

--- a/src/gui/widgets/spectrum_analyzer.py
+++ b/src/gui/widgets/spectrum_analyzer.py
@@ -647,6 +647,7 @@ class SpectrumAnalyzerWidget(
         # Cache variables for plot comparison
         self.last_freqs = None
         self.last_mags = None
+        self._spl_calibration_available = None
 
         self.init_ui()
 
@@ -771,9 +772,8 @@ class SpectrumAnalyzerWidget(
         # Unit Selection (Replaces Physical Units Checkbox)
         row1_layout.addWidget(QLabel(tr("Unit:")))
         self.unit_combo = QComboBox()
-        self.unit_combo.addItems(["dBFS", "dBV", "dB SPL"])
-        self.unit_combo.setCurrentText(self.module.display_unit)
         self.unit_combo.currentTextChanged.connect(self.on_unit_changed)
+        self._refresh_unit_options(force=True)
         row1_layout.addWidget(self.unit_combo)
 
         main_controls_layout.addLayout(row1_layout)
@@ -864,6 +864,7 @@ class SpectrumAnalyzerWidget(
         self.plot_widget = pg.PlotWidget()
         self.plot_widget.setLabel("left", tr("Magnitude"), units="dB")
         self.plot_widget.setLabel("bottom", tr("Frequency"), units="Hz")
+        self._update_plot_unit_label()
         self.plot_widget.setLogMode(x=True, y=False)
         self.plot_widget.setYRange(-120, 0)
         self.plot_widget.showGrid(x=True, y=True)
@@ -1180,15 +1181,59 @@ class SpectrumAnalyzerWidget(
 
     def on_unit_changed(self, val):
         self.module.display_unit = val
-        unit = val
-        if self.module.analysis_mode == "PSD":
-            unit += "/√Hz"
-        self.plot_widget.setLabel("left", "Magnitude", units=unit)
+        if hasattr(self, "plot_widget"):
+            self._update_plot_unit_label()
         # Reset peak to avoid mixing units
         self.module._peak_magnitude = None
         self.peak_curve.clear()  # Performance: Use clear() instead of setData([], []) to avoid list parsing overhead
 
+    def _has_spl_calibration(self):
+        """Return whether an absolute SPL offset is available and usable."""
+        try:
+            offset = self.module.audio_engine.calibration.get_spl_offset_db()
+            return offset is not None and np.isfinite(float(offset))
+        except (AttributeError, TypeError, ValueError):
+            return False
+
+    def _update_plot_unit_label(self):
+        unit = self.module.display_unit
+        if self.module.analysis_mode == "PSD":
+            unit += "/√Hz"
+        self.plot_widget.setLabel("left", tr("Magnitude"), units=unit)
+
+    def _refresh_unit_options(self, force=False):
+        """Expose absolute SPL units only while a valid SPL calibration exists."""
+        calibrated = self._has_spl_calibration()
+
+        if not calibrated and self.module.display_unit == "dB SPL":
+            self.module.display_unit = "dBFS"
+            self.module._peak_magnitude = None
+
+        if force or calibrated != self._spl_calibration_available:
+            options = ["dBFS", "dBV"]
+            if calibrated:
+                options.append("dB SPL")
+
+            self.unit_combo.blockSignals(True)
+            self.unit_combo.clear()
+            self.unit_combo.addItems(options)
+            self.unit_combo.setCurrentText(self.module.display_unit)
+            self.unit_combo.blockSignals(False)
+            self._spl_calibration_available = calibrated
+
+        if self.unit_combo.currentText() != self.module.display_unit:
+            self.unit_combo.blockSignals(True)
+            self.unit_combo.setCurrentText(self.module.display_unit)
+            self.unit_combo.blockSignals(False)
+
+        if hasattr(self, "plot_widget"):
+            self._update_plot_unit_label()
+
     def update_plot(self):
+        # Calibration can be changed from Settings while this widget remains open.
+        # Normalize the selected unit before any spectrum values are calculated.
+        self._refresh_unit_options()
+
         if not self.module.is_running:
             return
 

--- a/tests/logic_verification/gui/test_compact_modes.py
+++ b/tests/logic_verification/gui/test_compact_modes.py
@@ -109,11 +109,17 @@ def test_sound_level_meter_compact_mode(qtbot):
     assert not widget.is_compact_mode()
     assert not widget.sidebar.isHidden()
     assert not widget.tabs.isHidden()
+    assert not widget.calibration_warning.isHidden()
 
     widget.set_compact_mode(True)
     assert widget.is_compact_mode()
     assert widget.sidebar.isHidden()
     assert widget.tabs.isHidden()
+    assert widget.calibration_warning.isHidden()
+
+    # The periodic display refresh must not re-show it in compact mode.
+    widget.update_display()
+    assert widget.calibration_warning.isHidden()
 
     # Wait for the singleShot timer of 50ms to fire and check if adjustSize was called
     qtbot.wait(100)
@@ -125,6 +131,7 @@ def test_sound_level_meter_compact_mode(qtbot):
     assert not widget.is_compact_mode()
     assert not widget.sidebar.isHidden()
     assert not widget.tabs.isHidden()
+    assert not widget.calibration_warning.isHidden()
 
     # Wait for singleShot timer
     qtbot.wait(100)

--- a/tests/logic_verification/gui/test_sound_level_meter.py
+++ b/tests/logic_verification/gui/test_sound_level_meter.py
@@ -28,6 +28,54 @@ def slm():
 
 
 class TestSoundLevelMeterLogic:
+    def test_uncalibrated_display_uses_dbfs(self, qtbot):
+        engine = MockAudioEngine()
+        engine.calibration.get_spl_offset_db.return_value = None
+        module = SoundLevelMeter(engine)
+        widget = SoundLevelMeterWidget(module)
+        qtbot.addWidget(widget)
+        module.is_running = True
+        module.results.update({"Lp": -20.0, "Leq": -21.0, "Lmax": -18.0})
+
+        widget.update_display()
+
+        assert widget.disp_lp["unit"].text() == "dBFS"
+        assert widget.disp_leq["unit"].text() == "dBFS"
+        assert widget.metric_labels["Lmax"].text().endswith(" dBFS")
+        assert not widget.calibration_warning.isHidden()
+        assert "dBFS" in widget.calibration_warning.text()
+
+    def test_calibrated_display_uses_db_spl(self, qtbot):
+        engine = MockAudioEngine()
+        engine.calibration.get_spl_offset_db.return_value = 94.0
+        module = SoundLevelMeter(engine)
+        widget = SoundLevelMeterWidget(module)
+        qtbot.addWidget(widget)
+        module.is_running = True
+        module.results.update({"Lp": -20.0, "Leq": -21.0, "Lmax": -18.0})
+
+        widget.update_display()
+
+        assert widget.disp_lp["unit"].text() == "dB SPL"
+        assert widget.disp_lp["label"].text() == "74.0"
+        assert widget.metric_labels["Lmax"].text() == "76.0 dB SPL"
+        assert widget.calibration_warning.isHidden()
+
+    def test_calibration_warning_updates_while_stopped(self, qtbot):
+        engine = MockAudioEngine()
+        engine.calibration.get_spl_offset_db.return_value = None
+        module = SoundLevelMeter(engine)
+        widget = SoundLevelMeterWidget(module)
+        qtbot.addWidget(widget)
+
+        assert not widget.calibration_warning.isHidden()
+
+        engine.calibration.get_spl_offset_db.return_value = 94.0
+        widget.update_display()
+
+        assert widget.calibration_warning.isHidden()
+        assert widget.disp_lp["unit"].text() == "dB SPL"
+
     def test_sound_level_meter_impulse_logic(self):
         engine = MockAudioEngine()
         slm = SoundLevelMeter(engine)
@@ -271,4 +319,3 @@ class TestSoundLevelMeterSplittable:
         widget.restore_split_panels()
         assert not display_w.isHidden()
         assert not control_w.isHidden()
-

--- a/tests/logic_verification/gui/test_spectrum_analyzer_split.py
+++ b/tests/logic_verification/gui/test_spectrum_analyzer_split.py
@@ -137,6 +137,26 @@ def test_split_live_update_and_reattach_preserve_rendering_objects(spectrum_widg
     assert not spectrum_widget.cursor_label.isHidden()
 
 
+def test_split_compact_resizes_display_window(spectrum_widget, spectrum_wrapper, qtbot):
+    wrapper = spectrum_wrapper
+    wrapper.split()
+    qtbot.wait(1)
+
+    display_window = wrapper.split_display_window
+    display_window.resize(800, 600)
+    qtbot.wait(1)
+    size_before = display_window.size()
+    adjust_size = MagicMock(wraps=display_window.adjustSize)
+    display_window.adjustSize = adjust_size
+
+    wrapper.toggle_compact(True)
+    qtbot.wait(10)
+
+    assert spectrum_widget.is_compact_mode()
+    adjust_size.assert_called()
+    assert display_window.width() < size_before.width() or display_window.height() < size_before.height()
+
+
 def test_closing_one_split_window_restores_state_a(spectrum_widget, spectrum_wrapper, qtbot):
     wrapper = spectrum_wrapper
     wrapper.split()

--- a/tests/logic_verification/instruments/test_spectrum_analyzer.py
+++ b/tests/logic_verification/instruments/test_spectrum_analyzer.py
@@ -173,6 +173,28 @@ class TestSpectrumAnalyzer:
         assert val_spl_a == pytest.approx(val_spl, abs=0.2)
         assert "dB SPL(A)" in sa_widget.overall_label.text()
 
+    def test_uncalibrated_spl_falls_back_to_dbfs(self, sa_module, sa_widget, mock_engine):
+        """An unavailable SPL offset must never leave dBFS values labelled as dB SPL."""
+        mock_engine.calibration.get_spl_offset_db.return_value = None
+        sa_module.display_unit = "dB SPL"
+        sa_module.is_running = True
+
+        sa_widget.update_plot()
+
+        assert sa_module.display_unit == "dBFS"
+        assert sa_widget.unit_combo.findText("dB SPL") == -1
+        assert "dBFS" in sa_widget.overall_label.text()
+        assert "dB SPL" not in sa_widget.overall_label.text()
+
+    def test_spl_option_appears_after_calibration(self, sa_module, sa_widget, mock_engine):
+        """The SPL unit becomes available without recreating the analyzer widget."""
+        assert sa_widget.unit_combo.findText("dB SPL") == -1
+
+        mock_engine.calibration.get_spl_offset_db.return_value = 94.0
+        sa_widget.update_plot()
+
+        assert sa_widget.unit_combo.findText("dB SPL") >= 0
+
     def test_apply_min_max_envelope(self, sa_widget):
         """Verify that apply_min_max_envelope correctly downsamples single/dual channel magnitudes."""
         # 1. Single Channel test


### PR DESCRIPTION
## Summary

- prevent uncalibrated values from being presented as absolute dB SPL
- show an explicit uncalibrated dBFS warning in the Sound Level Meter normal view, while keeping compact mode clean
- dynamically expose the Spectrum Analyzer dB SPL unit only when a valid SPL calibration exists
- resize the actual split display window after compact/full layout changes
- add localized warning text and regression coverage

## Root cause

An absent SPL offset was treated as a zero offset in parts of the UI, which made relative dBFS values look like absolute SPL measurements. In split mode, compact layout changes were applied to the module widget, but size recalculation targeted that now-orphaned widget rather than the `IndependentWindow` that owns the split display panel.

## Impact

Uncalibrated readings are now clearly identified as dBFS, and split display windows shrink correctly when compact mode is enabled. Calibrated SPL behavior is preserved.

## Validation

- `./.venv/bin/python -m pytest -q -m 'not hardware'` — 1031 passed, 6 deselected, 29 subtests passed
- Ruff checks for all changed Python files
- `./.venv/bin/python scripts/check_trn_keys.py`
- `./.venv/bin/python scripts/check_ui_size_limits.py`
