### PR TITLE
Fix Semgrep non-literal import warning

### DIFF
--- a/.agents/skills/ci-prechecker/SKILL.md
+++ b/.agents/skills/ci-prechecker/SKILL.md
@@ -10,7 +10,7 @@ description: PR送信前にCI相当のローカル検証を行うときに使用
 ## 事前準備
 
 開発用ツールがプロジェクトの仮想環境にインストールされていることを確認してください。
-詳細は [tool usage guide](../../../.agent/workflows/tool_usage.md) を参照してください。
+詳細は [tool usage guide](../../workflows/tool_usage.md) を参照してください。
 
 ## 実行手順
 

--- a/.agents/workflows/tool_usage.md
+++ b/.agents/workflows/tool_usage.md
@@ -1,0 +1,63 @@
+---
+description: Instructions for running development tools (pytest, ruff, mypy)
+---
+
+# Tool Usage Guide
+
+## Python仮想環境
+
+Pythonと開発ツールは、リポジトリの仮想環境にある実行ファイルを使用します。
+システムにインストールされた同名コマンドは使用しません。
+
+- Python: `./.venv/bin/python`
+- Pytest: `./.venv/bin/pytest`
+- Ruff: `./.venv/bin/ruff`
+- Mypy: `./.venv/bin/mypy`
+
+仮想環境がない場合は、Python 3.12以降で作成して依存関係を導入します。
+
+```bash
+python3 -m venv .venv
+./.venv/bin/python -m pip install -U pip
+./.venv/bin/python -m pip install -r requirements.txt
+```
+
+## 開発時の確認
+
+変更内容に応じて、次のコマンドを使用します。
+
+```bash
+./.venv/bin/ruff check .
+./.venv/bin/ruff format --check .
+./.venv/bin/mypy src main_gui.py
+./.venv/bin/python scripts/check_trn_keys.py
+./.venv/bin/pytest -q
+```
+
+Markdownを変更した場合は、Markdown lintも実行します。
+
+```bash
+npx markdownlint-cli2 "**/*.md" "#node_modules"
+```
+
+GUIレイアウトまたは翻訳を変更した場合は、全言語のUIサイズ上限を確認します。
+
+```bash
+./.venv/bin/python scripts/check_ui_size_limits.py
+```
+
+実装中に英語だけを素早く確認する場合は `--quick` を使用できますが、最終確認では
+引数なしのコマンドを実行します。
+
+## PR前のCI相当チェック
+
+PRを作成する前は、`.agents/skills/ci-prechecker/SKILL.md` に記載された順序で
+Ruff、Mypy、翻訳キー、Markdown lint、全Pytestを実行します。
+
+ハードウェアテストは通常のPytestではスキップされます。対応機器を使用して明示的に
+検証する場合に限り、Pytestへ `--hardware` を指定します。
+
+## バージョン管理
+
+Git操作にはシステムの `git` コマンドを使用します。ユーザーの作業を保護するため、
+無関係な変更を上書きせず、破壊的な操作を避けてください。

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -1,7 +1,7 @@
 from importlib import import_module
 import logging
 import time
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 from PyQt6.QtCore import QTimer
 from PyQt6.QtGui import QPalette
@@ -29,18 +29,135 @@ from src.gui.module_registry import MODULE_REGISTRY
 from src.gui.widgets.detachable_wrapper import DetachableWidgetWrapper
 
 
