### PR TITLE
docs: exclude blocked proposals from backlog selection

### DIFF
--- a/.agents/skills/agent-proposal-backlog-issue/SKILL.md
+++ b/.agents/skills/agent-proposal-backlog-issue/SKILL.md
@@ -29,6 +29,13 @@ GitHub の現状も、次の最小確認で読み取る。認証・スコープ�
 - `gh project list --owner <owner> --format json` で対象 Project を確認する。MeasureLab では通常 `Agents: MeasureLab` を優先するが、存在を再確認してから使う。
 - `gh project item-list <number> --owner <owner> --format json` と Issue 検索で、同じ提案や同じ目的の Issue が既にないか調べる。
 
+### Blocked の提案を候補から除外する
+
+- Project の項目一覧から `Status: Blocked` の Issue を抽出し、Issue のタイトル・本文と `guide/PROPOSED_FEATURES.md` の提案名、対象ウィジェット、目的を照合する。
+- Blocked の Project 項目が代表しているプロポーサルは、未完了であっても現在の候補集合から除外する。Blocked であることを理由に、同じプロポーサルを再 Issue 化したり、重複する代替 Issue を作成したりしない。
+- Blocked 項目がプロポーサル由来か判断できない場合は、Issue の目的と提案の対応を追加確認し、対応を確定できるまでその提案を候補から外す。
+- 候補選定の記録には、除外したプロポーサル、対応する Issue、Project Status が `Blocked` であることを明記する。Blocked ではない既存 Issue も、従来どおり同じ提案・目的の重複確認で除外する。
+
 ## 選定基準
 
 候補を次の順で比較する。
@@ -41,6 +48,8 @@ GitHub の現状も、次の最小確認で読み取る。認証・スコープ�
 6. 現在のロードマップや既存 Project 項目と競合せず、実装範囲を 1 Issue に分解できるか。
 
 `Implemented`、`Covered`、`On hold`、`Not suitable` の提案は原則選ばない。`Conditional` は必要な fixture・基準経路・用途が Issue 内で明確になる場合だけ選ぶ。機能追加の魅力だけで判断せず、測定結果の信頼性と実装可能性を優先する。
+
+Blocked の既存 Issue が代表する提案は、上記の除外規則を優先し、実装の優先度や安全性が高く見えても選ばない。残りの候補から、既存 Issue と目的が重複しないものを比較する。
 
 ## Issue の作成内容
 
@@ -59,11 +68,12 @@ GUI の表示文字列を含む候補では、`tr()` による翻訳管理、全
 書き込み直前に、既存 Issue の重複と対象 Project を再確認する。認証・スコープの確認は必要な場合だけ行う。
 
 1. 既存 Issue のタイトル・目的が重複していないことを確認する。
-2. `gh issue create --repo <owner>/<repo> --title ... --body ... --label enhancement` で Issue を作成する。Project の `--project` オプションに依存せず、Issue 作成と Project 追加を分離して検証する。
-3. 作成結果の Issue URL を使い、`gh project item-add <number> --owner <owner> --url <issue-url> --format json` で Project に追加する。
-4. `gh project field-list <number> --owner <owner> --format json` で Status フィールドと `Backlog` オプションの ID を取得し、`gh project item-edit` で Status を Backlog に設定する。ID はプロジェクトごとに取得し、固定値を使い回さない。
-5. Priority フィールドがあり、候補が測定基盤・安全性に関わる最優先候補である場合は `P1` を設定してよい。ユーザーが優先度を指定した場合はそれを優先する。
-6. `gh project item-list ... --jq` と `gh issue view ... --json` で、Issue URL、Project 名、Status、必要な Priority、ラベルを再確認する。
+2. Project 項目を再取得し、選定した提案が Blocked Issue の代表する提案に含まれていないことを確認する。確認できない場合は Issue 作成を止める。
+3. `gh issue create --repo <owner>/<repo> --title ... --body ... --label enhancement` で Issue を作成する。Project の `--project` オプションに依存せず、Issue 作成と Project 追加を分離して検証する。
+4. 作成結果の Issue URL を使い、`gh project item-add <number> --owner <owner> --url <issue-url> --format json` で Project に追加する。
+5. `gh project field-list <number> --owner <owner> --format json` で Status フィールドと `Backlog` オプションの ID を取得し、`gh project item-edit` で Status を Backlog に設定する。ID はプロジェクトごとに取得し、固定値を使い回さない。
+6. Priority フィールドがあり、候補が測定基盤・安全性に関わる最優先候補である場合は `P1` を設定してよい。ユーザーが優先度を指定した場合はそれを優先する。
+7. `gh project item-list ... --jq` と `gh issue view ... --json` で、Issue URL、Project 名、Status、必要な Priority、ラベルを再確認する。
 
 Issue 作成後に Project 追加だけが失敗した場合は、同じタイトルで再作成しない。作成済み Issue の URL を報告し、権限不足が原因なら必要に応じて `gh auth refresh -s project` を案内したうえで、Project 追加を再開する。
 


### PR DESCRIPTION
## Summary

- Exclude proposals represented by Project items with Status `Blocked` from candidate selection.
- Require explicit Blocked-item cross-check before creating a new Issue.
- Record excluded proposal, Issue, and Blocked status in the selection report.

## Validation

- `./.venv/bin/python /Users/vach/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/agent-proposal-backlog-issue`
- `npx markdownlint-cli2 .agents/skills/agent-proposal-backlog-issue/SKILL.md`
- `git diff --check`

Related Issue: #2028

Ready for review.