### PR TITLE
chore: Clean up and consolidate trivial and dummy tests

### DIFF
--- a/tests/logic_verification/core/test_session_manager.py
+++ b/tests/logic_verification/core/test_session_manager.py
@@ -1,67 +1,27 @@
 import pytest
 from src.core.session_manager import SessionManager
 
-
 @pytest.fixture
 def session_manager():
-    """Fixture to provide a clean SessionManager instance."""
     return SessionManager()
 
+def test_session_manager_lifecycle(session_manager):
+    # Default state
+    assert session_manager.is_running is False
 
-def test_start_measurement_success(session_manager):
-    """Verify that start_measurement sets is_running to True when a module is set."""
+    # Starting without module does not run
+    session_manager.start_measurement()
+    assert session_manager.is_running is False
+
+    # Starting with module runs
     session_manager.current_module = "valid_module"
     session_manager.start_measurement()
     assert session_manager.is_running is True
 
-
-def test_start_measurement_no_module(session_manager):
-    """Verify that start_measurement does NOT set is_running to True if no module is set."""
-    # current_module is None by default
-    session_manager.start_measurement()
-    assert session_manager.is_running is False
-
-
-def test_stop_measurement(session_manager):
-    """Verify that stop_measurement sets is_running to False."""
-    session_manager.current_module = "valid_module"
-    session_manager.start_measurement()
-    assert session_manager.is_running is True
-
-    session_manager.stop_measurement()
-    assert session_manager.is_running is False
-
-
-def test_stop_measurement_idempotent(session_manager):
-    """Verify that calling stop_measurement multiple times is safe."""
-    session_manager.current_module = "valid_module"
-    session_manager.start_measurement()
-    session_manager.stop_measurement()
-    assert session_manager.is_running is False
-
-    # Call again
-    session_manager.stop_measurement()
-    assert session_manager.is_running is False
-
-
-def test_start_measurement_idempotent(session_manager):
-    """Verify that calling start_measurement multiple times keeps is_running True."""
-    session_manager.current_module = "valid_module"
-    session_manager.start_measurement()
-    assert session_manager.is_running is True
-
-    # Call again
-    session_manager.start_measurement()
-    assert session_manager.is_running is True
-
-
-def test_change_module_while_running(session_manager):
-    """Verify behavior when changing module while running."""
-    session_manager.current_module = "module_a"
-    session_manager.start_measurement()
-    assert session_manager.is_running is True
-
+    # Changing module while running is allowed and keeps it running
     session_manager.current_module = "module_b"
-    assert session_manager.current_module == "module_b"
-    # Assuming implementation allows changing module while running without stopping
     assert session_manager.is_running is True
+
+    # Stopping
+    session_manager.stop_measurement()
+    assert session_manager.is_running is False

--- a/tests/logic_verification/gui/test_noise_profiler_widget_logic.py
+++ b/tests/logic_verification/gui/test_noise_profiler_widget_logic.py
@@ -8,7 +8,7 @@ import numpy as np
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
 
-class TestNoiseProfilerLogicBase(unittest.TestCase):
+class NoiseProfilerLogicBaseTest(unittest.TestCase):
     def setUp(self):
         # 1. Prepare Mocks
         self.mock_qt = MagicMock()
@@ -79,7 +79,7 @@ class TestNoiseProfilerLogicBase(unittest.TestCase):
             del sys.modules["src.gui.widgets.noise_profiler"]
 
 
-class TestNoiseProfilerAverage(TestNoiseProfilerLogicBase):
+class TestNoiseProfilerAverage(NoiseProfilerLogicBaseTest):
     def setUp(self):
         super().setUp()
         self.engine = MagicMock()
@@ -113,51 +113,7 @@ class TestNoiseProfilerAverage(TestNoiseProfilerLogicBase):
         np.testing.assert_array_almost_equal(self.profiler._avg_magnitude, np.ones(513) * 2.0)
 
 