-_ALLOWED_MODULE_PATHS = frozenset(
-    [reg.module_path for reg in MODULE_REGISTRY.values()]
-    + ["src.gui.widgets.settings", "src.gui.widgets.welcome"]
-)
+_CLASS_LOADERS: dict[tuple[str, str], Callable[[], type[Any]]] = {
+    ("src.gui.widgets.signal_generator", "SignalGenerator"): lambda: (
+        import_module("src.gui.widgets.signal_generator").SignalGenerator
+    ),
+    ("src.gui.widgets.spectrum_analyzer", "SpectrumAnalyzer"): lambda: (
+        import_module("src.gui.widgets.spectrum_analyzer").SpectrumAnalyzer
+    ),
+    ("src.gui.widgets.sound_level_meter", "SoundLevelMeter"): lambda: (
+        import_module("src.gui.widgets.sound_level_meter").SoundLevelMeter
+    ),
+    ("src.gui.widgets.lufs_meter", "LufsMeter"): lambda: import_module("src.gui.widgets.lufs_meter").LufsMeter,
+    ("src.gui.widgets.loopback_finder", "LoopbackFinder"): lambda: (
+        import_module("src.gui.widgets.loopback_finder").LoopbackFinder
+    ),
+    ("src.gui.widgets.distortion_analyzer", "DistortionAnalyzer"): lambda: (
+        import_module("src.gui.widgets.distortion_analyzer").DistortionAnalyzer
+    ),
+    ("src.gui.widgets.advanced_distortion_meter", "AdvancedDistortionMeter"): lambda: (
+        import_module("src.gui.widgets.advanced_distortion_meter").AdvancedDistortionMeter
+    ),
+    ("src.gui.widgets.network_analyzer", "NetworkAnalyzer"): lambda: (
+        import_module("src.gui.widgets.network_analyzer").NetworkAnalyzer
+    ),
+    ("src.gui.widgets.oscilloscope", "Oscilloscope"): lambda: (
+        import_module("src.gui.widgets.oscilloscope").Oscilloscope
+    ),
+    ("src.gui.widgets.raw_time_series", "RawTimeSeries"): lambda: (
+        import_module("src.gui.widgets.raw_time_series").RawTimeSeries
+    ),
+    ("src.gui.widgets.event_detector", "EventDetector"): lambda: (
+        import_module("src.gui.widgets.event_detector").EventDetector
+    ),
+    ("src.gui.widgets.lock_in_amplifier", "LockInAmplifier"): lambda: (
+        import_module("src.gui.widgets.lock_in_amplifier").LockInAmplifier
+    ),
+    ("src.gui.widgets.lockin_harmonic_analyzer", "LockInHarmonicAnalyzer"): lambda: (
+        import_module("src.gui.widgets.lockin_harmonic_analyzer").LockInHarmonicAnalyzer
+    ),
+    ("src.gui.widgets.arbitrary_harmonic_generator", "ArbitraryHarmonicGenerator"): lambda: (
+        import_module("src.gui.widgets.arbitrary_harmonic_generator").ArbitraryHarmonicGenerator
+    ),
+    ("src.gui.widgets.lockin_spectrum_finder", "LockInSpectrumFinder"): lambda: (
+        import_module("src.gui.widgets.lockin_spectrum_finder").LockInSpectrumFinder
+    ),
+    ("src.gui.widgets.frequency_counter", "FrequencyCounter"): lambda: (
+        import_module("src.gui.widgets.frequency_counter").FrequencyCounter
+    ),
+    ("src.gui.widgets.lock_in_frequency_counter", "LockInFrequencyCounter"): lambda: (
+        import_module("src.gui.widgets.lock_in_frequency_counter").LockInFrequencyCounter
+    ),
+    ("src.gui.widgets.spectrogram", "Spectrogram"): lambda: import_module("src.gui.widgets.spectrogram").Spectrogram,
+    ("src.gui.widgets.boxcar_averager", "BoxcarAverager"): lambda: (
+        import_module("src.gui.widgets.boxcar_averager").BoxcarAverager
+    ),
+    ("src.gui.widgets.goniometer", "Goniometer"): lambda: import_module("src.gui.widgets.goniometer").Goniometer,
+    ("src.gui.widgets.impedance_analyzer", "ImpedanceAnalyzer"): lambda: (
+        import_module("src.gui.widgets.impedance_analyzer").ImpedanceAnalyzer
+    ),
+    ("src.gui.widgets.noise_profiler", "NoiseProfiler"): lambda: (
+        import_module("src.gui.widgets.noise_profiler").NoiseProfiler
+    ),
+    ("src.gui.widgets.recorder_player", "RecorderPlayer"): lambda: (
+        import_module("src.gui.widgets.recorder_player").RecorderPlayer
+    ),
+    ("src.gui.widgets.waveform_loop_player", "WaveformLoopPlayer"): lambda: (
+        import_module("src.gui.widgets.waveform_loop_player").WaveformLoopPlayer
+    ),
+    ("src.gui.widgets.transient_analyzer", "TransientAnalyzer"): lambda: (
+        import_module("src.gui.widgets.transient_analyzer").TransientAnalyzer
+    ),
+    ("src.gui.widgets.sound_quality_analyzer", "SoundQualityAnalyzer"): lambda: (
+        import_module("src.gui.widgets.sound_quality_analyzer").SoundQualityAnalyzer
+    ),
+    ("src.gui.widgets.timecode_monitor", "TimecodeMonitor"): lambda: (
+        import_module("src.gui.widgets.timecode_monitor").TimecodeMonitor
+    ),
+    ("src.gui.widgets.bnim_meter", "BNIMMeter"): lambda: import_module("src.gui.widgets.bnim_meter").BNIMMeter,
+    ("src.gui.widgets.hrtf_player", "HRTFPlayer"): lambda: import_module("src.gui.widgets.hrtf_player").HRTFPlayer,
+    ("src.gui.widgets.ultrasound_modulator", "UltrasoundModulator"): lambda: (
+        import_module("src.gui.widgets.ultrasound_modulator").UltrasoundModulator
+    ),
+    ("src.gui.widgets.linearity_analyzer", "LinearityAnalyzer"): lambda: (
+        import_module("src.gui.widgets.linearity_analyzer").LinearityAnalyzer
+    ),
+    ("src.gui.widgets.one_pps_monitor", "OnePPSMonitor"): lambda: (
+        import_module("src.gui.widgets.one_pps_monitor").OnePPSMonitor
+    ),
+    ("src.gui.widgets.stereo_alignment_monitor", "StereoAlignmentMonitor"): lambda: (
+        import_module("src.gui.widgets.stereo_alignment_monitor").StereoAlignmentMonitor
+    ),
+    ("src.gui.widgets.spatial_binaural_mixer", "SpatialBinauralMixer"): lambda: (
+        import_module("src.gui.widgets.spatial_binaural_mixer").SpatialBinauralMixer
+    ),
+    ("src.gui.widgets.processor_benchmark", "ProcessorBenchmark"): lambda: (
+        import_module("src.gui.widgets.processor_benchmark").ProcessorBenchmark
+    ),
+    ("src.gui.widgets.plot_comparer", "PlotComparer"): lambda: (
+        import_module("src.gui.widgets.plot_comparer").PlotComparer
+    ),
+    ("src.gui.widgets.transmission_analyzer", "TransmissionAnalyzer"): lambda: (
+        import_module("src.gui.widgets.transmission_analyzer").TransmissionAnalyzer
+    ),
+    ("src.gui.widgets.nonlinear_analyzer", "NonlinearAnalyzer"): lambda: (
+        import_module("src.gui.widgets.nonlinear_analyzer").NonlinearAnalyzer
+    ),
+    ("src.gui.widgets.lock_in_modeler", "LockInModeler"): lambda: (
+        import_module("src.gui.widgets.lock_in_modeler").LockInModeler
+    ),
+    ("src.gui.widgets.response_viewer", "ResponseViewer"): lambda: (
+        import_module("src.gui.widgets.response_viewer").ResponseViewer
+    ),
+    ("src.gui.widgets.feedforward_compensator", "FeedforwardCompensator"): lambda: (
+        import_module("src.gui.widgets.feedforward_compensator").FeedforwardCompensator
+    ),
+    ("src.gui.widgets.nonlinear_response_analyzer", "NonlinearResponseAnalyzer"): lambda: (
+        import_module("src.gui.widgets.nonlinear_response_analyzer").NonlinearResponseAnalyzer
+    ),
+    ("src.gui.widgets.settings", "SettingsWidget"): lambda: import_module("src.gui.widgets.settings").SettingsWidget,
+    ("src.gui.widgets.welcome", "WelcomeWidget"): lambda: import_module("src.gui.widgets.welcome").WelcomeWidget,
+}
 
 
 def _load_class(module_path: str, class_name: str):
