### PR TITLE
docs: Consolidate Detachable Wrapper feature descriptions across widgets

### DIFF
--- a/docs/widgets/event_detector.en.md
+++ b/docs/widgets/event_detector.en.md
@@ -102,9 +102,7 @@ The table shows the most recent 500 records. CSV and JSON exports include every 
 
 ## Common Features
 
-This widget supports **Detach Window**, **Screenshot**, **Logs**, **Split Window**, and
-**Compact Mode**. It does not support **Send to Comparer**.
-See [Detachable Wrapper](detachable_wrapper.en.md) for details about each operation.
+This widget supports common features of the Detachable Wrapper (such as **Split Window** and **Compact Mode**). Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
 
 ## Basic Measurement Procedure
 

--- a/docs/widgets/event_detector.md
+++ b/docs/widgets/event_detector.md
@@ -102,9 +102,7 @@ Event Rate = Event Count × 60 / Measurement Time [seconds]
 
 ## 共通機能
 
-このウィジェットは **Detach Window**、**Screenshot**、**Logs**、**Split Window**、
-**Compact Mode** に対応しています。**Send to Comparer** には対応していません。
-各操作の詳細は [Detachable Wrapper](detachable_wrapper.md) を参照してください。
+このウィジェットは Detachable Wrapper の共通機能（**ウィンドウ分割**や**コンパクトモード**など）に対応しています。詳細は [Detachable Wrapper](detachable_wrapper.md) の説明書を参照してください。
 
 ## 基本的な測定手順
 

--- a/docs/widgets/frequency_counter.en.md
+++ b/docs/widgets/frequency_counter.en.md
@@ -11,9 +11,7 @@ It can be used for measuring the stability of crystal oscillators, instrument tu
 
 ## Common Features
 
-This widget supports **Detach Window**, **Screenshot**, **Logs**, and **Compact Mode**.
-It does not support **Split Window** or **Send to Comparer**.
-See [Detachable Wrapper](detachable_wrapper.en.md) for details about each operation.
+This widget supports common features of the Detachable Wrapper (such as **Compact Mode**). Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
 
 ## Operation
 

--- a/docs/widgets/frequency_counter.md
+++ b/docs/widgets/frequency_counter.md
@@ -11,9 +11,7 @@
 
 ## 共通機能
 
-このウィジェットは **Detach Window**、**Screenshot**、**Logs**、**Compact Mode** に対応しています。
-表示部と操作部を分ける **Split Window** および **Send to Comparer** には対応していません。
-各操作の詳細は [Detachable Wrapper](detachable_wrapper.md) を参照してください。
+このウィジェットは Detachable Wrapper の共通機能（**コンパクトモード**など）に対応しています。詳細は [Detachable Wrapper](detachable_wrapper.md) の説明書を参照してください。
 
 ## 操作方法
 

--- a/docs/widgets/lockin_spectrum_finder.en.md
+++ b/docs/widgets/lockin_spectrum_finder.en.md
@@ -109,9 +109,7 @@ The **Audio Sonification** tab provides an audio output corresponding to detecte
 
 ## Common Features
 
-This widget supports **Detach Window**, **Screenshot**, **Logs**, and **Split Window**.
-It does not support **Compact Mode** or **Send to Comparer**.
-See [Detachable Wrapper](detachable_wrapper.en.md) for details about each operation.
+This widget supports common features of the Detachable Wrapper (such as **Split Window**). Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
 
 ## How to Read the Graph
 

--- a/docs/widgets/lockin_spectrum_finder.md
+++ b/docs/widgets/lockin_spectrum_finder.md
@@ -109,9 +109,7 @@
 
 ## 共通機能
 
-このウィジェットは **Detach Window**、**Screenshot**、**Logs**、**Split Window** に対応しています。
-**Compact Mode** および **Send to Comparer** には対応していません。
-各操作の詳細は [Detachable Wrapper](detachable_wrapper.md) を参照してください。
+このウィジェットは Detachable Wrapper の共通機能（**ウィンドウ分割**など）に対応しています。詳細は [Detachable Wrapper](detachable_wrapper.md) の説明書を参照してください。
 
 ## グラフの読み方
 

--- a/docs/widgets/stereo_alignment_monitor.en.md
+++ b/docs/widgets/stereo_alignment_monitor.en.md
@@ -9,9 +9,7 @@ It monitors L/R balance, frequency response match, center focus, and phase issue
 
 ## Common Features
 
