### PR TITLE
Declare widget capabilities and enforce contracts

### DIFF
--- a/docs/widget_feature_implementation_matrix.md
+++ b/docs/widget_feature_implementation_matrix.md
@@ -14,9 +14,9 @@ Nonlinear Response Analyzer は実験的モジュールですが、実装漏れ�
 判定は次のコード上の事実に基づきます。
 
 - 全モジュール共通機能: `DetachableWidgetWrapper` から常に提供されるか
-- コンパクトモード: `CompactableWidgetInterface` とレイアウト更新処理があるか
-- 2 窓分割: `SplittableWidgetInterface` と表示、操作、復元の 3 処理があるか
-- 比較送信: `ComparableWidgetInterface` と比較データ生成処理があるか
+- コンパクトモード: `WidgetCapabilities` の宣言と `CompactableWidgetInterface`、レイアウト更新処理が一致するか
+- 2 窓分割: `WidgetCapabilities` の宣言と `SplittableWidgetInterface`、表示、操作、復元の 3 処理が一致するか
+- 比較送信: `WidgetCapabilities` の宣言と `ComparableWidgetInterface`、比較データ生成処理が一致するか
 - テスト: 対象機能を直接操作する自動テストが存在し、今回の調査で成功したか
 
 ## ステータスの見方
@@ -142,20 +142,28 @@ Logs はモジュール固有ログではなく、共通のシングルトンロ
 - Menu Only: コンテンツ領域と通常ステータスバーを隠し、サイドバー幅まで縮小
 - Menu Only からの分離起動: モジュールをダブルクリックすると State B で開く
 - グローバル出力先: Physical、Internal Loopback、Loopback + Physical を共通選択
-- 遅延ロード: 選択時にモジュールとウィジェットを生成し、同じ共通ラッパーで包む
+- モジュール生成: 通常起動ではスプラッシュ表示中に全対象モジュールを事前ロードし、未生成の場合は
+  選択時に遅延ロードする。どちらの経路でも同じ共通ラッパーで包む
 - アクティビティ表示: 実行中モジュールをサイドバーで強調し、分離状態をツールチップへ表示
 
 ## 実装漏れ防止の観点で見つかった課題
 
-### 優先度高: 自動検出できない実装・資料のずれ
+### 対応済み: 機能宣言と実装の自動照合
 
-1. 機能対応表の正本がありません。現在はラッパーが `isinstance()` または `hasattr()` で
-   実行時に機能を推定します。そのため、新規ウィジェットでインターフェースや必要メソッドを
-   一つ実装し忘れても、ボタンが表示されないだけで気付きにくい構造です。
-2. `MODULE_REGISTRY` の全モジュールに対して、期待する機能宣言と実装を照合する契約テストがありません。
-3. Transmission Analyzer のコンパクトモード、Distortion Analyzer と Lock-in Amplifier の比較送信には
+1. `src/gui/module_registry.py` の `WidgetCapabilities` を機能対応の正本とし、ラッパーのボタン表示と
+   独立ウィンドウのコンパクト操作は宣言だけから決定するようにしました。`hasattr()` による推定経路は
+   使用しません。
+2. `MODULE_REGISTRY` の全 42 モジュールを実際に生成し、宣言、インターフェース、必須メソッドの
+   オーバーライドを照合する契約テストを追加しました。宣言と実装が異なる場合は、ラッパー初期化時にも
+   明確なエラーとして検出します。
+
+### 優先度高: 直接テストと資料同期の残課題
+
+1. Transmission Analyzer のコンパクトモード、Distortion Analyzer と Lock-in Amplifier の比較送信には
    直接テストが見当たりません。
-4. Logs ボタンからログビューアを開く共通操作には直接テストが見当たりません。
+2. Logs ボタンからログビューアを開く共通操作には直接テストが見当たりません。
+3. この表はまだ手書きです。実装状態と対象外理由を `WidgetCapabilities` から生成しなければ、
+   コードの正本と資料が将来ずれる可能性は残ります。
 
 ### 優先度中: ウィンドウ状態の扱い
 
@@ -184,16 +192,14 @@ Logs はモジュール固有ログではなく、共通のシングルトンロ
 
 ## 次に追加すると効果が高い仕組み
 
-1. モジュールごとの期待機能と対象外理由を宣言する `WidgetCapabilities` を一か所に置く
-2. `MODULE_REGISTRY` の全クラスを走査し、対象機能の宣言とインターフェース実装を照合するテストを追加する
-3. この表の実装状態、`要`、対象外理由を宣言データから自動生成し、手書きの表とコードの乖離をなくす
-4. 未テストの 7 個別機能と Logs 共通操作へテストを追加する
-5. State C をサイドバー表示と Menu Only の前面化処理へ追加する
-6. 個別マニュアルでは曖昧な「など」を避け、対応機能を明示する
+1. この表の実装状態、`要`、対象外理由を宣言データから自動生成し、手書きの表とコードの乖離をなくす
+2. 未テストの 3 個別機能と Logs 共通操作へテストを追加する
+3. State C をサイドバー表示と Menu Only の前面化処理へ追加する
+4. 個別マニュアルでは曖昧な「など」を避け、対応機能を明示する
 
 ## 検証記録
 
-今回、共通機能に関連する GUI テスト 17 ファイルをまとめて実行し、`113 passed` を確認しました。
+今回、共通機能に関連する GUI テスト 18 ファイルをまとめて実行し、`115 passed` を確認しました。
 静的確認だけでなく、コンパクト切り替え、分割と再接続、State B から State C への遷移、
 分割中のスクリーンショット、比較データ生成を含みます。
 
@@ -203,8 +209,10 @@ Logs はモジュール固有ログではなく、共通のシングルトンロ
 ## 主な根拠コード
 
 - モジュール一覧とラッパー適用: `src/gui/main_window.py`
+- モジュール機能宣言の正本: `src/gui/module_registry.py`
 - モジュール名の正本: `src/core/module_constants.py`
 - 分離、分割、撮影、ログ、比較送信: `src/gui/widgets/detachable_wrapper.py`
