### PR TITLE
docs: unify detachable wrapper common features phrasing and headings across English widget docs

### DIFF
--- a/docs/widgets/advanced_distortion_meter.en.md
+++ b/docs/widgets/advanced_distortion_meter.en.md
@@ -11,7 +11,7 @@ It is suitable for searching for the cause of phenomena such as "having good num
 
 ## Common Features
 
-This widget supports the common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
+This widget supports common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
 
 ## Operation
 

--- a/docs/widgets/arbitrary_harmonic_generator.en.md
+++ b/docs/widgets/arbitrary_harmonic_generator.en.md
@@ -10,7 +10,7 @@ This is particularly useful for generating test signals with specific distortion
 
 ## Common Features
 
-This widget supports the common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
+This widget supports common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
 
 ## Operation
 

--- a/docs/widgets/bnim_meter.en.md
+++ b/docs/widgets/bnim_meter.en.md
@@ -10,7 +10,7 @@ It is ideal for checking the sense of localization and spread of stereo sound im
 
 ## Common Features
 
-This widget supports the common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
+This widget supports common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
 
 ## How to Read the Screen
 

--- a/docs/widgets/boxcar_averager.en.md
+++ b/docs/widgets/boxcar_averager.en.md
@@ -11,7 +11,7 @@ This widget has both an "Internal mode," which outputs test signals itself to sy
 
 ## Common Features
 
-This widget supports the common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
+This widget supports common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
 
 ## Operation
 

--- a/docs/widgets/distortion_analyzer.en.md
+++ b/docs/widgets/distortion_analyzer.en.md
@@ -10,7 +10,7 @@ It is an important measurement tool to grasp the basic performance indicators of
 
 ## Common Features
 
-This widget supports the common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
+This widget supports common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
 
 ## Meaning of Key Indicators
 

--- a/docs/widgets/event_detector.en.md
+++ b/docs/widgets/event_detector.en.md
@@ -102,7 +102,7 @@ The table shows the most recent 500 records. CSV and JSON exports include every 
 
 ## Common Features
 
-This widget supports the common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
+This widget supports common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
 
 ## Basic Measurement Procedure
 

--- a/docs/widgets/feedforward_compensator.en.md
+++ b/docs/widgets/feedforward_compensator.en.md
@@ -10,7 +10,7 @@ By loading a Hammerstein model (1st to 5th order impulse response kernels) measu
 
 ## Common Features
 
-This widget supports the common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
+This widget supports common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
 
 ## How It Works: LICFF (Linear-Inverse Compensated Feedforward)
 

--- a/docs/widgets/frequency_counter.en.md
+++ b/docs/widgets/frequency_counter.en.md
@@ -11,7 +11,7 @@ It can be used for measuring the stability of crystal oscillators, instrument tu
 
 ## Common Features
 
-This widget supports the common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
+This widget supports common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
 
 ## Operation
 

--- a/docs/widgets/goniometer.en.md
+++ b/docs/widgets/goniometer.en.md
@@ -10,7 +10,7 @@ It is an essential tool for discovering phase cancellation problems in mixdown a
 
 ## Common Features
 
-This widget supports the common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
+This widget supports common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
 
 ## What are Lissajous Figures?
 

--- a/docs/widgets/hrtf_player.en.md
+++ b/docs/widgets/hrtf_player.en.md
@@ -9,7 +9,7 @@ It is useful in spatial audio (3D audio) production and research for intuitively
 
 ## Common Features
 
-This widget supports the common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
+This widget supports common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
 
 ## Features and UI
 

--- a/docs/widgets/impedance_analyzer.en.md
+++ b/docs/widgets/impedance_analyzer.en.md
@@ -17,7 +17,7 @@ It has the same functions as instruments generally called "LCR meters" and can m
 
 ## Common Features
 
-This widget supports the common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
+This widget supports common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
 
 ## Basic Knowledge for Beginners
 

--- a/docs/widgets/linearity_analyzer.en.md
+++ b/docs/widgets/linearity_analyzer.en.md
@@ -11,7 +11,7 @@ It is used to verify problems specific to digital equipment (DAC/ADC), such as "
 
 ## Common Features
 
