### PR TITLE
fix: prevent frequency counter worker signal lifetime race

### DIFF
--- a/src/gui/widgets/frequency_counter.py
+++ b/src/gui/widgets/frequency_counter.py
@@ -38,6 +38,7 @@ class AllanWorkerSignals(QObject):
     """Signals for the AllanWorker."""
 
     result = pyqtSignal(list, list)  # taus, devs
+    finished = pyqtSignal(object)  # worker
 
 
 class AllanWorker(QRunnable):
@@ -55,7 +56,7 @@ class AllanWorker(QRunnable):
     def run(self):
         try:
             if len(self.freq_history) < 10:
-                self.signals.result.emit([], [])
+                self._emit_result([], [])
                 return
 
             dt_seconds = self.update_interval_ms / 1000.0
@@ -68,7 +69,7 @@ class AllanWorker(QRunnable):
                 valid_mask = (np.isfinite(data)) & (data > 0)
                 data = data[valid_mask]
                 if len(data) < 10:
-                    self.signals.result.emit([], [])
+                    self._emit_result([], [])
                     return
                 # Convert to period
                 data = 1.0 / data
@@ -76,24 +77,40 @@ class AllanWorker(QRunnable):
                 # Frequency mode
                 data = data[np.isfinite(data)]
                 if len(data) < 10:
-                    self.signals.result.emit([], [])
+                    self._emit_result([], [])
                     return
 
             # --- Allan Deviation Calculation ---
             taus, devs = calculate_allan_deviation(data, dt_seconds)
 
-            self.signals.result.emit(taus, devs)
+            self._emit_result(taus, devs)
 
         except Exception as e:
             # On error, just emit empty
             logger.error(f"Allan calc error: {e}")
-            self.signals.result.emit([], [])
+            self._emit_result([], [])
+        finally:
+            self._emit_finished()
+
+    def _emit_result(self, taus, devs):
+        try:
+            self.signals.result.emit(taus, devs)
+        except RuntimeError as e:
+            logger.debug("Allan worker result discarded during shutdown: %s", e)
+
+    def _emit_finished(self):
+        try:
+            self.signals.finished.emit(self)
+        except RuntimeError:
+            # The owner is already being torn down; no cleanup callback remains.
+            pass
 
 
 class FrequencyWorkerSignals(QObject):
     """Signals for the FrequencyWorker."""
 
     result = pyqtSignal(object, float)  # freq (float or None), amp_db
+    finished = pyqtSignal(object)  # worker
 
 
 class FrequencyWorker(QRunnable):
@@ -112,11 +129,21 @@ class FrequencyWorker(QRunnable):
     def run(self):
         try:
             freq, db = calculate_frequency_metrics(self.data, self.sr, self.gate_threshold_db, self.calibration_factor)
-            self.signals.result.emit(freq, db)
         except Exception as e:
             # On error, we should probably emit something safe or just log
             logger.error(f"Freq worker error: {e}")
-            self.signals.result.emit(None, -140.0)
+            freq, db = None, -140.0
+
+        try:
+            self.signals.result.emit(freq, db)
+        except RuntimeError as e:
+            logger.debug("Frequency worker result discarded during shutdown: %s", e)
+        finally:
+            try:
+                self.signals.finished.emit(self)
+            except RuntimeError:
+                # The owner is already being torn down; no cleanup callback remains.
+                pass
 
 
 class FrequencyCounter(MeasurementModule):
@@ -445,9 +472,21 @@ class FrequencyCounterWidget(QWidget, CompactableWidgetInterface):
         self.module.start_time = time.time()
 
         # Async Allan Calculation
-        self.threadpool = QThreadPool()
+        # Keep both the pool and each runnable alive until its completion signal is
+        # delivered. QRunnable ownership otherwise lives only on the C++ side after
+        # start(), which can let its Python-owned signals be collected prematurely.
+        self.threadpool = QThreadPool(self)
+        self._active_workers: set[QRunnable] = set()
         self.is_allan_calculating = False
         self.is_calculating_freq = False