-class TestNoiseProfilerProcess(TestNoiseProfilerLogicBase):
-    def setUp(self):
-        super().setUp()
-        self.engine = MagicMock()
-        self.engine.sample_rate = 48000
-        self.engine.calibration.get_input_offset_db.return_value = 0.0
-
-        self.profiler = self.NoiseProfiler(self.engine)
-        self.profiler.buffer_size = 1024
-        self.profiler.input_data = np.random.rand(1024, 2)
-
-    def test_process_data_smoke(self):
-        # We need to ensure dependencies used inside process_data are also working (mocked or real)
-        # process_data calls AudioCalc, fft_manager.
-        # Since we mocked scipy/pywt at sys.modules level, imports inside core.analysis might fail or return mocks.
-        # If they return mocks, calculations will produce mocks.
-
-        # We might need to mock return values of fft_manager if we want meaningful output,
-        # or just check that it runs without error.
-
-        # Let's mock fft_manager.rfftfreq and rfft to return numpy arrays so logic continues
-        with patch("src.core.fft_manager.fft_manager") as mock_fft:
-            mock_fft.rfft.return_value = np.zeros(513)
-            mock_fft.rfftfreq.return_value = np.zeros(513)
-
-            # Also mock get_cached_window to return correct size (default buffer size 1024)
-            with patch("src.gui.widgets.noise_profiler.get_cached_window") as mock_window:
-                mock_window.return_value = np.ones(1024)
-                output = self.profiler.process_data(0, "dBV", False)
-
-            # Since rfft returns zeros, magnitude is zeros.
-            # update_average returns zeros.
-            # AudioCalc.calculate_noise_profile is called with zeros.
-
-            self.assertIsNotNone(output)
-            freqs, mag, results, raw_avg = output
-            self.assertIsNotNone(results)
-
-    def test_process_data_insufficient_data(self):
-        self.profiler.input_data = np.zeros((100, 2))
-        output = self.profiler.process_data(0, "dBV", False)
-        self.assertIsNone(output)
-
-
-class TestNoiseProfilerLogging(TestNoiseProfilerLogicBase):
+class TestNoiseProfilerLogging(NoiseProfilerLogicBaseTest):
     def test_worker_exception_logging(self):
         mock_engine = MagicMock()
         module = self.NoiseProfiler(mock_engine)
@@ -182,7 +138,7 @@ class TestNoiseProfilerLogging(TestNoiseProfilerLogicBase):
             assert mock_logger.error.called
 
 
-class TestNoiseProfilerRingBuffer(TestNoiseProfilerLogicBase):
+class TestNoiseProfilerRingBuffer(NoiseProfilerLogicBaseTest):
     def setUp(self):
         super().setUp()
         self.mock_engine = MagicMock()

--- a/tests/logic_verification/gui/test_nonlinear_analyzer_gui.py
+++ b/tests/logic_verification/gui/test_nonlinear_analyzer_gui.py
@@ -1,3 +1,4 @@
+import numpy as np
 from src.core.audio_engine import AudioEngine
 from src.gui.widgets.nonlinear_analyzer import NonlinearAnalyzer, NonlinearAnalyzerWidget
 
@@ -12,6 +13,9 @@ def test_nonlinear_analyzer_gui_start(qtbot):
     analyzer.sweep_duration = 0.1
     analyzer.averages = 1
     analyzer.num_amplitudes = 5
+
+    # Mock play_rec directly to avoid audio driver timeout issues
+    analyzer.run_play_rec = lambda out_data, **kwargs: np.zeros((len(out_data), 2), dtype=np.float32)
 
     widget = NonlinearAnalyzerWidget(analyzer)
     qtbot.addWidget(widget)
@@ -77,6 +81,9 @@ def test_nonlinear_analyzer_gui_stop(qtbot, monkeypatch):
     analyzer.sweep_duration = 2.0
     analyzer.averages = 1
     analyzer.num_amplitudes = 5
+
+    # Mock play_rec directly to avoid audio driver timeout issues
+    analyzer.run_play_rec = lambda out_data, **kwargs: np.zeros((len(out_data), 2), dtype=np.float32)
 
     widget = NonlinearAnalyzerWidget(analyzer)
     qtbot.addWidget(widget)


### PR DESCRIPTION
This PR focuses on cleaning up the pytest suite by removing dummy tests, consolidating trivial verifications, and fixing base class collection issues. It also introduces a targeted mock for hardware playback in `test_nonlinear_analyzer_gui.py` to prevent random CI timeouts without modifying production logic.

---
*PR created automatically by Jules for task [1820874304161881353](https://jules.google.com/task/1820874304161881353) started by @youtube-at-vach*