### PR TITLE
Add theoretical THD to harmonic generator

### DIFF
--- a/src/assets/lang/de.json
+++ b/src/assets/lang/de.json
@@ -1838,6 +1838,7 @@
     "The file sample rate ({0} Hz) differs from the engine rate ({1} Hz).\nResampling is required to play correctly.\n\nDo you want to proceed? (This may take a moment for large files)": "Die Datei-Abtastrate ({0} Hz) unterscheidet sich von der Engine-Rate ({1} Hz).\nResampling ist erforderlich, um korrekt abzuspielen.\n\nMöchten Sie fortfahren? (Dies kann bei großen Dateien einen Moment dauern)",
     "Theme": "Thema",
     "Thermal Limit": "Thermische Grenze",
+    "Theoretical THD: {0:.4f} %": "Theoretischer THD: {0:.4f} %",
     "This tool plays a test tone on each output channel and checks all input channels for the signal.": "Dieses Tool spielt einen Testton auf jedem Ausgangskanal ab und überprüft alle Eingangskanäle auf das Signal.",
     "This will stop the main audio engine temporarily.": "Dies stoppt die Haupt-Audio-Engine vorübergehend.",
     "Thresh": "Schwellw.",

--- a/src/assets/lang/en.json
+++ b/src/assets/lang/en.json
@@ -1838,6 +1838,7 @@
     "The file sample rate ({0} Hz) differs from the engine rate ({1} Hz).\nResampling is required to play correctly.\n\nDo you want to proceed? (This may take a moment for large files)": "The file sample rate ({0} Hz) differs from the engine rate ({1} Hz).\nResampling is required to play correctly.\n\nDo you want to proceed? (This may take a moment for large files)",
     "Theme": "Theme",
     "Thermal Limit": "Thermal Limit",
+    "Theoretical THD: {0:.4f} %": "Theoretical THD: {0:.4f} %",
     "This tool plays a test tone on each output channel and checks all input channels for the signal.": "This tool plays a test tone on each output channel and checks all input channels for the signal.",
     "This will stop the main audio engine temporarily.": "This will stop the main audio engine temporarily.",
     "Thresh": "Thresh",

--- a/src/assets/lang/es.json
+++ b/src/assets/lang/es.json
@@ -1838,6 +1838,7 @@
     "The file sample rate ({0} Hz) differs from the engine rate ({1} Hz).\nResampling is required to play correctly.\n\nDo you want to proceed? (This may take a moment for large files)": "La tasa de muestreo del archivo ({0} Hz) difiere de la tasa del motor ({1} Hz).\nSe requiere remuestreo para reproducir correctamente.\n\n¿Desea continuar? (Esto puede tardar un momento para archivos grandes)",
     "Theme": "Tema",
     "Thermal Limit": "Límite térmico",
+    "Theoretical THD: {0:.4f} %": "THD teórica: {0:.4f} %",
     "This tool plays a test tone on each output channel and checks all input channels for the signal.": "Esta herramienta reproduce un tono de prueba en cada canal de salida y verifica todos los canales de entrada para la señal.",
     "This will stop the main audio engine temporarily.": "Esto detendrá temporalmente el motor de audio principal.",
     "Thresh": "Umbral",

--- a/src/assets/lang/fr.json
+++ b/src/assets/lang/fr.json
@@ -1838,6 +1838,7 @@
     "The file sample rate ({0} Hz) differs from the engine rate ({1} Hz).\nResampling is required to play correctly.\n\nDo you want to proceed? (This may take a moment for large files)": "Le taux d'échantillonnage du fichier ({0} Hz) diffère du taux du moteur ({1} Hz).\nLe rééchantillonnage est nécessaire pour lire correctement.\n\nVoulez-vous continuer? (Cela peut prendre un moment pour les gros fichiers)",
     "Theme": "Thème",
     "Thermal Limit": "Limite thermique",
+    "Theoretical THD: {0:.4f} %": "THD théorique : {0:.4f} %",
     "This tool plays a test tone on each output channel and checks all input channels for the signal.": "Cet outil joue un ton de test sur chaque canal de sortie et vérifie tous les canaux d'entrée pour le signal.",
     "This will stop the main audio engine temporarily.": "Cela arrêtera temporairement le moteur audio principal.",
     "Thresh": "Seuil",

--- a/src/assets/lang/ja.json
+++ b/src/assets/lang/ja.json
@@ -1838,6 +1838,7 @@
     "The file sample rate ({0} Hz) differs from the engine rate ({1} Hz).\nResampling is required to play correctly.\n\nDo you want to proceed? (This may take a moment for large files)": "ファイルのサンプルレート ({0} Hz) がエンジンのレート ({1} Hz) と異なります。\n正しく再生するにはリサンプリングが必要です。\n\n続行しますか？ (大きなファイルの場合、時間がかかることがあります)",
     "Theme": "テーマ",
     "Thermal Limit": "熱雑音限界",