+- 全モジュール契約テスト: `tests/logic_verification/gui/test_widget_capabilities.py`
 - コンパクト契約: `src/gui/widgets/compactable_interface.py`
 - 2 窓分割契約: `src/gui/widgets/splittable_interface.py`
 - 比較送信契約: `src/gui/widgets/comparable_interface.py`

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -24,99 +24,9 @@ from PyQt6.QtWidgets import (
 from src.core.audio_engine import AudioEngine
 from src.core.config_manager import ConfigManager
 from src.core.localization import get_manager, tr
-from src.core.module_constants import (
-    ALL_MODULE_KEYS,
-    EXPERIMENTAL_MODULE_KEYS,
-    MODULE_1PPS_MONITOR,
-    MODULE_ADVANCED_DISTORTION_METER,
-    MODULE_TRANSMISSION_ANALYZER,
-    MODULE_BNIM_METER,
-    MODULE_BOXCAR_AVERAGER,
-    MODULE_DISTORTION_ANALYZER,
-    MODULE_FREQUENCY_COUNTER,
-    MODULE_GONIOMETER,
-    MODULE_HRTF_PLAYER,
-    MODULE_IMPEDANCE_ANALYZER,
-    MODULE_LINEARITY_ANALYZER,
-    MODULE_LOCK_IN_AMPLIFIER,
-    MODULE_LOCK_IN_FREQUENCY_COUNTER,
-    MODULE_LOCK_IN_HARMONIC_ANALYZER,
-    MODULE_ARBITRARY_HARMONIC_GENERATOR,
-    MODULE_LOCKIN_SPECTRUM_FINDER,
-    MODULE_LOOPBACK_FINDER,
-    MODULE_LUFS_METER,
-    MODULE_NETWORK_ANALYZER,
-    MODULE_NOISE_PROFILER,
-    MODULE_OSCILLOSCOPE,
-    MODULE_PROCESSOR_BENCHMARK,
-    MODULE_RAW_TIME_SERIES,
-    MODULE_EVENT_DETECTOR,
-    MODULE_PLOT_COMPARER,
-    MODULE_RECORDER_PLAYER,
-    MODULE_SIGNAL_GENERATOR,
-    MODULE_SOUND_LEVEL_METER,
-    MODULE_SOUND_QUALITY_ANALYZER,
-    MODULE_SPATIAL_BINAURAL_MIXER,
-    MODULE_SPECTROGRAM,
-    MODULE_SPECTRUM_ANALYZER,
-    MODULE_STEREO_ALIGNMENT_MONITOR,
-    MODULE_TIMECODE_MONITOR,
-    MODULE_TRANSIENT_ANALYZER,
-    MODULE_ULTRASOUND_MODULATOR,
-    MODULE_WAVEFORM_LOOP_PLAYER,
-    MODULE_NONLINEAR_ANALYZER,
-    MODULE_RESPONSE_VIEWER,
-    MODULE_FEEDFORWARD_COMPENSATOR,
-    MODULE_NONLINEAR_RESPONSE_ANALYZER,
-    MODULE_LOCKIN_MODELER,
-)
+from src.core.module_constants import ALL_MODULE_KEYS, EXPERIMENTAL_MODULE_KEYS
+from src.gui.module_registry import MODULE_REGISTRY
 from src.gui.widgets.detachable_wrapper import DetachableWidgetWrapper
-
-# Registry mapping module key -> (module_path, class_name)
-MODULE_REGISTRY = {
-    MODULE_SIGNAL_GENERATOR: ("src.gui.widgets.signal_generator", "SignalGenerator"),
-    MODULE_SPECTRUM_ANALYZER: ("src.gui.widgets.spectrum_analyzer", "SpectrumAnalyzer"),
-    MODULE_SOUND_LEVEL_METER: ("src.gui.widgets.sound_level_meter", "SoundLevelMeter"),
-    MODULE_LUFS_METER: ("src.gui.widgets.lufs_meter", "LufsMeter"),
-    MODULE_LOOPBACK_FINDER: ("src.gui.widgets.loopback_finder", "LoopbackFinder"),
-    MODULE_DISTORTION_ANALYZER: ("src.gui.widgets.distortion_analyzer", "DistortionAnalyzer"),
-    MODULE_ADVANCED_DISTORTION_METER: ("src.gui.widgets.advanced_distortion_meter", "AdvancedDistortionMeter"),
-    MODULE_NETWORK_ANALYZER: ("src.gui.widgets.network_analyzer", "NetworkAnalyzer"),
-    MODULE_OSCILLOSCOPE: ("src.gui.widgets.oscilloscope", "Oscilloscope"),
-    MODULE_RAW_TIME_SERIES: ("src.gui.widgets.raw_time_series", "RawTimeSeries"),
-    MODULE_EVENT_DETECTOR: ("src.gui.widgets.event_detector", "EventDetector"),
-    MODULE_LOCK_IN_AMPLIFIER: ("src.gui.widgets.lock_in_amplifier", "LockInAmplifier"),
-    MODULE_LOCK_IN_HARMONIC_ANALYZER: ("src.gui.widgets.lockin_harmonic_analyzer", "LockInHarmonicAnalyzer"),
-    MODULE_ARBITRARY_HARMONIC_GENERATOR: ("src.gui.widgets.arbitrary_harmonic_generator", "ArbitraryHarmonicGenerator"),
-    MODULE_LOCKIN_SPECTRUM_FINDER: ("src.gui.widgets.lockin_spectrum_finder", "LockInSpectrumFinder"),
-    MODULE_FREQUENCY_COUNTER: ("src.gui.widgets.frequency_counter", "FrequencyCounter"),
-    MODULE_LOCK_IN_FREQUENCY_COUNTER: ("src.gui.widgets.lock_in_frequency_counter", "LockInFrequencyCounter"),
-    MODULE_SPECTROGRAM: ("src.gui.widgets.spectrogram", "Spectrogram"),
-    MODULE_BOXCAR_AVERAGER: ("src.gui.widgets.boxcar_averager", "BoxcarAverager"),
-    MODULE_GONIOMETER: ("src.gui.widgets.goniometer", "Goniometer"),
-    MODULE_IMPEDANCE_ANALYZER: ("src.gui.widgets.impedance_analyzer", "ImpedanceAnalyzer"),
-    MODULE_NOISE_PROFILER: ("src.gui.widgets.noise_profiler", "NoiseProfiler"),
-    MODULE_RECORDER_PLAYER: ("src.gui.widgets.recorder_player", "RecorderPlayer"),
-    MODULE_WAVEFORM_LOOP_PLAYER: ("src.gui.widgets.waveform_loop_player", "WaveformLoopPlayer"),
-    MODULE_TRANSIENT_ANALYZER: ("src.gui.widgets.transient_analyzer", "TransientAnalyzer"),
-    MODULE_SOUND_QUALITY_ANALYZER: ("src.gui.widgets.sound_quality_analyzer", "SoundQualityAnalyzer"),
-    MODULE_TIMECODE_MONITOR: ("src.gui.widgets.timecode_monitor", "TimecodeMonitor"),
-    MODULE_BNIM_METER: ("src.gui.widgets.bnim_meter", "BNIMMeter"),
-    MODULE_HRTF_PLAYER: ("src.gui.widgets.hrtf_player", "HRTFPlayer"),
-    MODULE_ULTRASOUND_MODULATOR: ("src.gui.widgets.ultrasound_modulator", "UltrasoundModulator"),
-    MODULE_LINEARITY_ANALYZER: ("src.gui.widgets.linearity_analyzer", "LinearityAnalyzer"),
-    MODULE_1PPS_MONITOR: ("src.gui.widgets.one_pps_monitor", "OnePPSMonitor"),
-    MODULE_STEREO_ALIGNMENT_MONITOR: ("src.gui.widgets.stereo_alignment_monitor", "StereoAlignmentMonitor"),
-    MODULE_PROCESSOR_BENCHMARK: ("src.gui.widgets.processor_benchmark", "ProcessorBenchmark"),
-    MODULE_SPATIAL_BINAURAL_MIXER: ("src.gui.widgets.spatial_binaural_mixer", "SpatialBinauralMixer"),
-    MODULE_PLOT_COMPARER: ("src.gui.widgets.plot_comparer", "PlotComparer"),
-    MODULE_TRANSMISSION_ANALYZER: ("src.gui.widgets.transmission_analyzer", "TransmissionAnalyzer"),
-    MODULE_NONLINEAR_ANALYZER: ("src.gui.widgets.nonlinear_analyzer", "NonlinearAnalyzer"),
-    MODULE_RESPONSE_VIEWER: ("src.gui.widgets.response_viewer", "ResponseViewer"),
-    MODULE_FEEDFORWARD_COMPENSATOR: ("src.gui.widgets.feedforward_compensator", "FeedforwardCompensator"),
-    MODULE_NONLINEAR_RESPONSE_ANALYZER: ("src.gui.widgets.nonlinear_response_analyzer", "NonlinearResponseAnalyzer"),
-    MODULE_LOCKIN_MODELER: ("src.gui.widgets.lock_in_modeler", "LockInModeler"),
-}
 
 
 def _load_class(module_path: str, class_name: str):
@@ -134,7 +44,8 @@ def _load_module_class(module_key: str):
     if module_key not in MODULE_REGISTRY:
         raise KeyError(f"Unknown module key: {module_key}")
 
-    return _load_class(*MODULE_REGISTRY[module_key])
+    registration = MODULE_REGISTRY[module_key]
+    return _load_class(registration.module_path, registration.class_name)
 
 
 if False:
@@ -539,13 +450,19 @@ class MainWindow(QMainWindow):
         key = self._module_keys[module_index]
         container = self._module_containers[module_index]
         try:
+            registration = MODULE_REGISTRY[key]
             cls = _load_module_class(key)
             module = cls(self.audio_engine)
             self.modules[module_index] = module
 
             widget = module.get_widget()
             if widget:
-                wrapper = DetachableWidgetWrapper(widget, tr(key), self.config_manager)
+                wrapper = DetachableWidgetWrapper(
+                    widget,
+                    tr(key),
+                    self.config_manager,
+                    capabilities=registration.capabilities,
+                )
                 self.module_widgets[module_index] = wrapper
                 self._replace_container_contents(container, wrapper)
 

--- a/src/gui/module_registry.py
+++ b/src/gui/module_registry.py
@@ -1,0 +1,475 @@
+"""Module loading metadata and widget feature declarations.
+
+This module intentionally avoids importing PyQt or widget implementations so it
+can act as the lightweight source of truth for both runtime loading and tests.
+"""
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from src.core.module_constants import (
+    MODULE_1PPS_MONITOR,
+    MODULE_ADVANCED_DISTORTION_METER,
+    MODULE_ARBITRARY_HARMONIC_GENERATOR,
+    MODULE_BNIM_METER,
+    MODULE_BOXCAR_AVERAGER,
+    MODULE_DISTORTION_ANALYZER,
+    MODULE_EVENT_DETECTOR,
+    MODULE_FEEDFORWARD_COMPENSATOR,
+    MODULE_FREQUENCY_COUNTER,
+    MODULE_GONIOMETER,
+    MODULE_HRTF_PLAYER,
+    MODULE_IMPEDANCE_ANALYZER,
+    MODULE_LINEARITY_ANALYZER,
+    MODULE_LOCK_IN_AMPLIFIER,
+    MODULE_LOCK_IN_FREQUENCY_COUNTER,
+    MODULE_LOCK_IN_HARMONIC_ANALYZER,
+    MODULE_LOCKIN_MODELER,
+    MODULE_LOCKIN_SPECTRUM_FINDER,
+    MODULE_LOOPBACK_FINDER,
+    MODULE_LUFS_METER,
+    MODULE_NETWORK_ANALYZER,
+    MODULE_NOISE_PROFILER,
+    MODULE_NONLINEAR_ANALYZER,
+    MODULE_NONLINEAR_RESPONSE_ANALYZER,
+    MODULE_OSCILLOSCOPE,
+    MODULE_PLOT_COMPARER,
+    MODULE_PROCESSOR_BENCHMARK,
+    MODULE_RAW_TIME_SERIES,
+    MODULE_RECORDER_PLAYER,
+    MODULE_RESPONSE_VIEWER,
+    MODULE_SIGNAL_GENERATOR,
+    MODULE_SOUND_LEVEL_METER,
+    MODULE_SOUND_QUALITY_ANALYZER,
+    MODULE_SPATIAL_BINAURAL_MIXER,
+    MODULE_SPECTROGRAM,
+    MODULE_SPECTRUM_ANALYZER,
+    MODULE_STEREO_ALIGNMENT_MONITOR,
+    MODULE_TIMECODE_MONITOR,
+    MODULE_TRANSIENT_ANALYZER,
+    MODULE_TRANSMISSION_ANALYZER,
+    MODULE_ULTRASOUND_MODULATOR,
+    MODULE_WAVEFORM_LOOP_PLAYER,
+)
+
+
+class CapabilityStatus(StrEnum):
+    """Whether a widget feature is part of the module's supported contract."""
+
+    SUPPORTED = "supported"
+    EXCLUDED = "excluded"
+
+
+class CapabilityExclusionReason(StrEnum):
+    """Reviewed reasons why a widget feature is intentionally unavailable."""
+
+    NO_INDEPENDENT_DISPLAY = "no_independent_display"  # Matrix: 外A
+    NON_TRACE_COMPARISON = "non_trace_comparison"  # Matrix: 外B
+    COMPARISON_RECEIVER = "comparison_receiver"  # Matrix: 外C
+    COMPARISON_DEFERRED = "comparison_deferred"  # Matrix: 外D
+    COMPACT_DEFERRED = "compact_deferred"  # Matrix: 外E
+    SPLIT_DEFERRED = "split_deferred"  # Matrix: 外F
+
+
+@dataclass(frozen=True, slots=True)
+class FeatureCapability:
+    """One explicit supported/excluded decision for a widget feature."""
+
+    status: CapabilityStatus
+    exclusion_reason: CapabilityExclusionReason | None = None
+
+    def __post_init__(self) -> None:
+        if self.status is CapabilityStatus.SUPPORTED and self.exclusion_reason is not None:
+            raise ValueError("Supported capabilities cannot have an exclusion reason")
+        if self.status is CapabilityStatus.EXCLUDED and self.exclusion_reason is None:
+            raise ValueError("Excluded capabilities must have an exclusion reason")
+
+    @property
+    def is_supported(self) -> bool:
+        return self.status is CapabilityStatus.SUPPORTED
+
+
+SUPPORTED = FeatureCapability(CapabilityStatus.SUPPORTED)
+NO_INDEPENDENT_DISPLAY = FeatureCapability(
+    CapabilityStatus.EXCLUDED,
+    CapabilityExclusionReason.NO_INDEPENDENT_DISPLAY,
+)
+NON_TRACE_COMPARISON = FeatureCapability(
+    CapabilityStatus.EXCLUDED,
+    CapabilityExclusionReason.NON_TRACE_COMPARISON,
+)
+COMPARISON_RECEIVER = FeatureCapability(
+    CapabilityStatus.EXCLUDED,
+    CapabilityExclusionReason.COMPARISON_RECEIVER,
+)
+COMPARISON_DEFERRED = FeatureCapability(
+    CapabilityStatus.EXCLUDED,
+    CapabilityExclusionReason.COMPARISON_DEFERRED,
+)
+COMPACT_DEFERRED = FeatureCapability(
+    CapabilityStatus.EXCLUDED,
+    CapabilityExclusionReason.COMPACT_DEFERRED,
+)
+SPLIT_DEFERRED = FeatureCapability(
+    CapabilityStatus.EXCLUDED,
+    CapabilityExclusionReason.SPLIT_DEFERRED,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class WidgetCapabilities:
+    """Authoritative feature contract for one registered module widget."""
+
+    split_window: FeatureCapability
+    compact_mode: FeatureCapability
+    comparison: FeatureCapability
+
+    def __post_init__(self) -> None:
+        allowed_reasons = {
+            "split_window": {
+                CapabilityExclusionReason.NO_INDEPENDENT_DISPLAY,
+                CapabilityExclusionReason.SPLIT_DEFERRED,
+            },
+            "compact_mode": {
+                CapabilityExclusionReason.NO_INDEPENDENT_DISPLAY,
+                CapabilityExclusionReason.COMPACT_DEFERRED,
+            },
+            "comparison": {
+                CapabilityExclusionReason.NO_INDEPENDENT_DISPLAY,
+                CapabilityExclusionReason.NON_TRACE_COMPARISON,
+                CapabilityExclusionReason.COMPARISON_RECEIVER,
+                CapabilityExclusionReason.COMPARISON_DEFERRED,
+            },
+        }
+        for feature_name, allowed in allowed_reasons.items():
+            capability = getattr(self, feature_name)
+            reason = capability.exclusion_reason
+            if reason is not None and reason not in allowed:
+                raise ValueError(f"{reason.value!r} is not a valid exclusion reason for {feature_name}")
+
+
+@dataclass(frozen=True, slots=True)
+class ModuleRegistration:
+    """Lazy-loading metadata plus the widget contract for one module."""
+
+    module_path: str
+    class_name: str
+    capabilities: WidgetCapabilities
+
+
+def _caps(
+    *,
+    split: FeatureCapability,
+    compact: FeatureCapability,
+    comparison: FeatureCapability,
+) -> WidgetCapabilities:
+    return WidgetCapabilities(split_window=split, compact_mode=compact, comparison=comparison)
+
+
+def _registration(
+    module_path: str,
+    class_name: str,
+    *,
+    split: FeatureCapability,
+    compact: FeatureCapability,
+    comparison: FeatureCapability,
+) -> ModuleRegistration:
+    return ModuleRegistration(module_path, class_name, _caps(split=split, compact=compact, comparison=comparison))
+
+
+MODULE_REGISTRY: dict[str, ModuleRegistration] = {
+    MODULE_SIGNAL_GENERATOR: _registration(
+        "src.gui.widgets.signal_generator",
+        "SignalGenerator",
+        split=NO_INDEPENDENT_DISPLAY,
+        compact=NO_INDEPENDENT_DISPLAY,
+        comparison=NO_INDEPENDENT_DISPLAY,
+    ),
+    MODULE_SPECTRUM_ANALYZER: _registration(
+        "src.gui.widgets.spectrum_analyzer",
+        "SpectrumAnalyzer",
+        split=SUPPORTED,
+        compact=SUPPORTED,
+        comparison=SUPPORTED,
+    ),
+    MODULE_SOUND_LEVEL_METER: _registration(
+        "src.gui.widgets.sound_level_meter",
+        "SoundLevelMeter",
+        split=SUPPORTED,
+        compact=SUPPORTED,
+        comparison=COMPARISON_DEFERRED,
+    ),
+    MODULE_LUFS_METER: _registration(
+        "src.gui.widgets.lufs_meter",
+        "LufsMeter",
+        split=SUPPORTED,
+        compact=SUPPORTED,
+        comparison=COMPARISON_DEFERRED,
+    ),
+    MODULE_LOOPBACK_FINDER: _registration(
+        "src.gui.widgets.loopback_finder",
+        "LoopbackFinder",
+        split=SPLIT_DEFERRED,
+        compact=COMPACT_DEFERRED,
+        comparison=NON_TRACE_COMPARISON,
+    ),
+    MODULE_DISTORTION_ANALYZER: _registration(
+        "src.gui.widgets.distortion_analyzer",
+        "DistortionAnalyzer",
+        split=SPLIT_DEFERRED,
+        compact=COMPACT_DEFERRED,
+        comparison=SUPPORTED,
+    ),
+    MODULE_ADVANCED_DISTORTION_METER: _registration(
+        "src.gui.widgets.advanced_distortion_meter",
+        "AdvancedDistortionMeter",
+        split=SPLIT_DEFERRED,
+        compact=COMPACT_DEFERRED,
+        comparison=COMPARISON_DEFERRED,
+    ),
+    MODULE_NETWORK_ANALYZER: _registration(
+        "src.gui.widgets.network_analyzer",
+        "NetworkAnalyzer",
+        split=SPLIT_DEFERRED,
+        compact=COMPACT_DEFERRED,
+        comparison=SUPPORTED,
+    ),
+    MODULE_OSCILLOSCOPE: _registration(
+        "src.gui.widgets.oscilloscope",
+        "Oscilloscope",
+        split=SUPPORTED,
+        compact=SUPPORTED,
+        comparison=SUPPORTED,
+    ),
+    MODULE_RAW_TIME_SERIES: _registration(
+        "src.gui.widgets.raw_time_series",
+        "RawTimeSeries",
+        split=SUPPORTED,
+        compact=SUPPORTED,
+        comparison=COMPARISON_DEFERRED,
+    ),
+    MODULE_EVENT_DETECTOR: _registration(
+        "src.gui.widgets.event_detector",
+        "EventDetector",
+        split=SUPPORTED,
+        compact=SUPPORTED,
+        comparison=COMPARISON_DEFERRED,
+    ),
+    MODULE_LOCK_IN_AMPLIFIER: _registration(
+        "src.gui.widgets.lock_in_amplifier",
+        "LockInAmplifier",
+        split=SPLIT_DEFERRED,
+        compact=COMPACT_DEFERRED,
+        comparison=SUPPORTED,
+    ),
+    MODULE_LOCK_IN_HARMONIC_ANALYZER: _registration(
+        "src.gui.widgets.lockin_harmonic_analyzer",
+        "LockInHarmonicAnalyzer",
+        split=SPLIT_DEFERRED,
+        compact=COMPACT_DEFERRED,
+        comparison=COMPARISON_DEFERRED,
+    ),
+    MODULE_ARBITRARY_HARMONIC_GENERATOR: _registration(
+        "src.gui.widgets.arbitrary_harmonic_generator",
+        "ArbitraryHarmonicGenerator",
+        split=SPLIT_DEFERRED,
+        compact=COMPACT_DEFERRED,
+        comparison=COMPARISON_DEFERRED,
+    ),
+    MODULE_LOCKIN_SPECTRUM_FINDER: _registration(
+        "src.gui.widgets.lockin_spectrum_finder",
+        "LockInSpectrumFinder",
+        split=SUPPORTED,
+        compact=COMPACT_DEFERRED,
+        comparison=COMPARISON_DEFERRED,
+    ),
+    MODULE_FREQUENCY_COUNTER: _registration(
+        "src.gui.widgets.frequency_counter",
+        "FrequencyCounter",
+        split=SPLIT_DEFERRED,
+        compact=SUPPORTED,
+        comparison=COMPARISON_DEFERRED,
+    ),
+    MODULE_LOCK_IN_FREQUENCY_COUNTER: _registration(
+        "src.gui.widgets.lock_in_frequency_counter",
+        "LockInFrequencyCounter",
+        split=SPLIT_DEFERRED,
+        compact=COMPACT_DEFERRED,
+        comparison=COMPARISON_DEFERRED,
+    ),
+    MODULE_SPECTROGRAM: _registration(
+        "src.gui.widgets.spectrogram",
+        "Spectrogram",
+        split=SUPPORTED,
+        compact=SUPPORTED,
+        comparison=NON_TRACE_COMPARISON,
+    ),
+    MODULE_BOXCAR_AVERAGER: _registration(
+        "src.gui.widgets.boxcar_averager",
+        "BoxcarAverager",
+        split=SPLIT_DEFERRED,
+        compact=COMPACT_DEFERRED,
+        comparison=COMPARISON_DEFERRED,
+    ),
+    MODULE_GONIOMETER: _registration(
+        "src.gui.widgets.goniometer",
+        "Goniometer",
+        split=SUPPORTED,
+        compact=SUPPORTED,
+        comparison=COMPARISON_DEFERRED,
+    ),
+    MODULE_IMPEDANCE_ANALYZER: _registration(
+        "src.gui.widgets.impedance_analyzer",
+        "ImpedanceAnalyzer",
+        split=SPLIT_DEFERRED,
+        compact=COMPACT_DEFERRED,
+        comparison=COMPARISON_DEFERRED,
+    ),
+    MODULE_NOISE_PROFILER: _registration(
+        "src.gui.widgets.noise_profiler",
+        "NoiseProfiler",
+        split=SUPPORTED,
+        compact=SUPPORTED,
+        comparison=COMPARISON_DEFERRED,
+    ),
+    MODULE_RECORDER_PLAYER: _registration(
+        "src.gui.widgets.recorder_player",
+        "RecorderPlayer",
+        split=NO_INDEPENDENT_DISPLAY,
+        compact=NO_INDEPENDENT_DISPLAY,
+        comparison=NO_INDEPENDENT_DISPLAY,
+    ),
+    MODULE_WAVEFORM_LOOP_PLAYER: _registration(
+        "src.gui.widgets.waveform_loop_player",
+        "WaveformLoopPlayer",
+        split=SPLIT_DEFERRED,
+        compact=COMPACT_DEFERRED,
+        comparison=COMPARISON_DEFERRED,
+    ),
+    MODULE_TRANSIENT_ANALYZER: _registration(
+        "src.gui.widgets.transient_analyzer",
+        "TransientAnalyzer",
+        split=SPLIT_DEFERRED,
+        compact=COMPACT_DEFERRED,
+        comparison=COMPARISON_DEFERRED,
+    ),
+    MODULE_SOUND_QUALITY_ANALYZER: _registration(
+        "src.gui.widgets.sound_quality_analyzer",
+        "SoundQualityAnalyzer",
+        split=SPLIT_DEFERRED,
+        compact=COMPACT_DEFERRED,
+        comparison=COMPARISON_DEFERRED,
+    ),
+    MODULE_TIMECODE_MONITOR: _registration(
+        "src.gui.widgets.timecode_monitor",
+        "TimecodeMonitor",
+        split=SPLIT_DEFERRED,
+        compact=SUPPORTED,
+        comparison=NON_TRACE_COMPARISON,
+    ),
+    MODULE_BNIM_METER: _registration(
+        "src.gui.widgets.bnim_meter",
+        "BNIMMeter",
+        split=SUPPORTED,
+        compact=SUPPORTED,
+        comparison=COMPARISON_DEFERRED,
+    ),
+    MODULE_HRTF_PLAYER: _registration(
+        "src.gui.widgets.hrtf_player",
+        "HRTFPlayer",
+        split=SPLIT_DEFERRED,
+        compact=COMPACT_DEFERRED,
+        comparison=NON_TRACE_COMPARISON,
+    ),
+    MODULE_ULTRASOUND_MODULATOR: _registration(
+        "src.gui.widgets.ultrasound_modulator",
+        "UltrasoundModulator",
+        split=NO_INDEPENDENT_DISPLAY,
+        compact=NO_INDEPENDENT_DISPLAY,
+        comparison=NO_INDEPENDENT_DISPLAY,
+    ),
+    MODULE_LINEARITY_ANALYZER: _registration(
+        "src.gui.widgets.linearity_analyzer",
+        "LinearityAnalyzer",
+        split=SPLIT_DEFERRED,
+        compact=COMPACT_DEFERRED,
+        comparison=COMPARISON_DEFERRED,
+    ),
+    MODULE_1PPS_MONITOR: _registration(
+        "src.gui.widgets.one_pps_monitor",
+        "OnePPSMonitor",
+        split=SPLIT_DEFERRED,
+        compact=COMPACT_DEFERRED,
+        comparison=COMPARISON_DEFERRED,
+    ),
+    MODULE_STEREO_ALIGNMENT_MONITOR: _registration(
+        "src.gui.widgets.stereo_alignment_monitor",
+        "StereoAlignmentMonitor",
+        split=SPLIT_DEFERRED,
+        compact=SUPPORTED,
+        comparison=COMPARISON_DEFERRED,
+    ),
+    MODULE_SPATIAL_BINAURAL_MIXER: _registration(
+        "src.gui.widgets.spatial_binaural_mixer",
+        "SpatialBinauralMixer",
+        split=NO_INDEPENDENT_DISPLAY,
+        compact=NO_INDEPENDENT_DISPLAY,
+        comparison=NO_INDEPENDENT_DISPLAY,
+    ),
+    MODULE_PROCESSOR_BENCHMARK: _registration(
+        "src.gui.widgets.processor_benchmark",
+        "ProcessorBenchmark",
+        split=SPLIT_DEFERRED,
+        compact=COMPACT_DEFERRED,
+        comparison=COMPARISON_DEFERRED,
+    ),
+    MODULE_PLOT_COMPARER: _registration(
+        "src.gui.widgets.plot_comparer",
+        "PlotComparer",
+        split=SPLIT_DEFERRED,
+        compact=COMPACT_DEFERRED,
+        comparison=COMPARISON_RECEIVER,
+    ),
+    MODULE_TRANSMISSION_ANALYZER: _registration(
+        "src.gui.widgets.transmission_analyzer",
+        "TransmissionAnalyzer",
+        split=SPLIT_DEFERRED,
+        compact=SUPPORTED,
+        comparison=COMPARISON_DEFERRED,
+    ),
+    MODULE_NONLINEAR_ANALYZER: _registration(
+        "src.gui.widgets.nonlinear_analyzer",
+        "NonlinearAnalyzer",
+        split=SPLIT_DEFERRED,
+        compact=COMPACT_DEFERRED,
+        comparison=COMPARISON_DEFERRED,
+    ),
+    MODULE_LOCKIN_MODELER: _registration(
+        "src.gui.widgets.lock_in_modeler",
+        "LockInModeler",
+        split=SPLIT_DEFERRED,
+        compact=COMPACT_DEFERRED,
+        comparison=COMPARISON_DEFERRED,
+    ),
+    MODULE_RESPONSE_VIEWER: _registration(
+        "src.gui.widgets.response_viewer",
+        "ResponseViewer",
+        split=SPLIT_DEFERRED,
+        compact=COMPACT_DEFERRED,
+        comparison=COMPARISON_DEFERRED,
+    ),
+    MODULE_FEEDFORWARD_COMPENSATOR: _registration(
+        "src.gui.widgets.feedforward_compensator",
+        "FeedforwardCompensator",
+        split=SPLIT_DEFERRED,
+        compact=COMPACT_DEFERRED,
+        comparison=COMPARISON_DEFERRED,
+    ),
+    MODULE_NONLINEAR_RESPONSE_ANALYZER: _registration(
+        "src.gui.widgets.nonlinear_response_analyzer",
+        "NonlinearResponseAnalyzer",
+        split=SPLIT_DEFERRED,
+        compact=COMPACT_DEFERRED,
+        comparison=COMPARISON_DEFERRED,
+    ),
+}

--- a/src/gui/widgets/detachable_wrapper.py
+++ b/src/gui/widgets/detachable_wrapper.py
@@ -16,10 +16,54 @@ from PyQt6.QtWidgets import (
 )
 
 from src.core.localization import tr
+from src.gui.module_registry import WidgetCapabilities
 from src.gui.widgets.compactable_interface import CompactableWidgetInterface
 from src.gui.widgets.comparable_interface import ComparableWidgetInterface
 from src.gui.widgets.splittable_interface import SplittableWidgetInterface
 from src.core.comparison_manager import ComparisonManager
+
+
+def validate_widget_capabilities(widget: QWidget, capabilities: WidgetCapabilities) -> None:
+    """Fail fast when a widget implementation disagrees with its declaration."""
+
+    contracts = (
+        (
+            "compact mode",
+            capabilities.compact_mode.is_supported,
+            CompactableWidgetInterface,
+            ("update_compact_layout",),
+        ),
+        (
+            "split window",
+            capabilities.split_window.is_supported,
+            SplittableWidgetInterface,
+            ("get_display_widget", "get_control_widget", "restore_split_panels"),
+        ),
+        (
+            "comparison",
+            capabilities.comparison.is_supported,
+            ComparableWidgetInterface,
+            ("get_comparable_data",),
+        ),
+    )
+    widget_type = type(widget)
+    for feature_name, declared_supported, interface_type, required_methods in contracts:
+        implemented = isinstance(widget, interface_type)
+        if implemented != declared_supported:
+            declared_text = "supported" if declared_supported else "excluded"
+            implemented_text = "implements" if implemented else "does not implement"
+            raise ValueError(
+                f"{widget_type.__name__} declares {feature_name} as {declared_text} "
+                f"but {implemented_text} {interface_type.__name__}"
+            )
+        if not declared_supported:
+            continue
+        for method_name in required_methods:
+            if getattr(widget_type, method_name) is getattr(interface_type, method_name):
+                raise ValueError(
+                    f"{widget_type.__name__} declares {feature_name} as supported "
+                    f"but does not override {method_name}()"
+                )
 
 
 class IndependentWindow(QMainWindow):
@@ -32,12 +76,22 @@ class IndependentWindow(QMainWindow):
     toggle_compact_requested = pyqtSignal()
     reattach_requested = pyqtSignal()
 
-    def __init__(self, title, widget, parent=None):
+    def __init__(
+        self,
+        title,
+        widget,
+        parent=None,
+        *,
+        supports_compact_mode: bool = False,
+        compact_target=None,
+    ):
         super().__init__(parent)
         self.setWindowTitle(title)
         self.resize(800, 600)
         self.setCentralWidget(widget)
         self.content_widget = widget
+        self.supports_compact_mode = supports_compact_mode
+        self.compact_target = compact_target
 
     def closeEvent(self, event):
         self.closed.emit()
@@ -45,7 +99,7 @@ class IndependentWindow(QMainWindow):
 
     def keyPressEvent(self, event):
         # 'C' key toggles compact mode
-        if event.key() == Qt.Key.Key_C:
+        if event.key() == Qt.Key.Key_C and self.supports_compact_mode:
             self.toggle_compact_requested.emit()
             event.accept()
         else:
@@ -73,11 +127,8 @@ class IndependentWindow(QMainWindow):
 
         menu = QMenu(self)
 
-        is_compactable = isinstance(self.content_widget, CompactableWidgetInterface) or hasattr(
-            self.content_widget, "set_compact_mode"
-        )
-        if is_compactable:
-            is_compact = getattr(self.content_widget, "is_compact_mode", lambda: False)()
+        if self.supports_compact_mode:
+            is_compact = self.compact_target.is_compact_mode() if self.compact_target is not None else False
             toggle_action = QAction(tr("Toggle Compact Mode"), self)
             toggle_action.setCheckable(True)
             toggle_action.setChecked(is_compact)
@@ -98,11 +149,20 @@ class DetachableWidgetWrapper(QWidget):
     Supports split mode (State C) if the content widget implements SplittableWidgetInterface.
     """
 
-    def __init__(self, widget: QWidget, title: str, config_manager=None):
+    def __init__(
+        self,
+        widget: QWidget,
+        title: str,
+        config_manager=None,
+        *,
+        capabilities: WidgetCapabilities,
+    ):
         super().__init__()
+        validate_widget_capabilities(widget, capabilities)
         self.content_widget = widget
         self.title = title
         self.config_manager = config_manager
+        self.capabilities = capabilities
         self.is_detached = False
         self.independent_window = None
 
@@ -111,16 +171,9 @@ class DetachableWidgetWrapper(QWidget):
         self.split_display_window = None
         self.split_control_window = None
 
-        # Check if the content widget supports compact mode
-        self.is_compactable = isinstance(widget, CompactableWidgetInterface) or hasattr(widget, "set_compact_mode")
-
-        # Check if the content widget supports plot comparison
-        self.is_comparable = isinstance(widget, ComparableWidgetInterface) or hasattr(widget, "get_comparable_data")
-
-        # Check if the content widget supports split mode
-        self.is_splittable = isinstance(widget, SplittableWidgetInterface) or (
-            hasattr(widget, "get_display_widget") and hasattr(widget, "get_control_widget")
-        )
+        self.is_compactable = capabilities.compact_mode.is_supported
+        self.is_comparable = capabilities.comparison.is_supported
+        self.is_splittable = capabilities.split_window.is_supported
 
         self.init_ui()
 
@@ -367,7 +420,13 @@ class DetachableWidgetWrapper(QWidget):
         self.content_widget.show()
 
         # 2. Create independent window
-        self.independent_window = IndependentWindow(self.title, self.content_widget, self)
+        self.independent_window = IndependentWindow(
+            self.title,
+            self.content_widget,
+            self,
+            supports_compact_mode=self.is_compactable,
+            compact_target=self.content_widget,
+        )
         self.independent_window.closed.connect(self.reattach)
         self.independent_window.toggle_compact_requested.connect(self.toggle_compact_from_window)
         self.independent_window.reattach_requested.connect(self.reattach)
@@ -447,7 +506,13 @@ class DetachableWidgetWrapper(QWidget):
 
         # 2. Create independent window for display part
         display_title = self.title + " — " + tr("Display")
-        self.split_display_window = IndependentWindow(display_title, display_widget, self)
+        self.split_display_window = IndependentWindow(
+            display_title,
+            display_widget,
+            self,
+            supports_compact_mode=self.is_compactable,
+            compact_target=self.content_widget,
+        )
         self.split_display_window.closed.connect(self.reattach_all)
         self.split_display_window.toggle_compact_requested.connect(self.toggle_compact_from_window)
         self.split_display_window.reattach_requested.connect(self.reattach_all)

--- a/tests/benchmarks/gui/benchmark_spectrum_analyzer_split.py
+++ b/tests/benchmarks/gui/benchmark_spectrum_analyzer_split.py
@@ -21,6 +21,8 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 import numpy as np
 from PyQt6.QtWidgets import QApplication
 
+from src.core.module_constants import MODULE_SPECTRUM_ANALYZER
+from src.gui.module_registry import MODULE_REGISTRY
 from src.gui.widgets.detachable_wrapper import DetachableWidgetWrapper
 from src.gui.widgets.spectrum_analyzer import SpectrumAnalyzer, SpectrumAnalyzerWidget
 
@@ -223,7 +225,11 @@ def main() -> None:
     app = QApplication.instance() or QApplication([])
     module = SpectrumAnalyzer(_make_engine())
     widget = SpectrumAnalyzerWidget(module)
-    wrapper = DetachableWidgetWrapper(widget, "Spectrum Analyzer Benchmark")
+    wrapper = DetachableWidgetWrapper(
+        widget,
+        "Spectrum Analyzer Benchmark",
+        capabilities=MODULE_REGISTRY[MODULE_SPECTRUM_ANALYZER].capabilities,
+    )
     identities = _object_identities(widget)
 
     results = [_measure_case(app, wrapper, widget, "A", case) for case in CASES]

--- a/tests/logic_verification/gui/test_bnim_meter_split.py
+++ b/tests/logic_verification/gui/test_bnim_meter_split.py
@@ -12,6 +12,8 @@ if "sounddevice" not in sys.modules:
 os.environ["QT_QPA_PLATFORM"] = "offscreen"
 
 from PyQt6.QtWidgets import QApplication, QWidget
+from src.core.module_constants import MODULE_BNIM_METER
+from src.gui.module_registry import MODULE_REGISTRY
 from src.gui.widgets.bnim_meter import BNIMMeter, BNIMMeterWidget
 from src.gui.widgets.splittable_interface import SplittableWidgetInterface
 from src.gui.widgets.detachable_wrapper import DetachableWidgetWrapper
@@ -41,7 +43,11 @@ class TestBNIMMeterSplit(unittest.TestCase):
         self.assertEqual(control_widget, self.widget.controls_group)
 
     def test_detachable_wrapper_split_flow(self):
-        wrapper = DetachableWidgetWrapper(self.widget, "BNIM Meter")
+        wrapper = DetachableWidgetWrapper(
+            self.widget,
+            "BNIM Meter",
+            capabilities=MODULE_REGISTRY[MODULE_BNIM_METER].capabilities,
+        )
         self.assertTrue(wrapper.is_splittable)
         self.assertIsNotNone(wrapper.split_btn)
         self.assertTrue(wrapper.split_btn.isEnabled())

--- a/tests/logic_verification/gui/test_compact_modes.py
+++ b/tests/logic_verification/gui/test_compact_modes.py
@@ -10,6 +10,8 @@ from src.gui.widgets.raw_time_series import RawTimeSeries, RawTimeSeriesWidget
 from src.gui.widgets.bnim_meter import BNIMMeter, BNIMMeterWidget
 from src.gui.widgets.sound_level_meter import SoundLevelMeter, SoundLevelMeterWidget
 from src.gui.widgets.noise_profiler import NoiseProfiler, NoiseProfilerWidget
+from src.core.module_constants import MODULE_SOUND_LEVEL_METER
+from src.gui.module_registry import MODULE_REGISTRY
 from src.gui.widgets.compactable_interface import CompactableWidgetInterface
 from src.gui.widgets.detachable_wrapper import DetachableWidgetWrapper
 
@@ -163,7 +165,11 @@ def test_detachable_wrapper_compact_btn(qtbot):
     engine = MockAudioEngine()
     module = SoundLevelMeter(engine)
     widget = SoundLevelMeterWidget(module)
-    wrapper = DetachableWidgetWrapper(widget, "Test Widget")
+    wrapper = DetachableWidgetWrapper(
+        widget,
+        "Test Widget",
+        capabilities=MODULE_REGISTRY[MODULE_SOUND_LEVEL_METER].capabilities,
+    )
     qtbot.addWidget(wrapper)
 
     # Initially, it is not detached, so compact button should be disabled

--- a/tests/logic_verification/gui/test_detachable_wrapper_split_actions.py
+++ b/tests/logic_verification/gui/test_detachable_wrapper_split_actions.py
@@ -7,6 +7,12 @@ from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QPixmap
 from PyQt6.QtWidgets import QHBoxLayout, QWidget
 
+from src.gui.module_registry import (
+    COMPACT_DEFERRED,
+    COMPARISON_DEFERRED,
+    SUPPORTED,
+    WidgetCapabilities,
+)
 from src.gui.widgets.detachable_wrapper import DetachableWidgetWrapper
 from src.gui.widgets.splittable_interface import SplittableWidgetInterface
 
@@ -47,7 +53,12 @@ class _SplittableContent(_TrackingPanel, SplittableWidgetInterface):
 @pytest.fixture
 def split_wrapper(qapp, qtbot):
     content = _SplittableContent()
-    wrapper = DetachableWidgetWrapper(content, "Split Actions")
+    capabilities = WidgetCapabilities(
+        split_window=SUPPORTED,
+        compact_mode=COMPACT_DEFERRED,
+        comparison=COMPARISON_DEFERRED,
+    )
+    wrapper = DetachableWidgetWrapper(content, "Split Actions", capabilities=capabilities)
     qtbot.addWidget(wrapper)
     wrapper.show()
     yield wrapper, content

--- a/tests/logic_verification/gui/test_event_detector_widget.py
+++ b/tests/logic_verification/gui/test_event_detector_widget.py
@@ -53,10 +53,9 @@ def make_module(
 def test_event_detector_is_registered_after_raw_time_series():
     raw_index = ALL_MODULE_KEYS.index(MODULE_RAW_TIME_SERIES)
     assert ALL_MODULE_KEYS[raw_index + 1] == MODULE_EVENT_DETECTOR
-    assert MODULE_REGISTRY[MODULE_EVENT_DETECTOR] == (
-        "src.gui.widgets.event_detector",
-        "EventDetector",
-    )
+    registration = MODULE_REGISTRY[MODULE_EVENT_DETECTOR]
+    assert registration.module_path == "src.gui.widgets.event_detector"
+    assert registration.class_name == "EventDetector"
     assert _load_module_class(MODULE_EVENT_DETECTOR) is EventDetector
 
 
@@ -698,7 +697,11 @@ def test_widget_exposes_compact_and_split_panels(qtbot):
     widget.set_compact_mode(False)
     assert not widget.control_widget.isHidden()
 
-    wrapper = DetachableWidgetWrapper(widget, "Event Detector")
+    wrapper = DetachableWidgetWrapper(
+        widget,
+        "Event Detector",
+        capabilities=MODULE_REGISTRY[MODULE_EVENT_DETECTOR].capabilities,
+    )
     qtbot.addWidget(wrapper)
     wrapper.split()
     assert wrapper.is_split

--- a/tests/logic_verification/gui/test_goniometer_split.py
+++ b/tests/logic_verification/gui/test_goniometer_split.py
@@ -12,6 +12,8 @@ if "sounddevice" not in sys.modules:
 os.environ["QT_QPA_PLATFORM"] = "offscreen"
 
 from PyQt6.QtWidgets import QApplication, QWidget
+from src.core.module_constants import MODULE_GONIOMETER
+from src.gui.module_registry import MODULE_REGISTRY
 from src.gui.widgets.goniometer import Goniometer, GoniometerWidget
 from src.gui.widgets.splittable_interface import SplittableWidgetInterface
 from src.gui.widgets.detachable_wrapper import DetachableWidgetWrapper
@@ -43,7 +45,11 @@ class TestGoniometerSplit(unittest.TestCase):
         self.assertEqual(control_widget, self.widget.controls_group)
 
     def test_detachable_wrapper_split_flow(self):
-        wrapper = DetachableWidgetWrapper(self.widget, "Goniometer")
+        wrapper = DetachableWidgetWrapper(
+            self.widget,
+            "Goniometer",
+            capabilities=MODULE_REGISTRY[MODULE_GONIOMETER].capabilities,
+        )
         self.assertTrue(wrapper.is_splittable)
         self.assertIsNotNone(wrapper.split_btn)
         self.assertTrue(wrapper.split_btn.isEnabled())

--- a/tests/logic_verification/gui/test_lockin_spectrum_finder_split.py
+++ b/tests/logic_verification/gui/test_lockin_spectrum_finder_split.py
@@ -8,6 +8,8 @@ from PyQt6 import sip
 from PyQt6.QtWidgets import QWidget
 
 from src.core.config_manager import ConfigManager
+from src.core.module_constants import MODULE_LOCKIN_SPECTRUM_FINDER
+from src.gui.module_registry import MODULE_REGISTRY
 from src.gui.widgets.detachable_wrapper import DetachableWidgetWrapper
 from src.gui.widgets.lockin_spectrum_finder import LockInSpectrumFinder, LockInSpectrumFinderWidget
 from src.gui.widgets.splittable_interface import SplittableWidgetInterface
@@ -40,7 +42,11 @@ def lockin_widget(qapp, tmp_path, monkeypatch):
 
 @pytest.fixture
 def lockin_wrapper(lockin_widget, qapp):
-    wrapper = DetachableWidgetWrapper(lockin_widget, "Lock-in Spectrum Finder")
+    wrapper = DetachableWidgetWrapper(
+        lockin_widget,
+        "Lock-in Spectrum Finder",
+        capabilities=MODULE_REGISTRY[MODULE_LOCKIN_SPECTRUM_FINDER].capabilities,
+    )
     wrapper.show()
     yield wrapper
 

--- a/tests/logic_verification/gui/test_lufs_meter_split.py
+++ b/tests/logic_verification/gui/test_lufs_meter_split.py
@@ -12,6 +12,8 @@ if "sounddevice" not in sys.modules:
 os.environ["QT_QPA_PLATFORM"] = "offscreen"
 
 from PyQt6.QtWidgets import QApplication, QWidget
+from src.core.module_constants import MODULE_LUFS_METER
+from src.gui.module_registry import MODULE_REGISTRY
 from src.gui.widgets.lufs_meter import LufsMeter, LufsMeterWidget
 from src.gui.widgets.splittable_interface import SplittableWidgetInterface
 from src.gui.widgets.detachable_wrapper import DetachableWidgetWrapper
@@ -41,7 +43,11 @@ class TestLufsMeterSplit(unittest.TestCase):
         self.assertEqual(control_widget, self.widget.sidebar)
 
     def test_detachable_wrapper_split_flow(self):
-        wrapper = DetachableWidgetWrapper(self.widget, "LUFS Meter")
+        wrapper = DetachableWidgetWrapper(
+            self.widget,
+            "LUFS Meter",
+            capabilities=MODULE_REGISTRY[MODULE_LUFS_METER].capabilities,
+        )
         self.assertTrue(wrapper.is_splittable)
         self.assertIsNotNone(wrapper.split_btn)
         self.assertTrue(wrapper.split_btn.isEnabled())

--- a/tests/logic_verification/gui/test_noise_profiler_split.py
+++ b/tests/logic_verification/gui/test_noise_profiler_split.py
@@ -14,6 +14,8 @@ os.environ["QT_QPA_PLATFORM"] = "offscreen"
 
 from PyQt6.QtWidgets import QApplication, QWidget
 
+from src.core.module_constants import MODULE_NOISE_PROFILER
+from src.gui.module_registry import MODULE_REGISTRY
 from src.gui.widgets.detachable_wrapper import DetachableWidgetWrapper
 from src.gui.widgets.noise_profiler import NoiseProfiler, NoiseProfilerWidget
 from src.gui.widgets.splittable_interface import SplittableWidgetInterface
@@ -44,7 +46,11 @@ class TestNoiseProfilerSplit(unittest.TestCase):
         self.assertEqual(control_widget, self.widget.sidebar)
 
     def test_detachable_wrapper_split_flow(self):
-        wrapper = DetachableWidgetWrapper(self.widget, "Noise Profiler")
+        wrapper = DetachableWidgetWrapper(
+            self.widget,
+            "Noise Profiler",
+            capabilities=MODULE_REGISTRY[MODULE_NOISE_PROFILER].capabilities,
+        )
         self.assertTrue(wrapper.is_splittable)
         self.assertIsNotNone(wrapper.split_btn)
         self.assertTrue(wrapper.split_btn.isEnabled())

--- a/tests/logic_verification/gui/test_pyinstaller_imports.py
+++ b/tests/logic_verification/gui/test_pyinstaller_imports.py
@@ -74,6 +74,6 @@ def test_pyinstaller_imports_cover_every_registered_module():
         if isinstance(node, ast.ImportFrom)
         for alias in node.names
     }
-    registered_class_names = {class_name for _, class_name in MODULE_REGISTRY.values()}
+    registered_class_names = {registration.class_name for registration in MODULE_REGISTRY.values()}
 
     assert registered_class_names <= imported_class_names

--- a/tests/logic_verification/gui/test_raw_time_series_split.py
+++ b/tests/logic_verification/gui/test_raw_time_series_split.py
@@ -12,6 +12,8 @@ if "sounddevice" not in sys.modules:
 os.environ["QT_QPA_PLATFORM"] = "offscreen"
 
 from PyQt6.QtWidgets import QApplication, QWidget
+from src.core.module_constants import MODULE_RAW_TIME_SERIES
+from src.gui.module_registry import MODULE_REGISTRY
 from src.gui.widgets.raw_time_series import RawTimeSeries, RawTimeSeriesWidget
 from src.gui.widgets.splittable_interface import SplittableWidgetInterface
 from src.gui.widgets.detachable_wrapper import DetachableWidgetWrapper
@@ -43,7 +45,11 @@ class TestRawTimeSeriesSplit(unittest.TestCase):
         self.assertEqual(control_widget, self.widget.right_widget)
 
     def test_detachable_wrapper_split_flow(self):
-        wrapper = DetachableWidgetWrapper(self.widget, "Raw Time Series")
+        wrapper = DetachableWidgetWrapper(
+            self.widget,
+            "Raw Time Series",
+            capabilities=MODULE_REGISTRY[MODULE_RAW_TIME_SERIES].capabilities,
+        )
         self.assertTrue(wrapper.is_splittable)
         self.assertIsNotNone(wrapper.split_btn)
         self.assertTrue(wrapper.split_btn.isEnabled())

--- a/tests/logic_verification/gui/test_recorder_player_race.py
+++ b/tests/logic_verification/gui/test_recorder_player_race.py
@@ -60,6 +60,7 @@ class TestRecorderPlayerRace(unittest.TestCase):
             "scipy.optimize": MagicMock(),
             "sounddevice": MagicMock(),
             "soundfile": MagicMock(),
+            "src.core.analysis": MagicMock(),
             "src.core.calibration": MagicMock(),
             "PyQt6": MagicMock(),
             "PyQt6.QtCore": MagicMock(),
@@ -79,6 +80,10 @@ class TestRecorderPlayerRace(unittest.TestCase):
 
     def tearDown(self):
         self.patcher.stop()
+        # Restore the real Qt-backed module so later GUI contract tests do not
+        # inherit the MagicMock classes loaded by this isolated race test.
+        sys.modules.pop("src.gui.widgets.recorder_player", None)
+        importlib.import_module("src.gui.widgets.recorder_player")
 
     def test_infinite_loop_hang_empty_buffer(self):
         """Verify that an empty buffer doesn't cause an infinite loop."""

--- a/tests/logic_verification/gui/test_spectrogram_split.py
+++ b/tests/logic_verification/gui/test_spectrogram_split.py
@@ -14,6 +14,8 @@ os.environ["QT_QPA_PLATFORM"] = "offscreen"
 from PyQt6.QtWidgets import QApplication, QWidget
 from PyQt6 import sip
 
+from src.core.module_constants import MODULE_SPECTROGRAM
+from src.gui.module_registry import MODULE_REGISTRY
 from src.gui.widgets.detachable_wrapper import DetachableWidgetWrapper
 from src.gui.widgets.spectrogram import Spectrogram, SpectrogramWidget
 from src.gui.widgets.splittable_interface import SplittableWidgetInterface
@@ -45,7 +47,11 @@ def test_spectrogram_implements_split_interface(spectrogram_widget):
 
 
 def test_spectrogram_split_and_reattach_restores_vertical_layout(spectrogram_widget):
-    wrapper = DetachableWidgetWrapper(spectrogram_widget, "Spectrogram")
+    wrapper = DetachableWidgetWrapper(
+        spectrogram_widget,
+        "Spectrogram",
+        capabilities=MODULE_REGISTRY[MODULE_SPECTROGRAM].capabilities,
+    )
 
     assert wrapper.is_splittable
     assert wrapper.split_btn is not None

--- a/tests/logic_verification/gui/test_spectrum_analyzer_split.py
+++ b/tests/logic_verification/gui/test_spectrum_analyzer_split.py
@@ -7,6 +7,8 @@ import pytest
 from PyQt6 import sip
 from PyQt6.QtWidgets import QWidget
 
+from src.core.module_constants import MODULE_SPECTRUM_ANALYZER
+from src.gui.module_registry import MODULE_REGISTRY
 from src.gui.widgets.detachable_wrapper import DetachableWidgetWrapper
 from src.gui.widgets.spectrum_analyzer import SpectrumAnalyzer, SpectrumAnalyzerWidget
 from src.gui.widgets.splittable_interface import SplittableWidgetInterface
@@ -34,7 +36,11 @@ def spectrum_widget(qapp):
 
 @pytest.fixture
 def spectrum_wrapper(spectrum_widget, qapp):
-    wrapper = DetachableWidgetWrapper(spectrum_widget, "Spectrum Analyzer")
+    wrapper = DetachableWidgetWrapper(
+        spectrum_widget,
+        "Spectrum Analyzer",
+        capabilities=MODULE_REGISTRY[MODULE_SPECTRUM_ANALYZER].capabilities,
+    )
     wrapper.show()
     yield wrapper
     if not sip.isdeleted(wrapper):

--- a/tests/logic_verification/gui/test_widget_capabilities.py
+++ b/tests/logic_verification/gui/test_widget_capabilities.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from PyQt6.QtWidgets import QHBoxLayout, QWidget
+
+from src.core.audio_engine import AudioEngine
+from src.core.module_constants import ALL_MODULE_KEYS
+from src.gui.main_window import _load_module_class
+from src.gui.module_registry import (
+    CapabilityExclusionReason,
+    CapabilityStatus,
+    COMPARISON_DEFERRED,
+    FeatureCapability,
+    MODULE_REGISTRY,
+    NO_INDEPENDENT_DISPLAY,
+    SPLIT_DEFERRED,
+    SUPPORTED,
+    WidgetCapabilities,
+)
+from src.gui.widgets.compactable_interface import CompactableWidgetInterface
+from src.gui.widgets.comparable_interface import ComparableWidgetInterface
+from src.gui.widgets.detachable_wrapper import DetachableWidgetWrapper, validate_widget_capabilities
+from src.gui.widgets.splittable_interface import SplittableWidgetInterface
+from src.measurement_modules.base import MeasurementModule
+
+
+FULL_CAPABILITIES = WidgetCapabilities(
+    split_window=SUPPORTED,
+    compact_mode=SUPPORTED,
+    comparison=SUPPORTED,
+)
+NO_CAPABILITIES = WidgetCapabilities(
+    split_window=NO_INDEPENDENT_DISPLAY,
+    compact_mode=NO_INDEPENDENT_DISPLAY,
+    comparison=NO_INDEPENDENT_DISPLAY,
+)
+
+
+@pytest.fixture(scope="module")
+def shared_audio_engine() -> Iterator[AudioEngine]:
+    yield AudioEngine()
+
+
+def test_registry_covers_all_module_keys_in_ui_order():
+    assert list(MODULE_REGISTRY) == ALL_MODULE_KEYS
+
+
+@pytest.mark.parametrize("module_key", ALL_MODULE_KEYS)
+def test_registered_widget_matches_declared_capabilities(module_key, qapp, shared_audio_engine):
+    registration = MODULE_REGISTRY[module_key]
+    module_type = _load_module_class(module_key)
+    assert issubclass(module_type, MeasurementModule)
+
+    module = module_type(shared_audio_engine)
+    widget = module.get_widget()
+    assert isinstance(widget, QWidget)
+
+    try:
+        contracts = (
+            (
+                registration.capabilities.compact_mode.is_supported,
+                CompactableWidgetInterface,
+                ("update_compact_layout",),
+            ),
+            (
+                registration.capabilities.split_window.is_supported,
+                SplittableWidgetInterface,
+                ("get_display_widget", "get_control_widget", "restore_split_panels"),
+            ),
+            (
+                registration.capabilities.comparison.is_supported,
+                ComparableWidgetInterface,
+                ("get_comparable_data",),
+            ),
+        )
+        for declared_supported, interface_type, required_methods in contracts:
+            assert isinstance(widget, interface_type) is declared_supported
+            if declared_supported:
+                for method_name in required_methods:
+                    assert getattr(type(widget), method_name) is not getattr(interface_type, method_name)
+
+        validate_widget_capabilities(widget, registration.capabilities)
+    finally:
+        widget.close()
+        widget.deleteLater()
+        qapp.processEvents()
+
+
+class _DuckTypedWidget(QWidget):
+    def set_compact_mode(self, enabled: bool) -> None:
+        pass
+
+    def get_display_widget(self) -> QWidget:
+        return self
+
+    def get_control_widget(self) -> QWidget:
+        return self
+
+    def get_comparable_data(self) -> list[object]:
+        return []
+
+
+class _FullyCapableWidget(
+    QWidget,
+    CompactableWidgetInterface,
+    ComparableWidgetInterface,
+    SplittableWidgetInterface,
+):
+    def __init__(self):
+        QWidget.__init__(self)
+        CompactableWidgetInterface.__init__(self)
+        self.display_widget = QWidget()
+        self.control_widget = QWidget()
+        self.main_layout = QHBoxLayout(self)
+        self.main_layout.addWidget(self.display_widget)
+        self.main_layout.addWidget(self.control_widget)
+
+    def update_compact_layout(self) -> None:
+        self.control_widget.setVisible(not self.is_compact_mode())
+
+    def get_display_widget(self) -> QWidget:
+        return self.display_widget
+
+    def get_control_widget(self) -> QWidget:
+        return self.control_widget
+
+    def restore_split_panels(self) -> None:
+        self.main_layout.addWidget(self.display_widget)
+        self.main_layout.addWidget(self.control_widget)
+
+    def get_comparable_data(self) -> list[object]:
+        return []
+
+
+class _MissingCompactOverride(QWidget, CompactableWidgetInterface):
+    def __init__(self):
+        QWidget.__init__(self)
+        CompactableWidgetInterface.__init__(self)
+
+
+def test_wrapper_uses_declarations_instead_of_duck_typing(qtbot):
+    widget = _DuckTypedWidget()
+    wrapper = DetachableWidgetWrapper(widget, "Duck Typed", capabilities=NO_CAPABILITIES)
+    qtbot.addWidget(wrapper)
+
+    assert wrapper.compact_btn is None
+    assert wrapper.split_btn is None
+    assert wrapper.compare_btn is None
+
+    wrapper.detach()
+    assert wrapper.independent_window is not None
+    assert not wrapper.independent_window.supports_compact_mode
+
+
+def test_supported_declarations_drive_wrapper_and_independent_window(qtbot):
+    widget = _FullyCapableWidget()
+    wrapper = DetachableWidgetWrapper(widget, "Full", capabilities=FULL_CAPABILITIES)
+    qtbot.addWidget(wrapper)
+
+    assert wrapper.compact_btn is not None
+    assert wrapper.split_btn is not None
+    assert wrapper.compare_btn is not None
+
+    wrapper.detach()
+    assert wrapper.independent_window is not None
+    assert wrapper.independent_window.supports_compact_mode
+    assert wrapper.independent_window.compact_target is widget
+
+
+def test_capability_mismatches_fail_fast(qtbot):
+    fully_capable = _FullyCapableWidget()
+    duck_typed = _DuckTypedWidget()
+    missing_override = _MissingCompactOverride()
+    qtbot.addWidget(fully_capable)
+    qtbot.addWidget(duck_typed)
+    qtbot.addWidget(missing_override)
+
+    with pytest.raises(ValueError, match="declares compact mode as excluded"):
+        validate_widget_capabilities(fully_capable, NO_CAPABILITIES)
+    with pytest.raises(ValueError, match="declares compact mode as supported"):
+        validate_widget_capabilities(duck_typed, FULL_CAPABILITIES)
+
+    missing_override_capabilities = WidgetCapabilities(
+        split_window=SPLIT_DEFERRED,
+        compact_mode=SUPPORTED,
+        comparison=COMPARISON_DEFERRED,
+    )
+    with pytest.raises(ValueError, match=r"does not override update_compact_layout\(\)"):
+        validate_widget_capabilities(missing_override, missing_override_capabilities)
+
+
+def test_feature_specific_exclusion_reasons_are_enforced():
+    with pytest.raises(ValueError, match="Supported capabilities cannot have an exclusion reason"):
+        FeatureCapability(CapabilityStatus.SUPPORTED, CapabilityExclusionReason.COMPACT_DEFERRED)
+    with pytest.raises(ValueError, match="Excluded capabilities must have an exclusion reason"):
+        FeatureCapability(CapabilityStatus.EXCLUDED)
+    with pytest.raises(ValueError, match="not a valid exclusion reason for compact_mode"):
+        WidgetCapabilities(
+            split_window=SPLIT_DEFERRED,
+            compact_mode=COMPARISON_DEFERRED,
+            comparison=COMPARISON_DEFERRED,
+        )


### PR DESCRIPTION
## Summary

- centralize split-window, compact-mode, and plot-comparison support for all 42 modules in `WidgetCapabilities`
- make the module registry and detachable wrapper use those declarations as the runtime source of truth
- fail fast when declarations, interfaces, or required method overrides disagree
- add a full registry contract test and update existing wrapper tests, benchmark setup, and the implementation matrix
- restore the real Recorder / Player module after its isolated race test so later GUI tests are not polluted by mocked Qt modules

## Why

Feature availability was inferred at runtime through `isinstance()` and `hasattr()`. Missing interfaces or overrides could therefore remain invisible until a user invoked the feature, while the hand-maintained implementation matrix could drift from the code. This change makes every feature decision explicit and verifies the declaration against the real widget returned by each module.

## Impact

Existing feature availability is unchanged. New or modified modules must declare all three optional widget features and CI will reject incomplete or contradictory implementations.

## Validation

- `./.venv/bin/ruff check .`
- `./.venv/bin/mypy src main_gui.py`
- `./.venv/bin/python scripts/check_trn_keys.py`
- `npx markdownlint-cli2 "**/*.md" "#node_modules"`
- `./.venv/bin/pytest` — 1207 passed, 6 hardware-only tests skipped
- `./.venv/bin/python scripts/check_ui_size_limits.py`
- offscreen preload smoke check — 42/42 modules loaded