-This widget supports the common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
+This widget supports common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
 
 ## Meaning of Key Indicators
 

--- a/docs/widgets/lock_in_amplifier.en.md
+++ b/docs/widgets/lock_in_amplifier.en.md
@@ -11,7 +11,7 @@ While general spectrum analyzers "see all frequencies," the lock-in amplifier "m
 
 ## Common Features
 
-This widget supports the common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
+This widget supports common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
 
 ## Principles of Lock-in Measurement
 

--- a/docs/widgets/lock_in_frequency_counter.en.md
+++ b/docs/widgets/lock_in_frequency_counter.en.md
@@ -10,7 +10,7 @@ It is suitable for observing the long-term stability (drift) of a clock source, 
 
 ## Common Features
 
-This widget supports the common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
+This widget supports common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
 
 ## Operation
 

--- a/docs/widgets/lock_in_modeler.en.md
+++ b/docs/widgets/lock_in_modeler.en.md
@@ -8,7 +8,7 @@ In addition to standard frequency sweep measurements (tracking the fundamental a
 
 ## Common Features
 
-This widget supports the common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
+This widget supports common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
 
 ## Operation Procedure
 

--- a/docs/widgets/lockin_harmonic_analyzer.en.md
+++ b/docs/widgets/lockin_harmonic_analyzer.en.md
@@ -10,7 +10,7 @@ Unlike conventional FFT-based distortion measurements that rely on window functi
 
 ## Common Features
 
-This widget supports the common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
+This widget supports common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
 
 ### Unique Measurement Principle
 

--- a/docs/widgets/lockin_spectrum_finder.en.md
+++ b/docs/widgets/lockin_spectrum_finder.en.md
@@ -109,7 +109,7 @@ The **Audio Sonification** tab provides an audio output corresponding to detecte
 
 ## Common Features
 
-This widget supports the common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
+This widget supports common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
 
 ## How to Read the Graph
 

--- a/docs/widgets/log_viewer.en.md
+++ b/docs/widgets/log_viewer.en.md
@@ -9,7 +9,7 @@ While you don't normally need to keep it open, it is highly useful for diagnosin
 
 ## Common Features
 
-This widget supports the common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
+This widget supports common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
 
 ## Key Features
 

--- a/docs/widgets/loopback_finder.en.md
+++ b/docs/widgets/loopback_finder.en.md
@@ -14,7 +14,7 @@ When a measurement goes wrong, before blaming the FFT settings, filters, or math
 
 ## Common Features
 
-This widget supports the common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
+This widget supports common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
 
 ## Operations
 

--- a/docs/widgets/lufs_meter.en.md
+++ b/docs/widgets/lufs_meter.en.md
@@ -8,7 +8,7 @@ The LUFS Meter is a tool for measuring "Loudness" (the perceived volume by human
 
 ## Common Features
 
-This widget supports the common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
+This widget supports common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
 
 ## Key Indicators
 

--- a/docs/widgets/network_analyzer.en.md
+++ b/docs/widgets/network_analyzer.en.md
@@ -17,7 +17,7 @@ Primary uses:
 
 ## Common Features
 
-This widget supports the common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
+This widget supports common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
 
 ## Basic Operation
 

--- a/docs/widgets/noise_profiler.en.md
+++ b/docs/widgets/noise_profiler.en.md
@@ -16,7 +16,7 @@ It is ideal for evaluating the low-noise performance of amplifiers and microphon
 
 ## Common Features
 
-This widget supports the common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
+This widget supports common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
 
 ## Operation
 

--- a/docs/widgets/nonlinear_analyzer.en.md
+++ b/docs/widgets/nonlinear_analyzer.en.md
@@ -16,7 +16,7 @@ This widget provides the following analysis capabilities:
 
 ## Common Features
 
-This widget supports the common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
+This widget supports common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
 
 ## Settings
 

--- a/docs/widgets/nonlinear_response_analyzer.en.md
+++ b/docs/widgets/nonlinear_response_analyzer.en.md
@@ -14,7 +14,7 @@ This widget provides the following analysis capabilities:
 
 ## Common Features
 
-This widget supports the common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
+This widget supports common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
 
 ## Settings
 

--- a/docs/widgets/one_pps_monitor.en.md
+++ b/docs/widgets/one_pps_monitor.en.md
@@ -13,7 +13,7 @@ It inputs a pulse signal output every second from a GPS receiver or high-precisi
 
 ## Common Features
 
-This widget supports the common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
+This widget supports common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
 
 ## Features
 

--- a/docs/widgets/oscilloscope.en.md
+++ b/docs/widgets/oscilloscope.en.md
@@ -8,7 +8,7 @@ The Oscilloscope is a measurement tool that displays the waveform of the input s
 
 ## Common Features
 
-This widget supports the common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
+This widget supports common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
 
 ## Operation
 

--- a/docs/widgets/plot_comparer.en.md
+++ b/docs/widgets/plot_comparer.en.md
@@ -8,7 +8,7 @@ To help visualize differences between measurements, it features powerful compari
 
 ## Common Features
 
-This widget supports the common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
+This widget supports common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
 
 ## Key Features
 

--- a/docs/widgets/processor_benchmark.en.md
+++ b/docs/widgets/processor_benchmark.en.md
@@ -6,7 +6,7 @@ Processor Benchmark is a tool to test the FFT and UI rendering performance of yo
 
 ## Common Features
 
-This widget supports the common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
+This widget supports common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
 
 ## Primary Uses
 

--- a/docs/widgets/raw_time_series.en.md
+++ b/docs/widgets/raw_time_series.en.md
@@ -9,7 +9,7 @@ While an oscilloscope captures and displays momentary waveforms, Raw Time Series
 
 ## Common Features
 
-This widget supports the common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
+This widget supports common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
 
 ## Operations
 

--- a/docs/widgets/recorder_player.en.md
+++ b/docs/widgets/recorder_player.en.md
@@ -10,7 +10,7 @@ It supports loading common audio files such as WAV, MP3, FLAC, and OGG.
 
 ## Common Features
 
-This widget supports the common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
+This widget supports common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
 
 ## Operations
 

--- a/docs/widgets/response_viewer.en.md
+++ b/docs/widgets/response_viewer.en.md
@@ -8,7 +8,7 @@ The Response Viewer is an advanced visualization tool for analyzing linear and h
 
 ## Common Features
 
-This widget supports the common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
+This widget supports common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
 
 ## Key Features and Operation
 

--- a/docs/widgets/settings.en.md
+++ b/docs/widgets/settings.en.md
@@ -6,7 +6,7 @@ In the Settings widget, you manage settings related to the operation of the enti
 
 ## Common Features
 
-This widget supports the common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
+This widget supports common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
 
 ## General
 

--- a/docs/widgets/signal_generator.en.md
+++ b/docs/widgets/signal_generator.en.md
@@ -14,7 +14,7 @@ Main features:
 
 ## Common Features
 
-This widget supports the common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
+This widget supports common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
 
 ## Basic Operation
 

--- a/docs/widgets/sound_level_meter.en.md
+++ b/docs/widgets/sound_level_meter.en.md
@@ -8,7 +8,7 @@ The Sound Level Meter is a precision tool for measuring environmental noise and 
 
 ## Common Features
 
-This widget supports the common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
+This widget supports common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
 
 ## Basic Operation
 

--- a/docs/widgets/sound_quality_analyzer.en.md
+++ b/docs/widgets/sound_quality_analyzer.en.md
@@ -12,7 +12,7 @@ This tool is for **offline analysis only**. It analyzes pre-recorded audio files
 
 ## Common Features
 
-This widget supports the common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
+This widget supports common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
 
 ## Metric Descriptions
 

--- a/docs/widgets/spatial_binaural_mixer.en.md
+++ b/docs/widgets/spatial_binaural_mixer.en.md
@@ -18,7 +18,7 @@ Unlike real-time HRTF players, this module is specifically engineered for multi-
 
 ## Common Features
 
-This widget supports the common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
+This widget supports common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
 
 ## 🎛️ Usage Guide
 

--- a/docs/widgets/spectrogram.en.md
+++ b/docs/widgets/spectrogram.en.md
@@ -10,7 +10,7 @@ It is ideal for observing the "transitions" of sound, such as voice intonation a
 
 ## Common Features
 
-This widget supports the common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
+This widget supports common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
 
 ## Operation
 

--- a/docs/widgets/spectrum_analyzer.en.md
+++ b/docs/widgets/spectrum_analyzer.en.md
@@ -10,7 +10,7 @@ In addition to general FFT (Fast Fourier Transformation) analysis, it also featu
 
 ## Common Features
 
-This widget supports the common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
+This widget supports common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
 
 ## Operation
 

--- a/docs/widgets/stereo_alignment_monitor.en.md
+++ b/docs/widgets/stereo_alignment_monitor.en.md
@@ -9,7 +9,7 @@ It monitors L/R balance, frequency response match, center focus, and phase issue
 
 ## Common Features
 
-This widget supports the common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
+This widget supports common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
 
 ## What is Stereo Alignment?
 

--- a/docs/widgets/timecode_monitor.en.md
+++ b/docs/widgets/timecode_monitor.en.md
@@ -108,7 +108,7 @@ Calibration measures audio path delay. It does not rewrite the timecode content 
 
 ## Common Features
 
-This widget supports the common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
+This widget supports common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
 
 ## Usage Examples
 

--- a/docs/widgets/transient_analyzer.en.md
+++ b/docs/widgets/transient_analyzer.en.md
@@ -9,7 +9,7 @@ It uses the **Continuous Wavelet Transform (CWT)** to visualize sounds while mai
 
 ## Common Features
 
-This widget supports the common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
+This widget supports common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
 
 ## Operation
 

--- a/docs/widgets/transmission_analyzer.en.md
+++ b/docs/widgets/transmission_analyzer.en.md
@@ -10,9 +10,9 @@
 
 It supports both digital and analog signal paths—such as USB cables, Bluetooth connections, or physical analog circuits—measuring sampling synchronization delay, clock jitter, and signal integrity in real-time.
 
-## Detachable Wrapper Features
+## Common Features
 
-This widget supports common features of the Detachable Wrapper (such as **Compact Mode**). Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
+This widget supports common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
 
 ## Key Features & Measurement Modes
 

--- a/docs/widgets/ultrasound_modulator.en.md
+++ b/docs/widgets/ultrasound_modulator.en.md
@@ -17,7 +17,7 @@ Key Features:
 
 ## Common Features
 
-This widget supports the common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
+This widget supports common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
 
 ## Basic Operation
 

--- a/docs/widgets/waveform_loop_player.en.md
+++ b/docs/widgets/waveform_loop_player.en.md
@@ -9,7 +9,7 @@ It is highly useful when you want to repeatedly play back a specific audio signa
 
 ## Common Features
 
-This widget supports the common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
+This widget supports common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
 
 ## Operations
 

--- a/docs/widgets/welcome.en.md
+++ b/docs/widgets/welcome.en.md
@@ -8,7 +8,7 @@ If you are using this tool for the first time, grasp the overall picture of each
 
 ## Common Features
 
-This widget supports the common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
+This widget supports common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details.
 
 ## Operation
 


### PR DESCRIPTION
This PR standardizes the "Detachable Wrapper" boilerplate phrasing and section headings across all English widget documentation files to improve structural consistency and readability, as per the guidelines.

Specifically:
- Standardized the sentence to `"This widget supports common features of the Detachable Wrapper. Please refer to the [Detachable Wrapper](detachable_wrapper.en.md) documentation for details."`, removing variations and unnecessary articles (e.g. "supports **the** common features").
- Renamed the `## Detachable Wrapper Features` heading in `transmission_analyzer.en.md` to `## Common Features` to match all other widgets and the corresponding Japanese structure (`## 共通機能`).
- Validated via `markdownlint-cli2`. No changes were required for the Japanese files as they were already unified in phrasing and headings.

---
*PR created automatically by Jules for task [7843858587804899907](https://jules.google.com/task/7843858587804899907) started by @youtube-at-vach*