+    "Theoretical THD: {0:.4f} %": "理論THD: {0:.4f} %",
     "This tool plays a test tone on each output channel and checks all input channels for the signal.": "このツールは各出力チャンネルでテストトーンを再生し、全ての入力チャンネルで信号をチェックします。",
     "This will stop the main audio engine temporarily.": "これによりメインオーディオエンジンが一時的に停止します。",
     "Thresh": "しきい値",

--- a/src/assets/lang/ko.json
+++ b/src/assets/lang/ko.json
@@ -1838,6 +1838,7 @@
     "The file sample rate ({0} Hz) differs from the engine rate ({1} Hz).\nResampling is required to play correctly.\n\nDo you want to proceed? (This may take a moment for large files)": "파일 샘플 레이트 ({0} Hz)가 엔진 레이트 ({1} Hz)와 다릅니다.\n올바르게 재생하려면 리샘플링이 필요합니다.\n\n계속하시겠습니까? (큰 파일의 경우 시간이 걸릴 수 있습니다)",
     "Theme": "테마",
     "Thermal Limit": "열 잡음 한계",
+    "Theoretical THD: {0:.4f} %": "이론적 THD: {0:.4f} %",
     "This tool plays a test tone on each output channel and checks all input channels for the signal.": "이 도구는 각 출력 채널에서 테스트 톤을 재생하고 모든 입력 채널에서 신호를 확인합니다.",
     "This will stop the main audio engine temporarily.": "이로 인해 메인 오디오 엔진이 일시적으로 중지됩니다.",
     "Thresh": "임계값",

--- a/src/assets/lang/pt.json
+++ b/src/assets/lang/pt.json
@@ -1838,6 +1838,7 @@
     "The file sample rate ({0} Hz) differs from the engine rate ({1} Hz).\nResampling is required to play correctly.\n\nDo you want to proceed? (This may take a moment for large files)": "A taxa de amostragem do arquivo ({0} Hz) difere da taxa do motor ({1} Hz).\nA reamostragem é necessária para reproduzir corretamente.\n\nDeseja continuar? (Isso pode levar um momento para arquivos grandes)",
     "Theme": "Tema",
     "Thermal Limit": "Limite térmico",
+    "Theoretical THD: {0:.4f} %": "THD teórica: {0:.4f} %",
     "This tool plays a test tone on each output channel and checks all input channels for the signal.": "Esta ferramenta reproduz um tom de teste em cada canal de saída e verifica todos os canais de entrada para o sinal.",
     "This will stop the main audio engine temporarily.": "Isso irá parar o mecanismo de áudio principal temporariamente.",
     "Thresh": "Limiar",

--- a/src/assets/lang/ru.json
+++ b/src/assets/lang/ru.json
@@ -1838,6 +1838,7 @@
     "The file sample rate ({0} Hz) differs from the engine rate ({1} Hz).\nResampling is required to play correctly.\n\nDo you want to proceed? (This may take a moment for large files)": "Частота дискретизации файла ({0} Гц) отличается от частоты движка ({1} Гц).\nДля правильного воспроизведения требуется передискретизация.\n\nПродолжить? (Это может занять время для больших файлов)",
     "Theme": "Тема",
     "Thermal Limit": "Тепловой предел",
+    "Theoretical THD: {0:.4f} %": "Теоретический THD: {0:.4f} %",
     "This tool plays a test tone on each output channel and checks all input channels for the signal.": "Этот инструмент воспроизводит тестовый тон на каждом выходном канале и проверяет все входные каналы на наличие сигнала.",
     "This will stop the main audio engine temporarily.": "Это временно остановит основной аудиодвигатель.",
     "Thresh": "Порог",

--- a/src/assets/lang/zh.json
+++ b/src/assets/lang/zh.json
@@ -1838,6 +1838,7 @@
     "The file sample rate ({0} Hz) differs from the engine rate ({1} Hz).\nResampling is required to play correctly.\n\nDo you want to proceed? (This may take a moment for large files)": "文件采样率 ({0} Hz) 与引擎速率 ({1} Hz) 不同。\n需要重采样才能正确播放。\n\n是否继续? (大文件可能需要一些时间)",
     "Theme": "主题",
     "Thermal Limit": "热噪声限制",
+    "Theoretical THD: {0:.4f} %": "理论 THD：{0:.4f} %",
     "This tool plays a test tone on each output channel and checks all input channels for the signal.": "此工具在每个输出通道播放测试音调，并检查所有输入通道的信号。",
     "This will stop the main audio engine temporarily.": "这将临时停止主音频引擎。",
     "Thresh": "阈值",

--- a/src/gui/widgets/arbitrary_harmonic_generator.py
+++ b/src/gui/widgets/arbitrary_harmonic_generator.py
@@ -47,7 +47,7 @@ class ArbitraryHarmonicGenerator(MeasurementModule):
         self.output_enabled = True
 
         # Harmonics
-        self.max_harmonic = 20
+        self.max_harmonic = 10
         self.harmonics_amps = np.zeros(MAX_HARMONICS)  # Linear amplitude (0.0 means OFF)
         self.harmonics_phases_deg = np.zeros(MAX_HARMONICS)
 