-    """Dynamically load a class from a module."""
-    if module_path not in _ALLOWED_MODULE_PATHS:
-        raise ValueError(f"Module path not in allowlist: {module_path}")
-    module = import_module(module_path)
-    return getattr(module, class_name)
+    """Load an explicitly registered class without importing user-controlled paths."""
+    try:
+        loader = _CLASS_LOADERS[(module_path, class_name)]
+    except KeyError as exc:
+        raise ValueError(f"Class not in allowlist: {module_path}.{class_name}") from exc
+    return loader()
 
 
 def _load_module_class(module_key: str):

--- a/tests/logic_verification/gui/test_main_window_lazy_imports.py
+++ b/tests/logic_verification/gui/test_main_window_lazy_imports.py
@@ -1,0 +1,65 @@
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from src.gui import main_window
+from src.gui.module_registry import MODULE_REGISTRY
+
+
+def test_import_module_calls_use_literal_paths():
+    source = Path(main_window.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    import_calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "import_module"
+    ]
+
+    assert import_calls
+    assert all(
+        call.args and isinstance(call.args[0], ast.Constant) and isinstance(call.args[0].value, str)
+        for call in import_calls
+    )
+
+
+def test_lazy_class_loaders_match_registry():
+    registered_classes = {
+        (registration.module_path, registration.class_name) for registration in MODULE_REGISTRY.values()
+    }
+    utility_classes = {
+        ("src.gui.widgets.settings", "SettingsWidget"),
+        ("src.gui.widgets.welcome", "WelcomeWidget"),
+    }
+
+    assert set(main_window._CLASS_LOADERS) == registered_classes | utility_classes
+
+
+@pytest.mark.parametrize(
+    ("module_path", "class_name"),
+    [
+        ("untrusted.module", "InjectedClass"),
+        ("src.gui.widgets.settings", "InjectedClass"),
+    ],
+)
+def test_load_class_rejects_unregistered_module_and_class(module_path, class_name, monkeypatch):
+    import_module = pytest.fail
+    monkeypatch.setattr(main_window, "import_module", import_module)
+
+    with pytest.raises(ValueError, match="Class not in allowlist"):
+        main_window._load_class(module_path, class_name)
+
+
+def test_load_class_uses_literal_module_loader(monkeypatch):
+    sentinel = type("Sentinel", (), {})
+    imported_paths = []
+
+    def fake_import_module(module_path):
+        imported_paths.append(module_path)
+        return SimpleNamespace(SettingsWidget=sentinel)
+
+    monkeypatch.setattr(main_window, "import_module", fake_import_module)
+
+    assert main_window._load_class("src.gui.widgets.settings", "SettingsWidget") is sentinel
+    assert imported_paths == ["src.gui.widgets.settings"]


### PR DESCRIPTION
## 概要

- Semgrep finding 928698096 の非リテラル `import_module` 呼び出しを、明示登録されたモジュール・クラスごとのリテラルimportへ変更
- 未登録のモジュールまたはクラスをimport前に拒否
- 遅延ローダーとモジュールレジストリの一致、および全 `import_module` 引数が文字列リテラルであることを回帰テストで保証
- 削除されていた tool usage guide を `.agents/workflows/tool_usage.md` に復元・現行化し、CI pre-checker の参照先を修正

## 検証

- `./.venv/bin/ruff check .`
- `./.venv/bin/mypy src main_gui.py`
- `./.venv/bin/python scripts/check_trn_keys.py`
- `npx markdownlint-cli2 "**/*.md" "#node_modules"`
- `./.venv/bin/pytest`（1251 passed, 6 hardware tests skipped）