### PR TITLE
Allow positive dBFS clip detection thresholds

### DIFF
--- a/src/core/event_detector.py
+++ b/src/core/event_detector.py
@@ -87,10 +87,10 @@ class DetectorConfig:
             raise ValueError("holdoff_seconds must not be negative")
         if self.clip_level <= 0:
             raise ValueError("clip_level must be greater than zero")
-        if self.threshold >= self.clip_level:
-            raise ValueError("threshold must be smaller than clip_level")
         if not isinstance(self.clipping_invalidates_measurement, bool):
             raise ValueError("clipping_invalidates_measurement must be a boolean")
+        if self.clipping_invalidates_measurement and self.threshold >= self.clip_level:
+            raise ValueError("threshold must be smaller than clip_level")
 
     @property
     def holdoff_samples(self) -> int:

--- a/src/gui/widgets/event_detector.py
+++ b/src/gui/widgets/event_detector.py
@@ -66,8 +66,10 @@ class EventDetector(MeasurementModule):
     """AudioEngine adapter for the sample-accurate event detector core."""
 
     THRESHOLD_UNITS = ("FS", "mV", "V")
-    DEFAULT_CLIP_THRESHOLD_DBFS = -0.1
+    DEFAULT_CLIP_THRESHOLD_DBFS = 0.0
     DEFAULT_CLIP_RELEASE_DBFS = -1.0
+    MIN_CLIP_THRESHOLD_DBFS = -20.0
+    MAX_CLIP_THRESHOLD_DBFS = 100.0
 
     def __init__(self, audio_engine: AudioEngine):
         self.audio_engine = audio_engine
@@ -154,10 +156,7 @@ class EventDetector(MeasurementModule):
             "loopback",
             "audio_engine_64bit",
         )
-        return tuple(
-            (name, self._signature_value(getattr(self.audio_engine, name, None)))
-            for name in names
-        )
+        return tuple((name, self._signature_value(getattr(self.audio_engine, name, None))) for name in names)
 
     @staticmethod
     def _metadata_scalar(value: object) -> object:
@@ -683,9 +682,7 @@ class EventDetector(MeasurementModule):
                     return
                 samples = data[:, run_input_channel]
 