+
+    def _start_worker(self, worker: AllanWorker | FrequencyWorker) -> None:
+        self._active_workers.add(worker)
+        worker.signals.finished.connect(self._on_worker_finished)
+        self.threadpool.start(worker)
+
+    def _on_worker_finished(self, worker: QRunnable) -> None:
+        self._active_workers.discard(worker)
 
     def init_ui(self):
         layout = QVBoxLayout()
@@ -1010,7 +1049,7 @@ class FrequencyCounterWidget(QWidget, CompactableWidgetInterface):
 
                     worker = AllanWorker(history_snapshot, self.module.update_interval_ms, self.display_mode)
                     worker.signals.result.connect(self.on_allan_results)
-                    self.threadpool.start(worker)
+                    self._start_worker(worker)
 
             elif current_tab == 2:  # Jitter Histogram (Modulation Domain)
                 # Throttle histogram updates slightly to reduce UI churn.
@@ -1096,7 +1135,7 @@ class FrequencyCounterWidget(QWidget, CompactableWidgetInterface):
         self.is_calculating_freq = True
         worker = FrequencyWorker(data, sr, self.module.gate_threshold_db, cal_factor)
         worker.signals.result.connect(self.on_freq_calculation_result)
-        self.threadpool.start(worker)
+        self._start_worker(worker)
 
     def update_compact_layout(self):
         compact = self.is_compact_mode()

--- a/tests/logic_verification/gui/test_frequency_counter_reset.py
+++ b/tests/logic_verification/gui/test_frequency_counter_reset.py
@@ -6,7 +6,7 @@ import pytest
 pytest.importorskip("PyQt6")
 
 try:
-    from src.gui.widgets.frequency_counter import FrequencyCounter, FrequencyCounterWidget
+    from src.gui.widgets.frequency_counter import FrequencyCounter, FrequencyCounterWidget, FrequencyWorker
 except ImportError:
     pytest.skip("Skipping GUI test due to missing dependencies", allow_module_level=True)
 
@@ -59,6 +59,35 @@ def test_widget_channel_change_resets_history(qapp, frequency_counter):
     # Cleanup properly to avoid segfaults and "pure virtual method called"
     widget.deleteLater()
     qapp.processEvents()
+
+
+def test_widget_retains_worker_until_finished(qapp, qtbot, monkeypatch, frequency_counter):
+    monkeypatch.setattr(
+        "src.gui.widgets.frequency_counter.calculate_frequency_metrics",
+        lambda *_args: (1000.0, -20.0),
+    )
+    widget = FrequencyCounterWidget(frequency_counter)
+    worker = FrequencyWorker([], 48000, -60.0, 1.0)
+
+    widget._start_worker(worker)
+
+    assert worker in widget._active_workers
+    qtbot.waitUntil(lambda: worker not in widget._active_workers, timeout=1000)
+    widget.deleteLater()
+    qapp.processEvents()
+
+
+def test_frequency_worker_ignores_deleted_signals(monkeypatch):
+    from PyQt6 import sip
+
+    monkeypatch.setattr(
+        "src.gui.widgets.frequency_counter.calculate_frequency_metrics",
+        lambda *_args: (1000.0, -20.0),
+    )
+    worker = FrequencyWorker([], 48000, -60.0, 1.0)
+    sip.delete(worker.signals)
+
+    worker.run()
 
 
 def test_frequency_counter_compact_mode(qapp, qtbot, frequency_counter):


### PR DESCRIPTION
## Summary

- retain frequency and Allan-deviation runnables until their completion signals are delivered
- parent the worker thread pool to the frequency-counter widget and safely discard results during teardown
- avoid the second emit to an already-deleted signal object on calculation errors
- add regression coverage for runnable retention/release and deleted Qt signal objects

## Root cause

FrequencyCounterWidget created each QRunnable as a local variable and handed it to QThreadPool without retaining a Python-side reference. During Qt/Python ownership cleanup, the Python-owned signals object could be deleted while run() was still calculating. The result emit then raised RuntimeError, and the broad exception handler attempted a second emit through the same deleted object.

## Validation

- ./.venv/bin/ruff check .
- ./.venv/bin/mypy src main_gui.py
- ./.venv/bin/python scripts/check_trn_keys.py
- npx markdownlint-cli2 "**/*.md" "#node_modules"
- ./.venv/bin/pytest (1273 passed, 6 hardware tests skipped)