-This widget supports **Detach Window**, **Screenshot**, **Logs**, and **Compact Mode**.
-It does not support **Split Window** or **Send to Comparer**.
-See [Detachable Wrapper](detachable_wrapper.en.md) for details about each operation.
+This widget supports common features of the Detachable Wrapper (such as **Compact Mode**). Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
 
 ## What is Stereo Alignment?
 

--- a/docs/widgets/stereo_alignment_monitor.md
+++ b/docs/widgets/stereo_alignment_monitor.md
@@ -9,9 +9,7 @@ L/Rチャンネル間の整合性（アライメント）を詳細に解析す�
 
 ## 共通機能
 
-このウィジェットは **Detach Window**、**Screenshot**、**Logs**、**Compact Mode** に対応しています。
-**Split Window** および **Send to Comparer** には対応していません。
-各操作の詳細は [Detachable Wrapper](detachable_wrapper.md) を参照してください。
+このウィジェットは Detachable Wrapper の共通機能（**コンパクトモード**など）に対応しています。詳細は [Detachable Wrapper](detachable_wrapper.md) の説明書を参照してください。
 
 ## ステレオ・アライメントとは
 

--- a/docs/widgets/timecode_monitor.en.md
+++ b/docs/widgets/timecode_monitor.en.md
@@ -108,9 +108,7 @@ Calibration measures audio path delay. It does not rewrite the timecode content 
 
 ## Common Features
 
-This widget supports **Detach Window**, **Screenshot**, **Logs**, and **Compact Mode**.
-It does not support **Split Window** or **Send to Comparer**.
-See [Detachable Wrapper](detachable_wrapper.en.md) for details about each operation.
+This widget supports common features of the Detachable Wrapper (such as **Compact Mode**). Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
 
 ## Usage Examples
 

--- a/docs/widgets/timecode_monitor.md
+++ b/docs/widgets/timecode_monitor.md
@@ -108,9 +108,7 @@ MeasureLabからタイムコード信号を出力する機能です。このタ�
 
 ## 共通機能
 
-このウィジェットは **Detach Window**、**Screenshot**、**Logs**、**Compact Mode** に対応しています。
-**Split Window** および **Send to Comparer** には対応していません。
-各操作の詳細は [Detachable Wrapper](detachable_wrapper.md) を参照してください。
+このウィジェットは Detachable Wrapper の共通機能（**コンパクトモード**など）に対応しています。詳細は [Detachable Wrapper](detachable_wrapper.md) の説明書を参照してください。
 
 ## 使用例
 

--- a/docs/widgets/transmission_analyzer.en.md
+++ b/docs/widgets/transmission_analyzer.en.md
@@ -12,9 +12,7 @@ It supports both digital and analog signal paths—such as USB cables, Bluetooth
 
 ## Detachable Wrapper Features
 
-This widget supports **Detach Window**, **Screenshot**, **Logs**, and **Compact Mode**.
-It does not support **Split Window** or **Send to Comparer**.
-See [Detachable Wrapper](detachable_wrapper.en.md) for details about each operation.
+This widget supports common features of the Detachable Wrapper (such as **Compact Mode**). Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
 
 ## Key Features & Measurement Modes
 

--- a/docs/widgets/transmission_analyzer.md
+++ b/docs/widgets/transmission_analyzer.md
@@ -12,9 +12,7 @@ USBケーブル、Bluetooth接続、あるいは物理的なアナログ回路�
 
 ## Detachable Wrapper 共通機能
 
-このウィジェットは **Detach Window**、**Screenshot**、**Logs**、**Compact Mode** に対応しています。
-**Split Window** および **Send to Comparer** には対応していません。
-各操作の詳細は [Detachable Wrapper](detachable_wrapper.md) を参照してください。
+このウィジェットは Detachable Wrapper の共通機能（**コンパクトモード**など）に対応しています。詳細は [Detachable Wrapper](detachable_wrapper.md) の説明書を参照してください。
 
 ## 主な機能と測定モード
 


### PR DESCRIPTION
Consolidated verbose lists of supported Detachable Wrapper features into a single concise reference to detachable_wrapper.md across several widget documentation files, improving readability and reducing structural redundancy.

---
*PR created automatically by Jules for task [1899927398342907736](https://jules.google.com/task/1899927398342907736) started by @youtube-at-vach*