-            input_status = bool(
-                getattr(status, "input_overflow", False) or getattr(status, "input_underflow", False)
-            )
+            input_status = bool(getattr(status, "input_overflow", False) or getattr(status, "input_underflow", False))
             if status and not any(
                 hasattr(status, name)
                 for name in ("input_overflow", "input_underflow", "output_overflow", "output_underflow")
@@ -1154,7 +1151,10 @@ class EventDetectorWidget(QWidget, CompactableWidgetInterface, SplittableWidgetI
             self.spin_hysteresis.blockSignals(True)
             try:
                 self.spin_threshold.setDecimals(2)
-                self.spin_threshold.setRange(-20.0, -0.001)
+                self.spin_threshold.setRange(
+                    self.module.MIN_CLIP_THRESHOLD_DBFS,
+                    self.module.MAX_CLIP_THRESHOLD_DBFS,
+                )
                 self.spin_threshold.setSingleStep(0.1)
                 self.spin_threshold.setSuffix(" dBFS")
                 self.spin_threshold.setValue(threshold_dbfs)

--- a/tests/logic_verification/core/test_event_detector.py
+++ b/tests/logic_verification/core/test_event_detector.py
@@ -52,6 +52,17 @@ def test_config_rejects_invalid_settings(kwargs, message):
         DetectorConfig(**kwargs)
 
 
+def test_config_allows_clip_event_threshold_above_full_scale():
+    config = DetectorConfig(
+        sample_rate=1000,
+        threshold=1000.0,
+        hysteresis=999.0,
+        clipping_invalidates_measurement=False,
+    )
+
+    assert config.threshold == pytest.approx(1000.0)
+
+
 def test_positive_events_record_count_peak_duration_and_interval():
     detector = make_detector(polarity=EventPolarity.POSITIVE)
 

--- a/tests/logic_verification/gui/test_event_detector_widget.py
+++ b/tests/logic_verification/gui/test_event_detector_widget.py
@@ -64,13 +64,13 @@ def test_module_defaults_to_practical_clip_event_detection():
     module, callbacks = make_module(detection_mode=None)
 
     assert module.detection_mode == EventDetectionMode.CLIP_EVENTS
-    assert module.fs_to_dbfs(module.threshold) == pytest.approx(-0.1)
+    assert module.fs_to_dbfs(module.threshold) == pytest.approx(0.0)
     assert module.fs_to_dbfs(module.threshold - module.hysteresis) == pytest.approx(-1.0)
     assert module.polarity == EventPolarity.BOTH
     assert module.holdoff_ms == pytest.approx(10.0)
 
     module.start_analysis()
-    samples = np.array([0.0, 0.99, 0.8, *([0.0] * 11), -1.0, -0.8])
+    samples = np.array([0.0, 1.0, 0.8, *([0.0] * 11), -1.0, -0.8])
     callbacks[0](samples, np.zeros_like(samples), len(samples), None, False)
     snapshot = module.get_snapshot()
     metadata = module.get_run_metadata()
@@ -80,7 +80,7 @@ def test_module_defaults_to_practical_clip_event_detection():
     assert snapshot.measurement_valid
     assert metadata is not None
     assert metadata["detection_mode"] == "clip_events"
-    assert metadata["clip_threshold_dbfs"] == pytest.approx(-0.1)
+    assert metadata["clip_threshold_dbfs"] == pytest.approx(0.0)
     assert metadata["clip_rearm_dbfs"] == pytest.approx(-1.0)
     assert metadata["clipping_invalidates_measurement"] is False
 
@@ -91,13 +91,13 @@ def test_widget_defaults_to_clip_mode_and_preserves_each_mode_profile(qtbot):
     qtbot.addWidget(widget)
 
     assert widget.combo_mode.currentData() == EventDetectionMode.CLIP_EVENTS
-    assert widget.spin_threshold.value() == pytest.approx(-0.1)
+    assert widget.spin_threshold.value() == pytest.approx(0.0)
     assert widget.spin_hysteresis.value() == pytest.approx(-1.0)
     assert widget.combo_threshold_unit.isHidden()
     assert widget.combo_polarity.isHidden()
     assert widget.count_group.title() == "Clip Event Count"
     assert widget.rate_group.title() == "Clip Event Rate"
-    assert widget.lbl_conditions.text() == "CH1  •  Clip ≥ -0.10 dBFS  •  1 kHz"
+    assert widget.lbl_conditions.text() == "CH1  •  Clip ≥ 0.00 dBFS  •  1 kHz"
 
     widget.combo_mode.setCurrentIndex(widget.combo_mode.findData(EventDetectionMode.THRESHOLD_EVENTS))
     assert widget.spin_threshold.value() == pytest.approx(0.01)
@@ -107,9 +107,26 @@ def test_widget_defaults_to_clip_mode_and_preserves_each_mode_profile(qtbot):
     widget.spin_threshold.setValue(0.5)
 
     widget.combo_mode.setCurrentIndex(widget.combo_mode.findData(EventDetectionMode.CLIP_EVENTS))
-    assert widget.spin_threshold.value() == pytest.approx(-0.1)
+    assert widget.spin_threshold.value() == pytest.approx(0.0)
     widget.combo_mode.setCurrentIndex(widget.combo_mode.findData(EventDetectionMode.THRESHOLD_EVENTS))
     assert widget.spin_threshold.value() == pytest.approx(0.5)
+
+
+def test_clip_level_accepts_large_positive_dbfs_values(qtbot):
+    module, callbacks = make_module(detection_mode=None)
+    widget = EventDetectorWidget(module)
+    qtbot.addWidget(widget)
+
+    assert widget.spin_threshold.maximum() == pytest.approx(100.0)
+    widget.spin_threshold.setValue(60.0)
+
+    assert module.fs_to_dbfs(module.threshold) == pytest.approx(60.0)
+    widget.btn_start.click()
+    samples = np.array([0.0, 1000.0, 1001.0, 0.0], dtype=np.float32)
+    callbacks[0](samples, np.zeros_like(samples), len(samples), None, False)
+
+    assert module.get_snapshot().event_count == 1
+    assert module.get_run_metadata()["clip_threshold_dbfs"] == pytest.approx(60.0)
 
 
 def test_widget_reports_detected_clips_without_invalidating_clip_measurement(qtbot):


### PR DESCRIPTION
## Summary

- Set the default clip detection threshold to 0.0 dBFS.
- Expand the configurable clip threshold range to -20.0 through +100.0 dBFS.
- Allow thresholds at or above full scale when clipping does not invalidate the measurement.
- Add coverage for +60 dBFS float32 clip-event detection.

## Why

Float32 audio paths can carry valid sample values above 0 dBFS, but the clip-level control previously stopped below 0 dBFS. The detector core also rejected thresholds at or above 1.0 FS unconditionally, so simply widening the GUI range was insufficient.

Threshold-event mode keeps its existing full-scale safety constraint. Clip-event mode can now measure overs while preserving the requirement that the rearm level remains below the clip threshold.

## Impact

Users can configure clip detection for float32 devices and signal paths that exceed 0 dBFS. Existing threshold-event behavior is unchanged.

## Validation

- `./.venv/bin/python -m pytest -q tests/logic_verification/core/test_event_detector.py tests/logic_verification/gui/test_event_detector_widget.py` (`68 passed`)
- `./.venv/bin/ruff check` on the changed source and test files
- `./.venv/bin/ruff format --check` on the changed source and test files
- `./.venv/bin/python scripts/check_ui_size_limits.py`