### PR TITLE
Fix split window screenshot and state transitions

### DIFF
--- a/src/gui/widgets/detachable_wrapper.py
+++ b/src/gui/widgets/detachable_wrapper.py
@@ -262,6 +262,14 @@ class DetachableWidgetWrapper(QWidget):
                 return candidate
         return base
 
+    def _get_screenshot_target(self) -> QWidget:
+        """Return the panel that currently represents the module's display."""
+        if self.is_split and self.split_display_window is not None:
+            display_widget = self.split_display_window.centralWidget()
+            if display_widget is not None:
+                return display_widget
+        return self.content_widget
+
     def save_screenshot(self):
         out_dir = self._get_screenshot_output_dir()
         try:
@@ -271,7 +279,7 @@ class DetachableWidgetWrapper(QWidget):
             return
 
         try:
-            pixmap = self.content_widget.grab()
+            pixmap = self._get_screenshot_target().grab()
         except Exception as e:
             QMessageBox.warning(self, tr("Error"), tr("Failed to capture screenshot: {0}").format(str(e)))
             return
@@ -349,7 +357,7 @@ class DetachableWidgetWrapper(QWidget):
             self.detach()
 
     def detach(self):
-        if self.is_detached:
+        if self.is_detached or self.is_split:
             return
 
         # 1. Remove widget from local layout
@@ -375,7 +383,8 @@ class DetachableWidgetWrapper(QWidget):
         if self.compact_btn:
             self.compact_btn.setEnabled(True)
         if self.split_btn:
-            self.split_btn.setEnabled(False)
+            # State B can transition directly to State C.
+            self.split_btn.setEnabled(True)
         self.is_detached = True
 
     def reattach(self):

--- a/tests/logic_verification/gui/test_detachable_wrapper_split_actions.py
+++ b/tests/logic_verification/gui/test_detachable_wrapper_split_actions.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QPixmap
+from PyQt6.QtWidgets import QHBoxLayout, QWidget
+
+from src.gui.widgets.detachable_wrapper import DetachableWidgetWrapper
+from src.gui.widgets.splittable_interface import SplittableWidgetInterface
+
+
+class _TrackingPanel(QWidget):
+    def __init__(self, color: Qt.GlobalColor):
+        super().__init__()
+        self.color = color
+        self.grab_calls = 0
+
+    def grab(self) -> QPixmap:
+        self.grab_calls += 1
+        pixmap = QPixmap(8, 8)
+        pixmap.fill(self.color)
+        return pixmap
+
+
+class _SplittableContent(_TrackingPanel, SplittableWidgetInterface):
+    def __init__(self):
+        super().__init__(Qt.GlobalColor.black)
+        self.display_widget = _TrackingPanel(Qt.GlobalColor.green)
+        self.control_widget = _TrackingPanel(Qt.GlobalColor.blue)
+        self.main_layout = QHBoxLayout(self)
+        self.main_layout.addWidget(self.display_widget)
+        self.main_layout.addWidget(self.control_widget)
+
+    def get_display_widget(self) -> QWidget:
+        return self.display_widget
+
+    def get_control_widget(self) -> QWidget:
+        return self.control_widget
+
+    def restore_split_panels(self) -> None:
+        self.main_layout.addWidget(self.display_widget)
+        self.main_layout.addWidget(self.control_widget)
+
+
+@pytest.fixture
+def split_wrapper(qapp, qtbot):
+    content = _SplittableContent()
+    wrapper = DetachableWidgetWrapper(content, "Split Actions")
+    qtbot.addWidget(wrapper)
+    wrapper.show()
+    yield wrapper, content
+    if wrapper.is_split:
+        wrapper.reattach_all()
+    elif wrapper.is_detached:
+        wrapper.reattach()
+    qapp.processEvents()
+
+
+def test_screenshot_captures_visible_display_panel_while_split(split_wrapper, tmp_path, qtbot):
+    wrapper, content = split_wrapper
+    wrapper.config_manager = type(
+        "Config",
+        (),
+        {"get_screenshot_output_dir": lambda self: str(tmp_path)},
+    )()
+    wrapper.split()
+    qtbot.wait(1)
+
+    with patch("src.gui.widgets.detachable_wrapper.QMessageBox.information") as information:
+        wrapper.screenshot_btn.click()
+
+    assert content.display_widget.grab_calls == 1
+    assert content.control_widget.grab_calls == 0
+    assert content.grab_calls == 0
+    assert len(list(tmp_path.glob("Split_Actions_*.png"))) == 1
+    information.assert_called_once()
+
+
+def test_split_button_transitions_from_detached_state(split_wrapper, qtbot):
+    wrapper, content = split_wrapper
+    wrapper.detach()
+    qtbot.wait(1)
+
+    assert wrapper.is_detached
+    assert wrapper.split_btn is not None
+    assert wrapper.split_btn.isEnabled()
+
+    wrapper.split_btn.click()
+    qtbot.wait(1)
+
+    assert not wrapper.is_detached
+    assert wrapper.is_split
+    assert content.display_widget.parent() is wrapper.split_display_window
+    assert content.control_widget.parent() is wrapper.split_control_window
+
+
+def test_detach_request_does_not_corrupt_split_state(split_wrapper, qtbot):
+    wrapper, content = split_wrapper
+    wrapper.split()
+    qtbot.wait(1)
+    display_window = wrapper.split_display_window
+    control_window = wrapper.split_control_window
+
+    wrapper.detach()
+
+    assert wrapper.is_split
+    assert not wrapper.is_detached
+    assert wrapper.split_display_window is display_window
+    assert wrapper.split_control_window is control_window
+    assert content.display_widget.parent() is display_window
+    assert content.control_widget.parent() is control_window


### PR DESCRIPTION
## Summary

- capture the visible display panel when taking screenshots in split mode
- keep the Split Window button enabled while a widget is detached so State B can transition to State C
- guard against detach requests while already split
- add regression coverage for split-mode header actions and state integrity

## Root cause

In split mode, the original content widget is detached from the visible hierarchy while its display and control panels are owned by separate windows. The screenshot action still called `grab()` on that hidden content widget, which could produce an empty or incorrect image. The detached-state UI also disabled the Split Window button even though the state design supports transitioning directly from detached to split.

## Impact

Screenshots taken in split mode now capture the live display panel. Users can also move directly from a detached window to split mode using the UI, without risking state corruption from conflicting detach requests.

## Validation

- `./.venv/bin/python -m pytest -q` — 1033 passed, 6 skipped, 29 subtests passed
- related split GUI tests — 29 passed
- `./.venv/bin/ruff check src/gui/widgets/detachable_wrapper.py tests/logic_verification/gui/test_detachable_wrapper_split_actions.py`
- `./.venv/bin/python scripts/check_ui_size_limits.py`
- `git diff --check`