@@ -343,13 +343,22 @@ class ArbitraryHarmonicWidget(QWidget):
         tabs = QTabWidget()
 
         # 1. Preview Waveform Plot
+        waveform_tab = QWidget()
+        waveform_layout = QVBoxLayout(waveform_tab)
+        waveform_layout.setContentsMargins(0, 0, 0, 0)
+
+        self.lbl_theoretical_thd = QLabel()
+        self.lbl_theoretical_thd.setAlignment(Qt.AlignmentFlag.AlignRight)
+        waveform_layout.addWidget(self.lbl_theoretical_thd)
+
         self.plot_wave = pg.PlotWidget(title=tr("Synthesized Waveform Preview"))
         self.plot_wave.setLabel("bottom", tr("Time"), units="s")
         self.plot_wave.setLabel("left", tr("Amplitude"))
         self.plot_wave.showGrid(x=True, y=True)
         self.plot_wave.setYRange(-1.5, 1.5)
         self.curve_wave = self.plot_wave.plot(pen="y")
-        tabs.addTab(self.plot_wave, tr("Waveform Preview"))
+        waveform_layout.addWidget(self.plot_wave)
+        tabs.addTab(waveform_tab, tr("Waveform Preview"))
 
         # 2. Spectrum Plot
         self.plot_spec = pg.PlotWidget(title=tr("Synthesized Spectrum Preview"))
@@ -771,6 +780,10 @@ class ArbitraryHarmonicWidget(QWidget):
         sig = sin_coeffs @ np.sin(wt_matrix) + cos_coeffs @ np.cos(wt_matrix)
 
         self.curve_wave.setData(t_preview, sig)
+
+        harmonic_power = np.sum(sin_coeffs[1:] ** 2 + cos_coeffs[1:] ** 2)
+        theoretical_thd = 100.0 * np.sqrt(harmonic_power) / abs(a1)
+        self.lbl_theoretical_thd.setText(tr("Theoretical THD: {0:.4f} %").format(theoretical_thd))
 
         # 2. Spectrum Preview
         heights = np.full(max_h, -140.0)

--- a/tests/logic_verification/gui/widgets/test_arbitrary_harmonic_generator.py
+++ b/tests/logic_verification/gui/widgets/test_arbitrary_harmonic_generator.py
@@ -33,9 +33,30 @@ def test_initialization(generator_widget):
     assert widget.freq_spin.value() == 1000.0
     assert widget.amp_spin.value() == pytest.approx(-6.02, abs=1e-2)
     assert widget.phase_spin.value() == 0.0
-    assert widget.spin_max_harm.value() == 20
-    assert widget.table.rowCount() == 19  # Max 20 harmonics means rows for 2nd to 20th
+    assert widget.spin_max_harm.value() == 10
+    assert widget.table.rowCount() == 9  # Max 10 harmonics means rows for 2nd to 10th
     assert not widget.chk_comp_enable.isEnabled()
+
+
+def test_theoretical_thd_display_includes_compensation(generator_widget):
+    widget, module, _engine = generator_widget
+
+    module.gen_amplitude = 0.5
+    module.max_harmonic = 3
+    module.harmonics_amps[1] = 0.03
+    module.harmonics_phases_deg[1] = 0.0
+    module.harmonics_amps[2] = 0.04
+    module.harmonics_phases_deg[2] = 90.0
+
+    # Add an in-phase 0.01 component to the 2nd harmonic.
+    module.compensation_enabled = True
+    module.adjusted_compensation_coeffs[1] = 0.0 + 0.01j
+
+    widget.update_plots()
+
+    # Combined harmonic amplitudes are 0.04 and 0.04, so THD is
+    # sqrt(0.04^2 + 0.04^2) / 0.5 * 100 = 11.3137... %.
+    assert "11.3137 %" in widget.lbl_theoretical_thd.text()
 
 
 def test_fundamental_and_harmonics_signal_generation(generator_widget):


### PR DESCRIPTION
## Summary

- Show the theoretical THD value above the synthesized waveform preview.
- Calculate THD from the phase-aware combination of configured harmonics and enabled compensation components.
- Change the default maximum harmonic order from 20 to 10.
- Add localized labels for all supported languages and cover the behavior with a GUI test.

## Why

The output waveform monitor showed the synthesized shape but did not provide the expected distortion ratio. Displaying the theoretical THD makes the configured harmonic content immediately quantifiable, including the effect of compensation.

## User impact

Users can now see the theoretical THD update with harmonic and compensation settings. New generator instances start with 10 harmonics displayed by default.

## Validation

- `./.venv/bin/python -m pytest -q tests/logic_verification/gui/widgets/test_arbitrary_harmonic_generator.py tests/security/test_arbitrary_harmonic_generator_security.py` — 11 passed
- `./.venv/bin/ruff check src/gui/widgets/arbitrary_harmonic_generator.py tests/logic_verification/gui/widgets/test_arbitrary_harmonic_generator.py`
- `./.venv/bin/python scripts/check_trn_keys.py`
- `./.venv/bin/python scripts/check_ui_size_limits.py`