### PR TITLE
Prevent IMD signals in distortion analyzer sweeps

### DIFF
--- a/src/gui/widgets/distortion_analyzer.py
+++ b/src/gui/widgets/distortion_analyzer.py
@@ -607,6 +607,7 @@ class DistortionAnalyzerWidget(QWidget, ComparableWidgetInterface):
         super().__init__()
         self.module = module
         self.sweep_worker = None
+        self._realtime_output_mode_index = 1
         self.init_ui()
 
         # Theme handling
@@ -1174,12 +1175,15 @@ class DistortionAnalyzerWidget(QWidget, ComparableWidgetInterface):
         self._update_sweep_x_controls()
 
         if idx == 0:  # Real-time
+            self.out_mode_combo.setEnabled(True)
+            self.set_meters_mode("thd")
+            self.out_mode_combo.setCurrentIndex(self._realtime_output_mode_index)
             self.settings_tabs.setCurrentIndex(0)
             self.meters_group.setVisible(True)
-            self.set_meters_mode("thd")
             self.tabs.setCurrentIndex(0)
             self.sync_module_with_gui()
         else:
+            self._use_sine_for_sweep()
             self.settings_tabs.setCurrentIndex(1)
             self.meters_group.setVisible(False)
             self.tabs.setCurrentIndex(2)
@@ -1199,8 +1203,18 @@ class DistortionAnalyzerWidget(QWidget, ComparableWidgetInterface):
 
             self._update_sweep_y_axis_format()
 
+    def _use_sine_for_sweep(self):
+        """Enforce the single-tone signal expected by the sweep analysis."""
+        self.out_mode_combo.setCurrentIndex(1)
+        self.out_mode_combo.setEnabled(False)
+        self.module.output_enabled = True
+        self.module.signal_type = "sine"
+
     def on_out_mode_changed(self, idx):
         # 0: Off, 1: Sine, 2: SMPTE, 3: CCIF
+        if self.mode_combo.currentIndex() == 0:
+            self._realtime_output_mode_index = idx
+
         # Ensure calibration is reset when changing modes
         if idx != 4:
             if hasattr(self, "aes17_cal_btn"):
@@ -1352,7 +1366,11 @@ class DistortionAnalyzerWidget(QWidget, ComparableWidgetInterface):
             self.imd_row_widget.setVisible(True)
 
     def start_sweep(self, mode_idx):
-        self.module.start_analysis()  # Ensure audio is running
+        # SweepWorker always performs single-tone harmonic analysis. Keep this
+        # invariant here as well as in the UI in case this method is called
+        # directly or the module state was changed programmatically.
+        self._use_sine_for_sweep()
+        self.sync_module_with_gui()
         self.action_btn.setText(tr("Stop Sweep"))
         self.module.sweep_results = []
         self.sweep_curve.clear()  # Performance: Use clear() instead of setData([], []) to avoid list parsing overhead
@@ -1382,6 +1400,7 @@ class DistortionAnalyzerWidget(QWidget, ComparableWidgetInterface):
                 self.action_btn.setText(tr("Start Measurement"))
                 return
 
+        self.module.start_analysis()  # Ensure audio is running
         self.mode_combo.setEnabled(False)
         self.sweep_worker = SweepWorker(self.module, sweep_type, start, end, steps)
         self.sweep_worker.result_ready.connect(self.on_sweep_result)

--- a/tests/logic_verification/gui/widgets/test_distortion_analyzer_widget.py
+++ b/tests/logic_verification/gui/widgets/test_distortion_analyzer_widget.py
@@ -1,5 +1,6 @@
+from unittest.mock import MagicMock, patch
+
 import pytest
-from unittest.mock import MagicMock
 
 from src.gui.widgets.distortion_analyzer import (
     DistortionAnalyzer,
@@ -118,3 +119,54 @@ def test_aes17_calibration_button(qtbot, mock_audio_engine):
     }
     widget.on_worker_result(results_normal)
     assert widget.thdn_db_label.styleSheet() == ""
+
+
+@pytest.mark.parametrize(
+    ("imd_index", "sweep_index", "imd_signal_type"),
+    [
+        (2, 1, "smpte"),
+        (3, 2, "ccif"),
+    ],
+)
+def test_sweep_mode_uses_sine_and_restores_realtime_imd(
+    qtbot, mock_audio_engine, imd_index, sweep_index, imd_signal_type
+):
+    analyzer = DistortionAnalyzer(mock_audio_engine)
+    widget = DistortionAnalyzerWidget(analyzer)
+    qtbot.addWidget(widget)
+
+    widget.out_mode_combo.setCurrentIndex(imd_index)
+    assert analyzer.signal_type == imd_signal_type
+
+    widget.mode_combo.setCurrentIndex(sweep_index)
+
+    assert widget.out_mode_combo.currentIndex() == 1
+    assert not widget.out_mode_combo.isEnabled()
+    assert analyzer.output_enabled
+    assert analyzer.signal_type == "sine"
+
+    widget.mode_combo.setCurrentIndex(0)
+
+    assert widget.out_mode_combo.isEnabled()
+    assert widget.out_mode_combo.currentIndex() == imd_index
+    assert analyzer.signal_type == imd_signal_type
+
+
+def test_start_sweep_defensively_restores_sine_state(qtbot, mock_audio_engine):
+    analyzer = DistortionAnalyzer(mock_audio_engine)
+    analyzer.start_analysis = MagicMock()
+    widget = DistortionAnalyzerWidget(analyzer)
+    qtbot.addWidget(widget)
+    widget.mode_combo.setCurrentIndex(1)
+
+    analyzer.signal_type = "smpte"
+    analyzer.output_enabled = False
+
+    with patch("src.gui.widgets.distortion_analyzer.SweepWorker") as worker_class:
+        widget.start_sweep(1)
+
+    assert analyzer.signal_type == "sine"
+    assert analyzer.output_enabled
+    analyzer.start_analysis.assert_called_once_with()
+    worker_class.assert_called_once()
+    worker_class.return_value.start.assert_called_once_with()


### PR DESCRIPTION
## Summary

- force frequency and amplitude sweeps to use the sine-wave generator expected by the THD+N sweep analysis
- disable signal-type changes during a sweep mode and restore the previous real-time IMD selection when returning
- defensively normalize the signal state again when a sweep starts
- add regression coverage for SMPTE IMD, CCIF IMD, both sweep modes, and direct sweep startup

## Root cause

The sweep worker always performs single-tone harmonic/THD+N analysis, but the UI allowed the SMPTE or CCIF dual-tone IMD generator state to remain active. The worker therefore analyzed a dual-tone signal as though it were a single tone, producing invalid sweep plots.

## User impact

Selecting a frequency or amplitude sweep now consistently uses a sine wave, so IMD choices can no longer produce misleading sweep plots. Returning to real-time mode restores the user's previous IMD selection.

## Validation

- `./.venv/bin/ruff check .`
- `./.venv/bin/mypy src main_gui.py`
- `./.venv/bin/python scripts/check_trn_keys.py`
- `npx markdownlint-cli2 "**/*.md" "#node_modules"`
- `./.venv/bin/pytest` — 1033 passed, 6 skipped (hardware-only tests)