### PR TITLE
Fix measurement console auto-fit collapse

### DIFF
--- a/experiments/benchmark_convergence_algorithms.py
+++ b/experiments/benchmark_convergence_algorithms.py
@@ -3,6 +3,7 @@
 """
 Benchmark script comparing convergence speed across different adaptive predistortion algorithms.
 """
+
 import sys
 import os
 import numpy as np
@@ -14,6 +15,7 @@ if project_root not in sys.path:
 from PyQt6.QtWidgets import QApplication
 from src.core.audio_engine import AudioEngine
 from scripts.verify_lockin_adaptive_sweep import AdaptiveSSSWeeper
+
 
 def run_benchmark():
     algorithms = ["baseline", "newton_lm", "secant", "anderson"]
@@ -75,18 +77,18 @@ def run_benchmark():
         results[algo] = thd_db_traj
 
     # Print Summary Comparison Table
-    print("\n\n" + "="*80)
+    print("\n\n" + "=" * 80)
     print("                 ALGORITHM CONVERGENCE SPEED COMPARISON TABLE")
-    print("="*80)
+    print("=" * 80)
     header = f"| {'Iteration':<10} | {'Baseline (mu=0.7)':<18} | {'Newton-LM (mu=1.0)':<18} | {'Secant Method':<18} | {'Anderson Accel.':<18} |"
     print(header)
-    print("|" + "-"*12 + "|" + "-"*20 + "|" + "-"*20 + "|" + "-"*20 + "|" + "-"*20 + "|")
+    print("|" + "-" * 12 + "|" + "-" * 20 + "|" + "-" * 20 + "|" + "-" * 20 + "|" + "-" * 20 + "|")
 
     for i in range(num_iterations + 1):
         row = f"| Iter {i:<5} | {results['baseline'][i]:>15.1f} dB | {results['newton_lm'][i]:>15.1f} dB | {results['secant'][i]:>15.1f} dB | {results['anderson'][i]:>15.1f} dB |"
         print(row)
 
-    print("="*80)
+    print("=" * 80)
 
     # Calculate iterations to reach target cancellation levels
     targets = [-70.0, -80.0, -90.0, -100.0, -110.0]
@@ -101,6 +103,7 @@ def run_benchmark():
                     break
             status_str = f"{iters_needed} iteration(s)" if iters_needed is not None else "Not reached within test"
             print(f"  - {algo:<12}: {status_str}")
+
 
 if __name__ == "__main__":
     run_benchmark()

--- a/experiments/simulate_counter_model.py
+++ b/experiments/simulate_counter_model.py
@@ -27,15 +27,10 @@ fc_lti = 1200.0  # Cutoff for LTI Lowpass Filter
 
 def offline_dut_system(x, fs):
     """Simulates the forward Hammerstein system (Nonlinearity + LPF)."""
-    w = (
-        d_coeffs[1] * x
-        + d_coeffs[2] * (x**2)
-        + d_coeffs[3] * (x**3)
-        + d_coeffs[4] * (x**4)
-        + d_coeffs[5] * (x**5)
-    )
+    w = d_coeffs[1] * x + d_coeffs[2] * (x**2) + d_coeffs[3] * (x**3) + d_coeffs[4] * (x**4) + d_coeffs[5] * (x**5)
     b, a = butter(2, fc_lti / (fs / 2.0), btype="low")
     return lfilter(b, a, w)
+
 
 # ----------------------------------------------------
 # Dynamic & Safe Complex Interpolation Helper (PCHIP)
@@ -486,7 +481,7 @@ def main():
 
     print(f"[*] Phase 1: Running Multi-Amplitude Adaptive Sweeps ({adaptive_algorithm}, {sweep_mode})...")
     for amp in amplitudes:
-        print(f"    -> Running Adaptive Sweep for Amplitude: {amp:.2f} ({20*np.log10(amp):.1f} dBFS)")
+        print(f"    -> Running Adaptive Sweep for Amplitude: {amp:.2f} ({20 * np.log10(amp):.1f} dBFS)")
         sweeper = AdaptiveSSSWeeperSim(
             start_freq=start_freq,
             end_freq=end_freq,
@@ -646,8 +641,20 @@ def main():
     num_cycles_to_show = 5
     samples_to_show = int(num_cycles_to_show * fs / f0)
     plt.plot(t_val[:samples_to_show] * 1000.0, A_t[:samples_to_show], label="Original Input A(t)", color="black")
-    plt.plot(t_val[:samples_to_show] * 1000.0, Mx_A[:samples_to_show], label="Counter Correction Mx(A)(t)", color="red", linestyle="--")
-    plt.plot(t_val[:samples_to_show] * 1000.0, x_corr[:samples_to_show], label="Predistorted Input A(t) + Mx(A)(t)", color="blue", alpha=0.7)
+    plt.plot(
+        t_val[:samples_to_show] * 1000.0,
+        Mx_A[:samples_to_show],
+        label="Counter Correction Mx(A)(t)",
+        color="red",
+        linestyle="--",
+    )
+    plt.plot(
+        t_val[:samples_to_show] * 1000.0,
+        x_corr[:samples_to_show],
+        label="Predistorted Input A(t) + Mx(A)(t)",
+        color="blue",
+        alpha=0.7,
+    )
     plt.title("Time-Domain Waveforms (First 5 Cycles)")
     plt.xlabel("Time (ms)")
     plt.ylabel("Amplitude")

--- a/experiments/verify_lock_in_modeler_hammerstein_real_device.py
+++ b/experiments/verify_lock_in_modeler_hammerstein_real_device.py
@@ -34,16 +34,16 @@ def apply_hardware_non_idealities(sig, sample_rate, noise_dbfs=-85.0, jitter_sam
     # 1. Hardware Frequency Response (converter AC coupling HPF + AA LPF)
     if apply_filter:
         # HPF at 25 Hz (DC block)
-        b_hp, a_hp = butter(1, 25.0 / (fs / 2.0), btype='high')
+        b_hp, a_hp = butter(1, 25.0 / (fs / 2.0), btype="high")
         out_sig = lfilter(b_hp, a_hp, out_sig)
         # LPF at 21500 Hz (converter roll-off)
-        b_lp, a_lp = butter(2, 21500.0 / (fs / 2.0), btype='low')
+        b_lp, a_lp = butter(2, 21500.0 / (fs / 2.0), btype="low")
         out_sig = lfilter(b_lp, a_lp, out_sig)
 
     # 2. Clock Jitter / Fractional Delay
     if jitter_samples > 0:
         delay = np.random.normal(0.0, jitter_samples)
-        freqs = np.fft.rfftfreq(N, d=1.0/fs)
+        freqs = np.fft.rfftfreq(N, d=1.0 / fs)
         phase_shift = np.exp(-1j * 2.0 * np.pi * freqs * (delay / fs))
         sig_fft = np.fft.rfft(out_sig)
         out_sig = np.fft.irfft(sig_fft * phase_shift, n=N)
@@ -217,11 +217,19 @@ def run_sss_sweep(
     return plot_freqs, averaged_results, block_counts, max_blocks
 
 
-
-
 def run_lockin_measurement(
-    audio_engine, f0, A_in, num_runs=5, max_harmonic=5, fast_mode=False, signal_channel=0, ref_channel=1,
-    noise_dbfs=-85.0, jitter_samples=0.02, apply_filter=True, lockin_buffer_size=131072
+    audio_engine,
+    f0,
+    A_in,
+    num_runs=5,
+    max_harmonic=5,
+    fast_mode=False,
+    signal_channel=0,
+    ref_channel=1,
+    noise_dbfs=-85.0,
+    jitter_samples=0.02,
+    apply_filter=True,
+    lockin_buffer_size=131072,
 ):
     """
     Measures the harmonic components under a single-tone excitation using the LockInHarmonicAnalyzer.
@@ -258,7 +266,9 @@ def run_lockin_measurement(
                 if audio_engine.offline_mode:
                     sig = ref_sig
                     simulated_meas = sig - 0.08 * (sig**2) + 0.12 * (sig**3) - 0.04 * (sig**4) + 0.06 * (sig**5)
-                    meas_nonideal = apply_hardware_non_idealities(simulated_meas, fs, noise_dbfs, jitter_samples, apply_filter)
+                    meas_nonideal = apply_hardware_non_idealities(
+                        simulated_meas, fs, noise_dbfs, jitter_samples, apply_filter
+                    )
                     lockin.input_data[:, signal_channel] = meas_nonideal
                     lockin.input_data[:, ref_channel] = ref_nonideal
 
@@ -361,15 +371,17 @@ def run_parameter_sweep(engine, cli_args):
                                 sweep_duration, tsa, num_amplitudes, runs, sample_rate, buf_size
                             )
                             if total_time <= 120.0:
-                                candidates.append({
-                                    "sweep_duration": sweep_duration,
-                                    "tsa": tsa,
-                                    "num_amplitudes": num_amplitudes,
-                                    "runs": runs,
-                                    "buffer_size": buf_size,
-                                    "ref_phase_only": ref_phase_only,
-                                    "estimated_time": total_time
-                                })
+                                candidates.append(
+                                    {
+                                        "sweep_duration": sweep_duration,
+                                        "tsa": tsa,
+                                        "num_amplitudes": num_amplitudes,
+                                        "runs": runs,
+                                        "buffer_size": buf_size,
+                                        "ref_phase_only": ref_phase_only,
+                                        "estimated_time": total_time,
+                                    }
+                                )
 
     print(f"[+] Found {len(candidates)} valid parameter combinations within the 120-second limit.")
 
@@ -383,7 +395,9 @@ def run_parameter_sweep(engine, cli_args):
         ref_phase_only = cand["ref_phase_only"]
         est_t = cand["estimated_time"]
 
-        print(f"\n[*] Evaluating candidate {idx+1}/{len(candidates)}: Dur={sdur}s, TSA={tsa}, Amps={namps}, Runs={runs}, RefPhaseOnly={ref_phase_only} (Est Time: {est_t:.1f}s)...")
+        print(
+            f"\n[*] Evaluating candidate {idx + 1}/{len(candidates)}: Dur={sdur}s, TSA={tsa}, Amps={namps}, Runs={runs}, RefPhaseOnly={ref_phase_only} (Est Time: {est_t:.1f}s)..."
+        )
 
         # 1. SSS Sweep
         max_amp_db = -6.0
@@ -463,10 +477,12 @@ def run_parameter_sweep(engine, cli_args):
                 diff = (diff + 180) % 360 - 180
                 phases_aligned[idx_p] = phases_aligned[0] + diff
 
-            lockin_avg.append({
-                "amp_db": np.mean(amps),
-                "phase_deg": (np.mean(phases_aligned) + 180) % 360 - 180,
-            })
+            lockin_avg.append(
+                {
+                    "amp_db": np.mean(amps),
+                    "phase_deg": (np.mean(phases_aligned) + 180) % 360 - 180,
+                }
+            )
 
         # 6. Accuracy Evaluation
         amp_diffs = []
@@ -504,10 +520,14 @@ def run_parameter_sweep(engine, cli_args):
     print("\n" + "=" * 115)
     print("=== PARAMETER SWEEP RANKING ===")
     print("=" * 115)
-    print(f"{'Rank':<5} | {'Dur (s)':<8} | {'TSA':<4} | {'Amps':<5} | {'Runs':<5} | {'BufSize':<8} | {'RefPhaseOnly':<12} | {'Est Time (s)':<12} | {'Max Amp Err (dB)':<16} | {'Max Phase Err (deg)':<19}")
+    print(
+        f"{'Rank':<5} | {'Dur (s)':<8} | {'TSA':<4} | {'Amps':<5} | {'Runs':<5} | {'BufSize':<8} | {'RefPhaseOnly':<12} | {'Est Time (s)':<12} | {'Max Amp Err (dB)':<16} | {'Max Phase Err (deg)':<19}"
+    )
     print("-" * 115)
     for rank, r in enumerate(results[:20]):
-        print(f"{rank+1:<5} | {r['sweep_duration']:<8.1f} | {r['tsa']:<4} | {r['num_amplitudes']:<5} | {r['runs']:<5} | {r['buffer_size']:<8} | {str(r['ref_phase_only']):<12} | {r['estimated_time']:<12.1f} | {r['max_amp_err']:<16.4f} | {r['max_phase_err']:<19.4f}")
+        print(
+            f"{rank + 1:<5} | {r['sweep_duration']:<8.1f} | {r['tsa']:<4} | {r['num_amplitudes']:<5} | {r['runs']:<5} | {r['buffer_size']:<8} | {str(r['ref_phase_only']):<12} | {r['estimated_time']:<12.1f} | {r['max_amp_err']:<16.4f} | {r['max_phase_err']:<19.4f}"
+        )
     print("=" * 115)
 
     # Save results to JSON
@@ -525,10 +545,21 @@ def main():
         "--virtual", action="store_true", help="Run in virtual simulation loop mode instead of real device"
     )
     parser.add_argument("--fast", action="store_true", help="Run fast simulation without time delays")
-    parser.add_argument("--noise-dbfs", type=float, default=-85.0, help="Simulated noise floor in dBFS (default: -85.0)")
-    parser.add_argument("--jitter-samples", type=float, default=0.02, help="Simulated clock jitter in samples (default: 0.02)")
-    parser.add_argument("--hw-filter", action="store_true", default=True, help="Apply simulated hardware frequency response (default: True)")
-    parser.add_argument("--no-hw-filter", action="store_false", dest="hw_filter", help="Disable simulated hardware frequency response")
+    parser.add_argument(
+        "--noise-dbfs", type=float, default=-85.0, help="Simulated noise floor in dBFS (default: -85.0)"
+    )
+    parser.add_argument(
+        "--jitter-samples", type=float, default=0.02, help="Simulated clock jitter in samples (default: 0.02)"
+    )
+    parser.add_argument(
+        "--hw-filter",
+        action="store_true",
+        default=True,
+        help="Apply simulated hardware frequency response (default: True)",
+    )
+    parser.add_argument(
+        "--no-hw-filter", action="store_false", dest="hw_filter", help="Disable simulated hardware frequency response"
+    )
     parser.add_argument("--sweep-params", action="store_true", help="Sweep parameters to optimize accuracy")
     parser.add_argument("--runs", type=int, default=5, help="Number of runs for statistics and stability")
     parser.add_argument("--f0", type=float, default=1000.0, help="Test frequency for lock-in vs prediction comparison")
@@ -544,7 +575,11 @@ def main():
     parser.add_argument("--num-meas-points", type=int, default=500, help="Number of measurement points")
     parser.add_argument("--min-analysis-window", type=float, default=1.0, help="Minimum analysis window in seconds")
     parser.add_argument(
-        "--model", type=str, choices=["chebyshev"], default="chebyshev", help="Model domain mode (only 'chebyshev' is supported now)"
+        "--model",
+        type=str,
+        choices=["chebyshev"],
+        default="chebyshev",
+        help="Model domain mode (only 'chebyshev' is supported now)",
     )
     parser.add_argument(
         "--no-ref-phase-only", action="store_true", help="Disable ref-phase-only mode (use full XFER scaling)"
@@ -621,32 +656,36 @@ def main():
                 sig = logical_in[:, 0]
                 simulated_meas = sig - 0.08 * (sig**2) + 0.12 * (sig**3) - 0.04 * (sig**4) + 0.06 * (sig**5)
                 logical_in[:, 0] = apply_hardware_non_idealities(
-                    simulated_meas, engine.sample_rate,
+                    simulated_meas,
+                    engine.sample_rate,
                     noise_dbfs=cli_args.noise_dbfs,
                     jitter_samples=cli_args.jitter_samples,
-                    apply_filter=cli_args.hw_filter
+                    apply_filter=cli_args.hw_filter,
                 )
                 logical_in[:, 1] = apply_hardware_non_idealities(
-                    sig, engine.sample_rate,
+                    sig,
+                    engine.sample_rate,
                     noise_dbfs=cli_args.noise_dbfs,
                     jitter_samples=cli_args.jitter_samples,
-                    apply_filter=cli_args.hw_filter
+                    apply_filter=cli_args.hw_filter,
                 )
             else:
                 # Stereo sweep or default case
                 sig = logical_in[:, 1]
                 simulated_meas = sig - 0.08 * (sig**2) + 0.12 * (sig**3) - 0.04 * (sig**4) + 0.06 * (sig**5)
                 logical_in[:, 0] = apply_hardware_non_idealities(
-                    simulated_meas, engine.sample_rate,
+                    simulated_meas,
+                    engine.sample_rate,
                     noise_dbfs=cli_args.noise_dbfs,
                     jitter_samples=cli_args.jitter_samples,
-                    apply_filter=cli_args.hw_filter
+                    apply_filter=cli_args.hw_filter,
                 )
                 logical_in[:, 1] = apply_hardware_non_idealities(
-                    sig, engine.sample_rate,
+                    sig,
+                    engine.sample_rate,
                     noise_dbfs=cli_args.noise_dbfs,
                     jitter_samples=cli_args.jitter_samples,
-                    apply_filter=cli_args.hw_filter
+                    apply_filter=cli_args.hw_filter,
                 )
         return logical_in
 

--- a/experiments/verify_lock_in_modeler_hammerstein_real_device_grid.py
+++ b/experiments/verify_lock_in_modeler_hammerstein_real_device_grid.py
@@ -320,9 +320,7 @@ def main():
     )
     parser.add_argument("--num-amplitudes", type=int, default=5, help="Number of excitation amplitudes for sweep")
     parser.add_argument("--num-meas-points", type=int, default=500, help="Number of measurement points")
-    parser.add_argument(
-        "--model", type=str, choices=["chebyshev"], default="chebyshev", help="Model domain mode"
-    )
+    parser.add_argument("--model", type=str, choices=["chebyshev"], default="chebyshev", help="Model domain mode")
     parser.add_argument(
         "--no-ref-phase-only", action="store_true", help="Disable ref-phase-only mode (use full XFER scaling)"
     )
@@ -382,7 +380,10 @@ def main():
                 break
 
         if uac_idx is None:
-            print("[-] Error: ZOOM UAC-232 not found. Run with --virtual or --test-run if no real hardware is connected.", flush=True)
+            print(
+                "[-] Error: ZOOM UAC-232 not found. Run with --virtual or --test-run if no real hardware is connected.",
+                flush=True,
+            )
             sys.exit(1)
 
         print(f"[+] Found ZOOM UAC-232 at index {uac_idx}", flush=True)
@@ -460,7 +461,10 @@ def main():
 
     print("\n[+] Determined Reference Single-Tone Response:", flush=True)
     for n in range(1, max_harmonic + 1):
-        print(f"  H{n}: Amp = {lockin_ref_avg[n-1]['amp_db']:.2f} dB (std={lockin_ref_avg[n-1]['amp_std']:.3f}), Phase = {lockin_ref_avg[n-1]['phase_deg']:.1f} deg (std={lockin_ref_avg[n-1]['phase_std']:.2f})", flush=True)
+        print(
+            f"  H{n}: Amp = {lockin_ref_avg[n - 1]['amp_db']:.2f} dB (std={lockin_ref_avg[n - 1]['amp_std']:.3f}), Phase = {lockin_ref_avg[n - 1]['phase_deg']:.1f} deg (std={lockin_ref_avg[n - 1]['phase_std']:.2f})",
+            flush=True,
+        )
 
     # ----------------------------------------------------
     # Phase B: SSS Sweep Captures (Once per Duration/Amplitude)
@@ -495,12 +499,14 @@ def main():
                 ref_channel=1,
             )
 
-            captured_sweeps[dur].append({
-                "amplitude": amp,
-                "sig_blocks": sig_blocks,
-                "ref_blocks": ref_blocks,
-                "latency": latency,
-            })
+            captured_sweeps[dur].append(
+                {
+                    "amplitude": amp,
+                    "sig_blocks": sig_blocks,
+                    "ref_blocks": ref_blocks,
+                    "latency": latency,
+                }
+            )
 
     engine.unregister_callback(dummy_cb_id)
     print("\n[+] SSS Sweep capturing completed.", flush=True)
@@ -579,26 +585,34 @@ def main():
                 max_amp_err = np.max(amp_diffs) if amp_diffs else 0.0
                 max_phase_err = np.max(phase_diffs) if phase_diffs else 0.0
 
-                results_matrix.append({
-                    "duration_s": dur,
-                    "analysis_cycle": cyc,
-                    "min_window_ms": int(win * 1000),
-                    "mae_amp_db": mae_amp,
-                    "mae_phase_deg": mae_phase,
-                    "max_amp_err_db": max_amp_err,
-                    "max_phase_err_deg": max_phase_err,
-                })
+                results_matrix.append(
+                    {
+                        "duration_s": dur,
+                        "analysis_cycle": cyc,
+                        "min_window_ms": int(win * 1000),
+                        "mae_amp_db": mae_amp,
+                        "mae_phase_deg": mae_phase,
+                        "max_amp_err_db": max_amp_err,
+                        "max_phase_err_deg": max_phase_err,
+                    }
+                )
 
         # Print results table for this duration
         print("\n=========================================================================================", flush=True)
         print(f" MATRIX EVALUATION SUMMARY: Duration = {dur}s", flush=True)
         print("=========================================================================================", flush=True)
-        print(" Cycles     | Min Window   | MAE Amp (dB)   | MAE Phase (deg)  | Max Amp Err (dB)  | Max Phase Err (deg)", flush=True)
+        print(
+            " Cycles     | Min Window   | MAE Amp (dB)   | MAE Phase (deg)  | Max Amp Err (dB)  | Max Phase Err (deg)",
+            flush=True,
+        )
         print("-" * 105, flush=True)
         dur_results = [r for r in results_matrix if r["duration_s"] == dur]
         for r in dur_results:
             win_str = f"{r['min_window_ms']} ms"
-            print(f" {r['analysis_cycle']:<10.1f} | {win_str:<12} | {r['mae_amp_db']:>14.4f} | {r['mae_phase_deg']:>16.4f} | {r['max_amp_err_db']:>17.4f} | {r['max_phase_err_deg']:>20.4f}", flush=True)
+            print(
+                f" {r['analysis_cycle']:<10.1f} | {win_str:<12} | {r['mae_amp_db']:>14.4f} | {r['mae_phase_deg']:>16.4f} | {r['max_amp_err_db']:>17.4f} | {r['max_phase_err_deg']:>20.4f}",
+                flush=True,
+            )
         print("=========================================================================================", flush=True)
 
     # ----------------------------------------------------
@@ -615,17 +629,29 @@ def main():
     # Export to CSV
     with open(output_csv_path, "w", encoding="utf-8", newline="") as f:
         writer = csv.writer(f)
-        writer.writerow(["duration_s", "analysis_cycle", "min_window_ms", "mae_amp_db", "mae_phase_deg", "max_amp_err_db", "max_phase_err_deg"])
+        writer.writerow(
+            [
+                "duration_s",
+                "analysis_cycle",
+                "min_window_ms",
+                "mae_amp_db",
+                "mae_phase_deg",
+                "max_amp_err_db",
+                "max_phase_err_deg",
+            ]
+        )
         for r in results_matrix:
-            writer.writerow([
-                r["duration_s"],
-                r["analysis_cycle"],
-                r["min_window_ms"],
-                r["mae_amp_db"],
-                r["mae_phase_deg"],
-                r["max_amp_err_db"],
-                r["max_phase_err_deg"]
-            ])
+            writer.writerow(
+                [
+                    r["duration_s"],
+                    r["analysis_cycle"],
+                    r["min_window_ms"],
+                    r["mae_amp_db"],
+                    r["mae_phase_deg"],
+                    r["max_amp_err_db"],
+                    r["max_phase_err_deg"],
+                ]
+            )
     print(f"[+] Saved matrix CSV results to {output_csv_path}", flush=True)
     print("\n[+] Verification run completed successfully.", flush=True)
 

--- a/experiments/verify_lockin_adaptive_sweep.py
+++ b/experiments/verify_lockin_adaptive_sweep.py
@@ -726,7 +726,9 @@ def main():
         help="Fast convergence algorithm (baseline, newton_lm, secant, anderson)",
     )
     parser.add_argument("--mu", type=float, default=1.0, help="Learning rate (0 < mu <= 1.0) to prevent overshoot")
-    parser.add_argument("--mu-decay", type=float, default=0.92, help="Learning rate decay factor per iteration (e.g. 0.85 - 0.95)")
+    parser.add_argument(
+        "--mu-decay", type=float, default=0.92, help="Learning rate decay factor per iteration (e.g. 0.85 - 0.95)"
+    )
     parser.add_argument("--analysis-cycles", type=float, default=12.0, help="Analysis cycles for lock-in tracking")
     parser.add_argument("--min-window", type=float, default=0.012, help="Minimum analysis window in seconds")
     parser.add_argument("--meas-points", type=int, default=300, help="Number of measurement points")

--- a/src/core/calibration.py
+++ b/src/core/calibration.py
@@ -63,18 +63,14 @@ class CalibrationManager:
                     data = json.load(f)
                     self.input_sensitivity = data.get("input_sensitivity", 1.0)
                     if "input_sensitivity_is_calibrated" in data:
-                        self.input_sensitivity_is_calibrated = bool(
-                            data.get("input_sensitivity_is_calibrated")
-                        )
+                        self.input_sensitivity_is_calibrated = bool(data.get("input_sensitivity_is_calibrated"))
                     else:
                         # Legacy files did not record this state. A non-default
                         # sensitivity could only be entered through calibration
                         # settings, so preserve it as calibrated. The ambiguous
                         # 1.0 V/FS case intentionally fails closed.
                         try:
-                            self.input_sensitivity_is_calibrated = (
-                                abs(float(self.input_sensitivity) - 1.0) > 1e-12
-                            )
+                            self.input_sensitivity_is_calibrated = abs(float(self.input_sensitivity) - 1.0) > 1e-12
                         except Exception:
                             self.input_sensitivity_is_calibrated = False
                     self.output_gain = data.get("output_gain", 1.0)
@@ -120,8 +116,7 @@ class CalibrationManager:
                     stored_last_profile = data.get("last_profile")
                     self.last_profile = (
                         stored_last_profile
-                        if isinstance(stored_last_profile, str)
-                        and stored_last_profile in self.profiles
+                        if isinstance(stored_last_profile, str) and stored_last_profile in self.profiles
                         else None
                     )
             except Exception as e:
@@ -132,9 +127,7 @@ class CalibrationManager:
         if self.last_profile and self.last_profile in self.profiles:
             p = self.profiles[self.last_profile]
             p["input_sensitivity"] = self.input_sensitivity
-            p["input_sensitivity_is_calibrated"] = bool(
-                self.input_sensitivity_is_calibrated
-            )
+            p["input_sensitivity_is_calibrated"] = bool(self.input_sensitivity_is_calibrated)
             p["output_gain"] = self.output_gain
             p["output_gain_is_calibrated"] = bool(self.output_gain_is_calibrated)
             p["frequency_calibration"] = self.frequency_calibration
@@ -145,9 +138,7 @@ class CalibrationManager:
 
         data = {
             "input_sensitivity": self.input_sensitivity,
-            "input_sensitivity_is_calibrated": bool(
-                self.input_sensitivity_is_calibrated
-            ),
+            "input_sensitivity_is_calibrated": bool(self.input_sensitivity_is_calibrated),
             "output_gain": self.output_gain,
             "output_gain_is_calibrated": bool(self.output_gain_is_calibrated),
             "frequency_calibration": self.frequency_calibration,
@@ -305,9 +296,7 @@ class CalibrationManager:
         """Capture all values owned by a calibration profile."""
         return {
             "input_sensitivity": self.input_sensitivity,
-            "input_sensitivity_is_calibrated": bool(
-                self.input_sensitivity_is_calibrated
-            ),
+            "input_sensitivity_is_calibrated": bool(self.input_sensitivity_is_calibrated),
             "output_gain": self.output_gain,
             "output_gain_is_calibrated": bool(self.output_gain_is_calibrated),
             "frequency_calibration": self.frequency_calibration,
@@ -321,28 +310,18 @@ class CalibrationManager:
         """Apply a complete profile snapshot while preserving legacy defaults."""
         self.input_sensitivity = snapshot.get("input_sensitivity", 1.0)
         if "input_sensitivity_is_calibrated" in snapshot:
-            self.input_sensitivity_is_calibrated = bool(
-                snapshot.get("input_sensitivity_is_calibrated")
-            )
+            self.input_sensitivity_is_calibrated = bool(snapshot.get("input_sensitivity_is_calibrated"))
         else:
             try:
-                self.input_sensitivity_is_calibrated = (
-                    abs(float(self.input_sensitivity) - 1.0) > 1e-12
-                )
+                self.input_sensitivity_is_calibrated = abs(float(self.input_sensitivity) - 1.0) > 1e-12
             except Exception:
                 self.input_sensitivity_is_calibrated = False
 
         self.output_gain = snapshot.get("output_gain", 1.0)
-        self.output_gain_is_calibrated = bool(
-            snapshot.get("output_gain_is_calibrated", False)
-        )
+        self.output_gain_is_calibrated = bool(snapshot.get("output_gain_is_calibrated", False))
         self.frequency_calibration = snapshot.get("frequency_calibration", 1.0)
-        self.frequency_calibration_1pps = snapshot.get(
-            "frequency_calibration_1pps", 1.0
-        )
-        self.frequency_calibration_source = snapshot.get(
-            "frequency_calibration_source", "basic"
-        )
+        self.frequency_calibration_1pps = snapshot.get("frequency_calibration_1pps", 1.0)
+        self.frequency_calibration_source = snapshot.get("frequency_calibration_source", "basic")
         self.lockin_gain_offset = snapshot.get("lockin_gain_offset", 0.0)
         self.spl_offset_db = snapshot.get("spl_offset_db", None)
 
@@ -406,9 +385,7 @@ class CalibrationManager:
         self.profiles[name] = profile
         self._apply_calibration_snapshot(snapshot)
         self.last_profile = name
-        self._save_profile_mutation_or_raise(
-            old_profiles, old_last_profile, old_snapshot
-        )
+        self._save_profile_mutation_or_raise(old_profiles, old_last_profile, old_snapshot)
 
     def duplicate_profile(
         self,
@@ -438,9 +415,7 @@ class CalibrationManager:
         profile.update(snapshot)
         self.profiles[name] = profile
         self.last_profile = name
-        self._save_profile_mutation_or_raise(
-            old_profiles, old_last_profile, snapshot
-        )
+        self._save_profile_mutation_or_raise(old_profiles, old_last_profile, snapshot)
 
     def rename_profile(self, old_name, new_name):
         """Rename a profile without changing its calibration or device metadata."""
@@ -462,9 +437,7 @@ class CalibrationManager:
         self.profiles[new_name] = self.profiles.pop(old_name)
         if self.last_profile == old_name:
             self.last_profile = new_name
-        self._save_profile_mutation_or_raise(
-            old_profiles, old_last_profile, snapshot
-        )
+        self._save_profile_mutation_or_raise(old_profiles, old_last_profile, snapshot)
 
     def save_profile(
         self,
@@ -538,9 +511,7 @@ class CalibrationManager:
         del self.profiles[name]
         if self.last_profile == name:
             self.last_profile = None
-        self._save_profile_mutation_or_raise(
-            old_profiles, old_last_profile, snapshot
-        )
+        self._save_profile_mutation_or_raise(old_profiles, old_last_profile, snapshot)
 
     def get_profiles(self):
         """Returns the dictionary of profiles."""

--- a/src/core/hammerstein_model.py
+++ b/src/core/hammerstein_model.py
@@ -194,19 +194,31 @@ def estimate_hammerstein_kernels(
     sum_R2 = np.sum(R_array**2)
 
     # 5th Harmonic -> H5 (measured at 5 * sorted_freqs)
-    H5_phys_val = 16.0 * np.sum(g5 * R5[:, np.newaxis], axis=0) / sum_R10 if P >= 5 and sum_R10 > 1e-12 else np.zeros(J, dtype=complex)
+    H5_phys_val = (
+        16.0 * np.sum(g5 * R5[:, np.newaxis], axis=0) / sum_R10
+        if P >= 5 and sum_R10 > 1e-12
+        else np.zeros(J, dtype=complex)
+    )
 
     # 4th Harmonic -> H4 (measured at 4 * sorted_freqs)
-    H4_phys_val = 8.0 * np.sum(g4 * R4[:, np.newaxis], axis=0) / sum_R8 if P >= 4 and sum_R8 > 1e-12 else np.zeros(J, dtype=complex)
+    H4_phys_val = (
+        8.0 * np.sum(g4 * R4[:, np.newaxis], axis=0) / sum_R8
+        if P >= 4 and sum_R8 > 1e-12
+        else np.zeros(J, dtype=complex)
+    )
 
     # 3rd Harmonic -> H3 (measured at 3 * sorted_freqs)
     if P >= 5:
         # Interpolate H5(5f) to 3f to subtract from g3(f)
         H5_at_3f = _interpolate_complex_kernel(3.0 * sorted_freqs, 5.0 * sorted_freqs, H5_phys_val)
-        g3_prime = g3 - (5.0/16.0) * H5_at_3f[np.newaxis, :] * R5[:, np.newaxis]
+        g3_prime = g3 - (5.0 / 16.0) * H5_at_3f[np.newaxis, :] * R5[:, np.newaxis]
     else:
         g3_prime = g3
-    H3_phys_val = 4.0 * np.sum(g3_prime * R3[:, np.newaxis], axis=0) / sum_R6 if P >= 3 and sum_R6 > 1e-12 else np.zeros(J, dtype=complex)
+    H3_phys_val = (
+        4.0 * np.sum(g3_prime * R3[:, np.newaxis], axis=0) / sum_R6
+        if P >= 3 and sum_R6 > 1e-12
+        else np.zeros(J, dtype=complex)
+    )
 
     # 2nd Harmonic -> H2 (measured at 2 * sorted_freqs)
     if P >= 4:
@@ -215,7 +227,11 @@ def estimate_hammerstein_kernels(
         g2_prime = g2 - 0.5 * H4_at_2f[np.newaxis, :] * R4[:, np.newaxis]
     else:
         g2_prime = g2
-    H2_phys_val = 2.0 * np.sum(g2_prime * R2[:, np.newaxis], axis=0) / sum_R4 if P >= 2 and sum_R4 > 1e-12 else np.zeros(J, dtype=complex)
+    H2_phys_val = (
+        2.0 * np.sum(g2_prime * R2[:, np.newaxis], axis=0) / sum_R4
+        if P >= 2 and sum_R4 > 1e-12
+        else np.zeros(J, dtype=complex)
+    )
 
     # 1st Harmonic -> H1 (measured at sorted_freqs)
     g1_prime = g1.copy()
@@ -227,7 +243,9 @@ def estimate_hammerstein_kernels(
         # Interpolate H5(5f) to f to subtract from g1(f)
         H5_at_f = _interpolate_complex_kernel(sorted_freqs, 5.0 * sorted_freqs, H5_phys_val)
         g1_prime -= 0.625 * H5_at_f[np.newaxis, :] * R5[:, np.newaxis]
-    H1_phys_val = np.sum(g1_prime * R_array[:, np.newaxis], axis=0) / sum_R2 if sum_R2 > 1e-12 else np.zeros(J, dtype=complex)
+    H1_phys_val = (
+        np.sum(g1_prime * R_array[:, np.newaxis], axis=0) / sum_R2 if sum_R2 > 1e-12 else np.zeros(J, dtype=complex)
+    )
 
     H_est_list = [H1_phys_val, H2_phys_val, H3_phys_val, H4_phys_val, H5_phys_val][:P]
 
@@ -238,9 +256,7 @@ def estimate_hammerstein_kernels(
         # H_raw is estimated at physical frequencies (p+1) * sorted_freqs.
         # We need to map it to target physical frequencies sorted_freqs.
         H_mapped = _interpolate_complex_kernel(
-            target_freqs=sorted_freqs,
-            source_phys_freqs=(p + 1) * sorted_freqs,
-            source_values=H_raw
+            target_freqs=sorted_freqs, source_phys_freqs=(p + 1) * sorted_freqs, source_values=H_raw
         )
         H_mapped_list.append(H_mapped)
 

--- a/src/core/predistortion.py
+++ b/src/core/predistortion.py
@@ -132,9 +132,7 @@ class PredistortionManager:
             fade_out_mask = n_global >= (sweep_samples - width)
             if np.any(fade_out_mask):
                 n_fade_out = np.clip(n_global[fade_out_mask], 0, sweep_samples - 1)
-                win_chunk[fade_out_mask] = 0.5 * (
-                    1.0 - np.cos(np.pi * (sweep_samples - 1 - n_fade_out) / width)
-                )
+                win_chunk[fade_out_mask] = 0.5 * (1.0 - np.cos(np.pi * (sweep_samples - 1 - n_fade_out) / width))
 
         x_corr = x_base.copy()
 
@@ -260,7 +258,7 @@ class PredistortionManager:
                 (self.meas_freqs[fade_mask] - low_cutoff) / (low_transition - low_cutoff), 0.0, 1.0
             )
 
-        current_mu = mu * (self.mu_decay ** iteration) if algo == "baseline" else mu
+        current_mu = mu * (self.mu_decay**iteration) if algo == "baseline" else mu
         logger.info(
             "Updating predistortion correction for iteration %d (algo='%s', learning rate mu=%.4f):",
             iteration,

--- a/src/core/realtime_sss_core.py
+++ b/src/core/realtime_sss_core.py
@@ -226,7 +226,7 @@ class RealtimeSSSEngine:
             fitted = weighted_design @ coeffs
             ss_res = np.sum((weighted_y - fitted) ** 2)
 
-        ss_tot = np.sum(weighted_y ** 2)
+        ss_tot = np.sum(weighted_y**2)
         quality = np.clip(1.0 - (ss_res / ss_tot), 0.0, 1.0) if ss_tot > 1e-12 else 0.0
 
         results = [complex(coeffs[1 + 2 * p], -coeffs[2 + 2 * p]) for p in range(active_max_harmonic)]

--- a/src/gui/main_window.py
+++ b/src/gui/main_window.py
@@ -859,8 +859,7 @@ class MainWindow(QMainWindow):
                 )
             if self._callback_error_latched:
                 tooltip_sections.append(
-                    f"{tr('Error')}: {self._last_callback_error}\n"
-                    f"{tr('Error Count')}: {self._callback_error_count}"
+                    f"{tr('Error')}: {self._last_callback_error}\n{tr('Error Count')}: {self._callback_error_count}"
                 )
 
             self.io_error_button.setText(

--- a/src/gui/measurement_console.py
+++ b/src/gui/measurement_console.py
@@ -490,6 +490,12 @@ class MeasurementConsoleWindow(QMainWindow):
         if not self._closing:
             QTimer.singleShot(0, self._cache_usable_geometry)
 
+    def adjustSize(self) -> None:
+        """Keep hosted widgets from auto-fitting the whole dock workspace."""
+        if self._docks:
+            return
+        super().adjustSize()
+
     def _cache_usable_geometry(self) -> None:
         """Remember a stable geometry that cannot collapse the restored console."""
         from PyQt6 import sip

--- a/src/gui/widgets/feedforward_compensator.py
+++ b/src/gui/widgets/feedforward_compensator.py
@@ -1371,9 +1371,11 @@ class FeedforwardCompensatorWidget(QWidget):
                     reply = QMessageBox.warning(
                         self,
                         tr("Warning"),
-                        tr("Warning: The loaded model is labeled as Inverse (逆方向). A Forward (順方向) model is recommended for feedforward compensation. Do you want to proceed?"),
+                        tr(
+                            "Warning: The loaded model is labeled as Inverse (逆方向). A Forward (順方向) model is recommended for feedforward compensation. Do you want to proceed?"
+                        ),
                         QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
-                        QMessageBox.StandardButton.No
+                        QMessageBox.StandardButton.No,
                     )
                     if reply == QMessageBox.StandardButton.No:
                         return

--- a/src/gui/widgets/lockin_spectrum_finder.py
+++ b/src/gui/widgets/lockin_spectrum_finder.py
@@ -834,7 +834,7 @@ class LockInSpectrumFinder(MeasurementModule):
                         if appended:
                             # appended is small, so array conversion + argmin is fast enough,
                             # but we can just use a loop for even faster deduplication of a small list
-                            closest_diff = min((abs(a - mf) for a in appended), default=float('inf'))
+                            closest_diff = min((abs(a - mf) for a in appended), default=float("inf"))
                             if closest_diff < 1e-4:
                                 # We already have it or something very close to it in appended
                                 # Technically original code replaced the existing one if < 1e-4,

--- a/src/gui/widgets/loopback_finder.py
+++ b/src/gui/widgets/loopback_finder.py
@@ -636,7 +636,10 @@ class LoopbackFinderWidget(QWidget):
             reason = tr("Virtual mode cannot scan physical loopback paths.")
         elif engine.input_device is None or engine.output_device is None:
             reason = tr("Select both an input and output device.")
-        elif not np.isfinite(float(engine.sample_rate)) or float(engine.sample_rate) <= 2 * self.module.profile.frequency_hz:
+        elif (
+            not np.isfinite(float(engine.sample_rate))
+            or float(engine.sample_rate) <= 2 * self.module.profile.frequency_hz
+        ):
             reason = tr("The sample rate is not valid for the loopback test signal.")
 
         self._scan_available = not reason
@@ -740,7 +743,9 @@ class LoopbackFinderWidget(QWidget):
                 )
             )
         elif result.state == ScanTerminalState.INVALID:
-            self.progress_bar.setValue(100 if result.completed_outputs == result.output_channels else self.progress_bar.value())
+            self.progress_bar.setValue(
+                100 if result.completed_outputs == result.output_channels else self.progress_bar.value()
+            )
             self.validity_label.setText(tr("INVALID"))
             self.validity_label.setStyleSheet("color: #ff4040; font-weight: bold;")
             self.summary_label.setText(tr("Scan invalid — review the warnings below."))

--- a/src/gui/widgets/oscilloscope.py
+++ b/src/gui/widgets/oscilloscope.py
@@ -648,7 +648,9 @@ class Oscilloscope(MeasurementModule):
         is_calibrated, factor, _ = self.get_amplitude_display_state()
 
         target_div = 5.0
-        vdiv_options = [val for _, val in (self.VDIV_OPTIONS_CALIBRATED if is_calibrated else self.VDIV_OPTIONS_UNCALIBRATED)]
+        vdiv_options = [
+            val for _, val in (self.VDIV_OPTIONS_CALIBRATED if is_calibrated else self.VDIV_OPTIONS_UNCALIBRATED)
+        ]
 
         for _ch_idx, (vpp_fs, attr_name) in enumerate([(l_vpp_fs, "vdiv_left"), (r_vpp_fs, "vdiv_right")]):
             vpp = vpp_fs * factor if is_calibrated else vpp_fs
@@ -778,21 +780,29 @@ class OscilloscopeWidget(QWidget, CompactableWidgetInterface, ComparableWidgetIn
 
         # Badge & Status Header
         self.badge_group = QGroupBox()
-        self.badge_group.setStyleSheet("QGroupBox { border: 1px solid #3d4450; border-radius: 4px; margin-top: 0px; padding: 2px; }")
+        self.badge_group.setStyleSheet(
+            "QGroupBox { border: 1px solid #3d4450; border-radius: 4px; margin-top: 0px; padding: 2px; }"
+        )
         badge_layout = QHBoxLayout(self.badge_group)
         badge_layout.setContentsMargins(4, 2, 4, 2)
         badge_layout.setSpacing(4)
 
         self.badge_l_label = QLabel()
-        self.badge_l_label.setStyleSheet("QLabel { color: #00ff00; font-weight: bold; background: #16241a; padding: 2px 4px; border-radius: 3px; border: 1px solid #00aa00; font-size: 11px; }")
+        self.badge_l_label.setStyleSheet(
+            "QLabel { color: #00ff00; font-weight: bold; background: #16241a; padding: 2px 4px; border-radius: 3px; border: 1px solid #00aa00; font-size: 11px; }"
+        )
         badge_layout.addWidget(self.badge_l_label)
 
         self.badge_r_label = QLabel()
-        self.badge_r_label.setStyleSheet("QLabel { color: #ff5555; font-weight: bold; background: #2b1818; padding: 2px 4px; border-radius: 3px; border: 1px solid #aa0000; font-size: 11px; }")
+        self.badge_r_label.setStyleSheet(
+            "QLabel { color: #ff5555; font-weight: bold; background: #2b1818; padding: 2px 4px; border-radius: 3px; border: 1px solid #aa0000; font-size: 11px; }"
+        )
         badge_layout.addWidget(self.badge_r_label)
 
         self.badge_status_label = QLabel()
-        self.badge_status_label.setStyleSheet("QLabel { color: #d0d7de; font-weight: normal; padding: 2px 4px; font-size: 11px; }")
+        self.badge_status_label.setStyleSheet(
+            "QLabel { color: #d0d7de; font-weight: normal; padding: 2px 4px; font-size: 11px; }"
+        )
         badge_layout.addWidget(self.badge_status_label)
 
         badge_layout.addStretch()
@@ -1445,9 +1455,7 @@ class OscilloscopeWidget(QWidget, CompactableWidgetInterface, ComparableWidgetIn
         scale_unit = "V/div" if is_calibrated else "FS/div"
 
         l_status = tr("ON") if self.module.show_left else tr("OFF")
-        self.badge_l_label.setText(
-            f"CH1: {format_si(self.module.vdiv_left, scale_unit, sig_figs=3)} [{l_status}]"
-        )
+        self.badge_l_label.setText(f"CH1: {format_si(self.module.vdiv_left, scale_unit, sig_figs=3)} [{l_status}]")
         self.badge_l_label.setStyleSheet(
             "QLabel { color: #00ff00; font-weight: bold; background: #16241a; padding: 3px 6px; border-radius: 3px; border: 1px solid #00aa00; }"
             if self.module.show_left
@@ -1455,9 +1463,7 @@ class OscilloscopeWidget(QWidget, CompactableWidgetInterface, ComparableWidgetIn
         )
 
         r_status = tr("ON") if self.module.show_right else tr("OFF")
-        self.badge_r_label.setText(
-            f"CH2: {format_si(self.module.vdiv_right, scale_unit, sig_figs=3)} [{r_status}]"
-        )
+        self.badge_r_label.setText(f"CH2: {format_si(self.module.vdiv_right, scale_unit, sig_figs=3)} [{r_status}]")
         self.badge_r_label.setStyleSheet(
             "QLabel { color: #ff5555; font-weight: bold; background: #2b1818; padding: 3px 6px; border-radius: 3px; border: 1px solid #aa0000; }"
             if self.module.show_right
@@ -1595,9 +1601,7 @@ class OscilloscopeWidget(QWidget, CompactableWidgetInterface, ComparableWidgetIn
     def _update_calibration_status(self):
         is_calibrated, sensitivity, _unit = self.module.get_amplitude_display_state()
         if is_calibrated:
-            self.calibration_status_label.setText(
-                tr("Input: Calibrated ({0:.4g} V/FS)").format(sensitivity)
-            )
+            self.calibration_status_label.setText(tr("Input: Calibrated ({0:.4g} V/FS)").format(sensitivity))
         else:
             self.calibration_status_label.setText(tr("Input: Uncalibrated (FS)"))
 
@@ -1605,25 +1609,17 @@ class OscilloscopeWidget(QWidget, CompactableWidgetInterface, ComparableWidgetIn
         is_calibrated, _factor, _unit = self.module.get_amplitude_display_state()
         if is_calibrated:
             self.meas_l_label.setText(
-                tr("L: Vrms: {0:.3f} V  Vpp: {1:.3f} V").format(
-                    measurements["l_rms"], measurements["l_vpp"]
-                )
+                tr("L: Vrms: {0:.3f} V  Vpp: {1:.3f} V").format(measurements["l_rms"], measurements["l_vpp"])
             )
             self.meas_r_label.setText(
-                tr("R: Vrms: {0:.3f} V  Vpp: {1:.3f} V").format(
-                    measurements["r_rms"], measurements["r_vpp"]
-                )
+                tr("R: Vrms: {0:.3f} V  Vpp: {1:.3f} V").format(measurements["r_rms"], measurements["r_vpp"])
             )
         else:
             self.meas_l_label.setText(
-                tr("L: RMS: {0:.3f} FS  Pk-Pk: {1:.3f} FS").format(
-                    measurements["l_rms"], measurements["l_vpp"]
-                )
+                tr("L: RMS: {0:.3f} FS  Pk-Pk: {1:.3f} FS").format(measurements["l_rms"], measurements["l_vpp"])
             )
             self.meas_r_label.setText(
-                tr("R: RMS: {0:.3f} FS  Pk-Pk: {1:.3f} FS").format(
-                    measurements["r_rms"], measurements["r_vpp"]
-                )
+                tr("R: RMS: {0:.3f} FS  Pk-Pk: {1:.3f} FS").format(measurements["r_rms"], measurements["r_vpp"])
             )
 
     def update_plot(self):

--- a/src/gui/widgets/settings.py
+++ b/src/gui/widgets/settings.py
@@ -2052,9 +2052,7 @@ class SettingsWidget(QWidget):
                 if 0 <= index < len(devices):
                     info = devices[index]
                     name = str(info.get("name", "") or "")
-                    host_api = str(
-                        info.get("hostapi_name", "") or info.get("hostapi", "") or ""
-                    )
+                    host_api = str(info.get("hostapi_name", "") or info.get("hostapi", "") or "")
                     return name, host_api
             except (TypeError, ValueError, IndexError):
                 pass
@@ -2093,23 +2091,13 @@ class SettingsWidget(QWidget):
         unavailable = tr("Not available")
 
         if has_profile:
-            self.cal_profile_status_label.setText(
-                tr("Changes are saved automatically to '{0}'.").format(name)
-            )
-            stored_input = str(
-                profile.get("input_device_name", profile.get("device_name", "")) or ""
-            )
-            stored_input_api = str(
-                profile.get("input_host_api", profile.get("host_api", "")) or ""
-            )
+            self.cal_profile_status_label.setText(tr("Changes are saved automatically to '{0}'.").format(name))
+            stored_input = str(profile.get("input_device_name", profile.get("device_name", "")) or "")
+            stored_input_api = str(profile.get("input_host_api", profile.get("host_api", "")) or "")
             stored_output = str(profile.get("output_device_name", "") or "")
             stored_output_api = str(profile.get("output_host_api", "") or "")
-            stored_input_text = self._format_profile_device(
-                stored_input, stored_input_api
-            )
-            stored_output_text = self._format_profile_device(
-                stored_output, stored_output_api
-            )
+            stored_input_text = self._format_profile_device(stored_input, stored_input_api)
+            stored_output_text = self._format_profile_device(stored_output, stored_output_api)
             self.cal_profile_device_label.setText(
                 tr("Profile devices — Input: {0} | Output: {1}").format(
                     stored_input_text or unavailable,
@@ -2122,11 +2110,7 @@ class SettingsWidget(QWidget):
                 and current_input
                 and (
                     stored_input != current_input
-                    or bool(
-                        stored_input_api
-                        and current_input_api
-                        and stored_input_api != current_input_api
-                    )
+                    or bool(stored_input_api and current_input_api and stored_input_api != current_input_api)
                 )
             )
             output_mismatch = bool(
@@ -2134,11 +2118,7 @@ class SettingsWidget(QWidget):
                 and current_output
                 and (
                     stored_output != current_output
-                    or bool(
-                        stored_output_api
-                        and current_output_api
-                        and stored_output_api != current_output_api
-                    )
+                    or bool(stored_output_api and current_output_api and stored_output_api != current_output_api)
                 )
             )
             if input_mismatch or output_mismatch:
@@ -2152,9 +2132,7 @@ class SettingsWidget(QWidget):
             else:
                 self.cal_profile_warning_label.hide()
         else:
-            self.cal_profile_status_label.setText(
-                tr("Current calibration is not assigned to a named profile.")
-            )
+            self.cal_profile_status_label.setText(tr("Current calibration is not assigned to a named profile."))
             self.cal_profile_device_label.setText(
                 tr("Current devices — Input: {0} | Output: {1}").format(
                     current_input_text or unavailable,
@@ -2203,12 +2181,8 @@ class SettingsWidget(QWidget):
             self._refresh_all_calibration_displays()
         except Exception as e:
             active = self.audio_engine.calibration.last_profile
-            self.refresh_cal_profiles(
-                active if isinstance(active, str) else None
-            )
-            QMessageBox.critical(
-                self, tr("Error"), tr("Failed to load profile: {0}").format(e)
-            )
+            self.refresh_cal_profiles(active if isinstance(active, str) else None)
+            QMessageBox.critical(self, tr("Error"), tr("Failed to load profile: {0}").format(e))
 
     def _prompt_profile_name(self, title, label, initial=""):
         name, accepted = QInputDialog.getText(
@@ -2223,17 +2197,13 @@ class SettingsWidget(QWidget):
 
         name = name.strip()
         if not name:
-            QMessageBox.warning(
-                self, tr("Warning"), tr("Profile name cannot be empty.")
-            )
+            QMessageBox.warning(self, tr("Warning"), tr("Profile name cannot be empty."))
             return None
         if name in self.audio_engine.calibration.get_profiles() and name != initial:
             QMessageBox.warning(
                 self,
                 tr("Profile Name In Use"),
-                tr("A profile named '{0}' already exists. Choose a different name.").format(
-                    name
-                ),
+                tr("A profile named '{0}' already exists. Choose a different name.").format(name),
             )
             return None
         return name

--- a/src/gui/widgets/signal_generator.py
+++ b/src/gui/widgets/signal_generator.py
@@ -1287,9 +1287,7 @@ class SignalGenerator(MeasurementModule):
         else:
             target._buffer_index = 0
 
-        if self._filter_runtime_signature(target, sample_rate) == self._filter_runtime_signature(
-            source, sample_rate
-        ):
+        if self._filter_runtime_signature(target, sample_rate) == self._filter_runtime_signature(source, sample_rate):
             target._combined_zi = None if source._combined_zi is None else source._combined_zi.copy()
         else:
             target._combined_zi = None
@@ -1430,9 +1428,7 @@ class SignalGenerator(MeasurementModule):
     def _channel_needs_render(self, channel: str) -> bool:
         state = self._playback_states[channel]
         return bool(
-            state.route_gain > 0.0
-            or state.route_target_gain > 0.0
-            or state.route_position < state.route_samples
+            state.route_gain > 0.0 or state.route_target_gain > 0.0 or state.route_position < state.route_samples
         )
 
     def _apply_route_transition(self, channel: str, samples: np.ndarray):
@@ -1464,9 +1460,7 @@ class SignalGenerator(MeasurementModule):
 
     def _stop_routes_are_silent(self) -> bool:
         return all(
-            state.route_target_gain == 0.0
-            and state.route_gain == 0.0
-            and state.route_position >= state.route_samples
+            state.route_target_gain == 0.0 and state.route_gain == 0.0 and state.route_position >= state.route_samples
             for state in self._playback_states.values()
         )
 

--- a/src/gui/widgets/sound_level_meter.py
+++ b/src/gui/widgets/sound_level_meter.py
@@ -641,9 +641,7 @@ class SoundLevelMeterWidget(QWidget, CompactableWidgetInterface, SplittableWidge
         content_layout = QVBoxLayout()
         content_layout.setContentsMargins(10, 10, 10, 10)
 
-        self.calibration_warning = QLabel(
-            "⚠ " + tr("SPL calibration is not set. Values are shown in dBFS.")
-        )
+        self.calibration_warning = QLabel("⚠ " + tr("SPL calibration is not set. Values are shown in dBFS."))
         self.calibration_warning.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.calibration_warning.setWordWrap(True)
         self.calibration_warning.setStyleSheet(

--- a/src/gui/widgets/spectrum_analyzer.py
+++ b/src/gui/widgets/spectrum_analyzer.py
@@ -907,6 +907,7 @@ class SpectrumAnalyzerWidget(
 
         def dummy_method(*args, **kwargs):
             pass
+
         self.rta_bar_main.setDownsampling = dummy_method
         self.rta_bar_left.setDownsampling = dummy_method
         self.rta_bar_right.setDownsampling = dummy_method
@@ -1391,16 +1392,10 @@ class SpectrumAnalyzerWidget(
                     self.rta_bar_right.setVisible(True)
 
                     self.rta_bar_left.setOpts(
-                        x=x_log - w_log / 4,
-                        height=plot_mags_clipped[:, 0] - y_min,
-                        y0=y_min,
-                        width=w_log / 2 * 0.9
+                        x=x_log - w_log / 4, height=plot_mags_clipped[:, 0] - y_min, y0=y_min, width=w_log / 2 * 0.9
                     )
                     self.rta_bar_right.setOpts(
-                        x=x_log + w_log / 4,
-                        height=plot_mags_clipped[:, 1] - y_min,
-                        y0=y_min,
-                        width=w_log / 2 * 0.9
+                        x=x_log + w_log / 4, height=plot_mags_clipped[:, 1] - y_min, y0=y_min, width=w_log / 2 * 0.9
                     )
                 else:
                     self.rta_bar_main.setVisible(True)
@@ -1408,24 +1403,14 @@ class SpectrumAnalyzerWidget(
                     self.rta_bar_right.setVisible(False)
                     if plot_mags.ndim == 2:
                         plot_mags_clipped = plot_mags_clipped[:, 0]
-                    self.rta_bar_main.setOpts(
-                        x=x_log,
-                        height=plot_mags_clipped - y_min,
-                        y0=y_min,
-                        width=w_log * 0.9
-                    )
+                    self.rta_bar_main.setOpts(x=x_log, height=plot_mags_clipped - y_min, y0=y_min, width=w_log * 0.9)
             else:
                 self.rta_bar_main.setVisible(True)
                 self.rta_bar_left.setVisible(False)
                 self.rta_bar_right.setVisible(False)
                 if plot_mags.ndim == 2:
                     plot_mags_clipped = plot_mags_clipped[:, 0]
-                self.rta_bar_main.setOpts(
-                    x=x_log,
-                    height=plot_mags_clipped - y_min,
-                    y0=y_min,
-                    width=w_log * 0.9
-                )
+                self.rta_bar_main.setOpts(x=x_log, height=plot_mags_clipped - y_min, y0=y_min, width=w_log * 0.9)
             return
 
         # Ensure RTA bars are hidden in non-RTA mode

--- a/tests/benchmarks/gui/benchmark_spectrum_analyzer_split.py
+++ b/tests/benchmarks/gui/benchmark_spectrum_analyzer_split.py
@@ -239,9 +239,7 @@ def main() -> None:
         app.processEvents()
         if identities != _object_identities(widget):
             raise AssertionError("Split recreated a performance-sensitive object")
-        results.extend(
-            _measure_case(app, wrapper.split_display_window, widget, "C", case) for case in CASES
-        )
+        results.extend(_measure_case(app, wrapper.split_display_window, widget, "C", case) for case in CASES)
 
         wrapper.reattach_all()
         app.processEvents()

--- a/tests/core/export/test_json_exporter.py
+++ b/tests/core/export/test_json_exporter.py
@@ -50,9 +50,11 @@ def test_export_traces_success():
     assert parsed_json["traces"][0]["x_data"] == [0.0, 1.0, 2.0]
     assert parsed_json["traces"][0]["y_data"] == [1.0, 2.0, 3.0]
 
+
 def test_format_id():
     exporter = JsonTraceExporter()
     assert exporter.format_id == "json"
+
 
 def test_properties():
     exporter = JsonTraceExporter()

--- a/tests/core/test_core_hammerstein_model.py
+++ b/tests/core/test_core_hammerstein_model.py
@@ -107,11 +107,11 @@ def test_predict_harmonic_response():
     sample_rate = 48000.0
     sorted_freqs = np.array([50.0, 500.0])
     H_freqs = [
-        np.array([1.0+0j, 1.0+0j]),  # H1
-        np.array([2.0+0j, 2.0+0j]),  # H2
-        np.array([0.0+0j, 0.0+0j]),  # H3
-        np.array([0.0+0j, 0.0+0j]),  # H4
-        np.array([0.0+0j, 0.0+0j]),  # H5
+        np.array([1.0 + 0j, 1.0 + 0j]),  # H1
+        np.array([2.0 + 0j, 2.0 + 0j]),  # H2
+        np.array([0.0 + 0j, 0.0 + 0j]),  # H3
+        np.array([0.0 + 0j, 0.0 + 0j]),  # H4
+        np.array([0.0 + 0j, 0.0 + 0j]),  # H5
     ]
 
     predictions = predict_harmonic_response(

--- a/tests/core/test_realtime_sss_core.py
+++ b/tests/core/test_realtime_sss_core.py
@@ -409,6 +409,7 @@ def test_engine_reset_analysis_history():
     assert engine._hist_signal == []
     assert engine._hist_ref == []
 
+
 def test_engine_generate_output_block():
     engine = RealtimeSSSEngine(
         sample_rate=48000,
@@ -447,7 +448,7 @@ def test_engine_generate_output_block():
 
     # 3. Post-sweep blocks containing only silence
     post_sweep_index = engine.sweep_samples // frames + 1
-    outdata_block.fill(1.0) # fill with ones so we can see if it was zeroed
+    outdata_block.fill(1.0)  # fill with ones so we can see if it was zeroed
     engine.generate_output_block(outdata_block, post_sweep_index)
     assert np.all(outdata_block == 0.0)
 
@@ -465,7 +466,7 @@ def test_engine_adaptive_drift_correction():
     fc = 10.0
     fs = 48000.0
     nyq = fs / 2.0
-    b, a = signal.butter(2, fc / nyq, btype='high')
+    b, a = signal.butter(2, fc / nyq, btype="high")
 
     # Generate full SSS signal and apply highpass filter
     out_sig = engine.out_sig
@@ -501,18 +502,14 @@ def test_engine_adaptive_drift_correction():
 
     # 1. Process with has_ref=True (adaptive correction active)
     for idx in range(block_index + 1):
-        f_mid, _, _ = engine.process_input_block(
-            sig_blocks[idx], idx, ref_in_block=ref_blocks[idx]
-        )
+        f_mid, _, _ = engine.process_input_block(sig_blocks[idx], idx, ref_in_block=ref_blocks[idx])
     # Directly execute the LS fit at the end to get the exact latest SNR
     _, results_corr, quality_corr = engine._execute_ls_fit(f_mid, has_ref=True)
 
     # 2. Process with ref_in_block=None (no correction)
     engine.reset_filter_states()
     for idx in range(block_index + 1):
-        f_mid, _, _ = engine.process_input_block(
-            sig_blocks[idx], idx, ref_in_block=None
-        )
+        f_mid, _, _ = engine.process_input_block(sig_blocks[idx], idx, ref_in_block=None)
     # Directly execute the LS fit at the end to get the exact latest SNR
     _, results_nocorr, quality_nocorr = engine._execute_ls_fit(f_mid, has_ref=False)
 
@@ -552,7 +549,7 @@ def test_engine_weak_reference_guard():
         rb = np.zeros((frames, 1))
         if end <= len(out_sig):
             sb[:, 0] = out_sig[start:end]
-            rb[:, 0] = np.random.normal(0, 1e-6, frames) # noisy reference
+            rb[:, 0] = np.random.normal(0, 1e-6, frames)  # noisy reference
 
         f_mid, sig_results, quality = engine.process_input_block(sb, idx, ref_in_block=rb)
 
@@ -567,7 +564,7 @@ def test_engine_weak_reference_guard():
         start = idx * frames
         end = start + frames
         sb = np.zeros((frames, 1))
-        rb = np.zeros((frames, 1)) # silence
+        rb = np.zeros((frames, 1))  # silence
         if end <= len(out_sig):
             sb[:, 0] = out_sig[start:end]
 
@@ -576,5 +573,3 @@ def test_engine_weak_reference_guard():
     fundamental_amp_silent = np.abs(sig_results[0])
     assert fundamental_amp_silent == 0.0
     assert quality == 0.0
-
-

--- a/tests/logic_verification/core/test_calibration.py
+++ b/tests/logic_verification/core/test_calibration.py
@@ -79,9 +79,7 @@ def test_set_sensitivities(calibration_manager):
     ("legacy_sensitivity", "expected_calibrated"),
     [(1.0, False), (2.0, True)],
 )
-def test_legacy_input_calibration_state_migration(
-    temp_config_path, legacy_sensitivity, expected_calibrated
-):
+def test_legacy_input_calibration_state_migration(temp_config_path, legacy_sensitivity, expected_calibrated):
     with open(temp_config_path, "w", encoding="utf-8") as f:
         json.dump({"input_sensitivity": legacy_sensitivity}, f)
 

--- a/tests/logic_verification/core/test_config_manager.py
+++ b/tests/logic_verification/core/test_config_manager.py
@@ -115,7 +115,6 @@ class TestConfigManager(unittest.TestCase):
         cm.set_dithering_bit_depth("24")
         self.assertEqual(cm.get_dithering_bit_depth(), "24")
 
-
     def test_audio_engine_64bit(self):
         cm = self.ConfigManager(config_filename=self.config_path)
 
@@ -250,8 +249,6 @@ class TestConfigManager(unittest.TestCase):
                         "Unable to ensure screenshot directory at /default/shot: No perm"
                     )
 
-
-
     def test_is_dithering_enabled(self):
         cm = self.ConfigManager(config_filename=self.config_path)
 
@@ -262,7 +259,6 @@ class TestConfigManager(unittest.TestCase):
         cm.config.pop("audio", None)
         cm.set_dithering_enabled(False)
         self.assertFalse(cm.is_dithering_enabled())
-
 
     def test_save_config(self):
         cm = self.ConfigManager(config_filename=self.config_path)
@@ -298,6 +294,7 @@ class TestConfigManager(unittest.TestCase):
             mock_timer.assert_called_once_with(1.0, cm._flush_config)
             new_timer_instance.start.assert_called_once()
             self.assertEqual(cm._save_timer, new_timer_instance)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/logic_verification/core/test_predistortion.py
+++ b/tests/logic_verification/core/test_predistortion.py
@@ -70,24 +70,32 @@ def test_update_correction_secant_and_newton():
     block_counts = np.ones(num_blocks, dtype=int)
 
     raw_results = np.zeros((num_blocks, 3), dtype=complex)
-    raw_results[:, 0] = 1.0   # H1
-    raw_results[:, 1] = 0.1   # H2
+    raw_results[:, 0] = 1.0  # H1
+    raw_results[:, 1] = 0.1  # H2
     raw_results[:, 2] = 0.05  # H3
 
     # Iteration 0
-    manager_newton.update_correction(iteration=0, x_data=x_data, raw_results=raw_results, block_counts=block_counts, mu=0.5)
+    manager_newton.update_correction(
+        iteration=0, x_data=x_data, raw_results=raw_results, block_counts=block_counts, mu=0.5
+    )
     assert manager_newton.H0_1 is not None
 
     # Iteration 1
-    manager_newton.update_correction(iteration=1, x_data=x_data, raw_results=raw_results, block_counts=block_counts, mu=0.5)
+    manager_newton.update_correction(
+        iteration=1, x_data=x_data, raw_results=raw_results, block_counts=block_counts, mu=0.5
+    )
     assert np.all(manager_newton.F_corr[2][meas_freqs > 80.0] < 0.0)
 
     # Test Secant algorithm
     manager_secant = PredistortionManager(
         start_freq=20.0, end_freq=20000.0, meas_freqs=meas_freqs, max_harmonic=3, algorithm="secant"
     )
-    manager_secant.update_correction(iteration=0, x_data=x_data, raw_results=raw_results, block_counts=block_counts, mu=1.0)
-    manager_secant.update_correction(iteration=1, x_data=x_data, raw_results=raw_results, block_counts=block_counts, mu=1.0)
+    manager_secant.update_correction(
+        iteration=0, x_data=x_data, raw_results=raw_results, block_counts=block_counts, mu=1.0
+    )
+    manager_secant.update_correction(
+        iteration=1, x_data=x_data, raw_results=raw_results, block_counts=block_counts, mu=1.0
+    )
     assert len(manager_secant.F_history[2]) == 2
     assert len(manager_secant.H_history[2]) == 2
 

--- a/tests/logic_verification/core/test_session_manager.py
+++ b/tests/logic_verification/core/test_session_manager.py
@@ -1,9 +1,11 @@
 import pytest
 from src.core.session_manager import SessionManager
 
+
 @pytest.fixture
 def session_manager():
     return SessionManager()
+
 
 def test_session_manager_lifecycle(session_manager):
     # Default state

--- a/tests/logic_verification/gui/test_basic_split.py
+++ b/tests/logic_verification/gui/test_basic_split.py
@@ -37,13 +37,15 @@ def qapp():
     yield app
 
 
-@pytest.fixture(params=[
-    (BNIMMeter, BNIMMeterWidget, MODULE_BNIM_METER, "BNIM Meter"),
-    (Goniometer, GoniometerWidget, MODULE_GONIOMETER, "Goniometer"),
-    (LufsMeter, LufsMeterWidget, MODULE_LUFS_METER, "LUFS Meter"),
-    (NoiseProfiler, NoiseProfilerWidget, MODULE_NOISE_PROFILER, "Noise Profiler"),
-    (RawTimeSeries, RawTimeSeriesWidget, MODULE_RAW_TIME_SERIES, "Raw Time Series"),
-])
+@pytest.fixture(
+    params=[
+        (BNIMMeter, BNIMMeterWidget, MODULE_BNIM_METER, "BNIM Meter"),
+        (Goniometer, GoniometerWidget, MODULE_GONIOMETER, "Goniometer"),
+        (LufsMeter, LufsMeterWidget, MODULE_LUFS_METER, "LUFS Meter"),
+        (NoiseProfiler, NoiseProfilerWidget, MODULE_NOISE_PROFILER, "Noise Profiler"),
+        (RawTimeSeries, RawTimeSeriesWidget, MODULE_RAW_TIME_SERIES, "Raw Time Series"),
+    ]
+)
 def module_setup(request, qapp):
     ModuleClass, WidgetClass, module_constant, title = request.param
 
@@ -71,7 +73,11 @@ def test_splittable_interface_implementation(module_setup):
     assert display_widget is widget.display_widget
 
     # Some widgets use 'sidebar', some use 'controls_group'
-    actual_control = getattr(widget, 'sidebar', None) or getattr(widget, 'controls_group', None) or getattr(widget, 'right_widget', None)
+    actual_control = (
+        getattr(widget, "sidebar", None)
+        or getattr(widget, "controls_group", None)
+        or getattr(widget, "right_widget", None)
+    )
     assert control_widget is actual_control
 
 
@@ -103,5 +109,9 @@ def test_detachable_wrapper_split_flow(module_setup):
     wrapper.reattach_all()
     assert not wrapper.is_split
     assert widget.display_widget.parent() is widget
-    actual_control = getattr(widget, 'sidebar', None) or getattr(widget, 'controls_group', None) or getattr(widget, 'right_widget', None)
+    actual_control = (
+        getattr(widget, "sidebar", None)
+        or getattr(widget, "controls_group", None)
+        or getattr(widget, "right_widget", None)
+    )
     assert actual_control.parent() is widget

--- a/tests/logic_verification/gui/test_loopback_finder.py
+++ b/tests/logic_verification/gui/test_loopback_finder.py
@@ -146,9 +146,7 @@ def test_steady_tone_present_in_baseline_is_not_accepted_as_a_route():
     sample_rate = 48_000
     baseline_frames = int(sample_rate * profile.baseline_duration_s)
     tone_frames = int(sample_rate * profile.tone_duration_s)
-    step_frames = int(
-        sample_rate * (profile.baseline_duration_s + profile.tone_duration_s + profile.tail_duration_s)
-    )
+    step_frames = int(sample_rate * (profile.baseline_duration_s + profile.tone_duration_s + profile.tail_duration_s))
     phase = np.arange(step_frames)
     ambient = 0.1 * np.sin(2 * np.pi * profile.frequency_hz * phase / sample_rate)
     buffer = ambient.astype(np.float32)[:, np.newaxis]
@@ -208,14 +206,10 @@ def test_clipping_invalidates_the_affected_input_column(monkeypatch):
     assert result.state == loopback_module.ScanTerminalState.INVALID
     assert result.clipped_inputs == (1,)
     assert all(
-        item.verdict == loopback_module.PairVerdict.INVALID
-        for item in result.measurements
-        if item.input_channel == 1
+        item.verdict == loopback_module.PairVerdict.INVALID for item in result.measurements if item.input_channel == 1
     )
     assert any(
-        item.verdict == loopback_module.PairVerdict.DETECTED
-        for item in result.measurements
-        if item.input_channel == 2
+        item.verdict == loopback_module.PairVerdict.DETECTED for item in result.measurements if item.input_channel == 2
     )
 
 

--- a/tests/logic_verification/gui/test_measurement_console.py
+++ b/tests/logic_verification/gui/test_measurement_console.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import base64
 
-from PyQt6.QtCore import QSize, Qt
+from PyQt6.QtCore import QSize, Qt, QTimer
 from PyQt6.QtWidgets import (
     QApplication,
     QDockWidget,
@@ -427,6 +427,28 @@ def test_console_close_preserves_last_usable_geometry_during_transient_shrink(qt
     second.show()
     qtbot.waitUntil(second._has_usable_window_size)
     second.close()
+
+
+def test_console_ignores_delayed_auto_fit_from_hosted_compact_widget(qtbot):
+    host = _ConsoleHostStub([_DummyWrapper() for _ in range(4)])
+    console = MeasurementConsoleWindow(host)
+    for index in range(4):
+        console.add_module(index, arrange=False)
+    console.arrange_two_by_two()
+    console.resize(1200, 800)
+    console.show()
+    qtbot.waitUntil(lambda: console.isVisible())
+    qtbot.wait(100)
+    expected_size = QSize(console.size())
+
+    # Some compact widgets defer ``self.window().adjustSize()``. During
+    # workspace restoration self.window() is the console, so that legacy
+    # callback must not collapse the user-managed dock workspace.
+    QTimer.singleShot(0, console.adjustSize)
+    qtbot.wait(10)
+
+    assert console.size() == expected_size
+    console.close()
 
 
 def test_console_recovers_hidden_docks_and_tiny_saved_geometry(qtbot):

--- a/tests/logic_verification/gui/test_network_analyzer.py
+++ b/tests/logic_verification/gui/test_network_analyzer.py
@@ -390,6 +390,7 @@ def test_subsample_delay_compensation():
     # We need a dummy worker that is running
     class DummyWorker:
         is_running = True
+
     worker = DummyWorker()
 
     # Collect signals
@@ -451,6 +452,7 @@ def test_auto_delay_updates_ui_and_latency_sec(qtbot):
 
     class DummyWorker:
         is_running = True
+
     worker = DummyWorker()
 
     # Run data processing (which triggers signals)
@@ -508,6 +510,7 @@ def test_latency_model_modes_and_phase_invariance(qtbot):
 
     class DummyWorker:
         is_running = True
+
     worker = DummyWorker()
 
     # --- 1. Run Sweep in Auto mode ---
@@ -555,6 +558,3 @@ def test_latency_model_modes_and_phase_invariance(qtbot):
 
     # Check that they match well (allowing minor windowing/interpolation deviation at edges)
     assert np.allclose(phase_diff_rad[mask_16k], expected_diff_rad[mask_16k], atol=0.2)
-
-
-

--- a/tests/logic_verification/gui/test_oscilloscope_math.py
+++ b/tests/logic_verification/gui/test_oscilloscope_math.py
@@ -118,6 +118,7 @@ class TestOscilloscopeMath(unittest.TestCase):
 
     def test_math_i18n_mode_mapping(self):
         from src.core.localization import tr
+
         translated_derivative = tr("Derivative")
         self.widget.on_math_changed(translated_derivative)
         self.assertEqual(self.module.math_mode, "Derivative")

--- a/tests/logic_verification/gui/test_pyinstaller_imports.py
+++ b/tests/logic_verification/gui/test_pyinstaller_imports.py
@@ -69,10 +69,7 @@ def test_pyinstaller_imports_cover_every_registered_module():
     file_path = Path("src/gui/pyinstaller_imports.py")
     tree = ast.parse(file_path.read_text(encoding="utf-8"), filename=str(file_path))
     imported_class_names = {
-        alias.name
-        for node in ast.walk(tree)
-        if isinstance(node, ast.ImportFrom)
-        for alias in node.names
+        alias.name for node in ast.walk(tree) if isinstance(node, ast.ImportFrom) for alias in node.names
     }
     registered_class_names = {registration.class_name for registration in MODULE_REGISTRY.values()}
 

--- a/tests/logic_verification/instruments/test_spectrum_analyzer_refactor.py
+++ b/tests/logic_verification/instruments/test_spectrum_analyzer_refactor.py
@@ -59,7 +59,7 @@ class TestSpectrumAnalyzerRefactor:
 
         # The band at 25 Hz (bounds ~22.4 - 28.3 Hz) has no FFT bins since 20 Hz and 40 Hz are outside.
         # With our fix, it should be mapped to the closest bin (20 Hz) and not be discarded.
-        expected_center = 20 * (2 ** (1/3))  # 25.198
+        expected_center = 20 * (2 ** (1 / 3))  # 25.198
         has_25hz_band = any(np.isclose(f, expected_center, rtol=1e-3) for f in smoothed_freqs)
         assert has_25hz_band, f"Expected center frequency {expected_center} to be retained."
 

--- a/tests/logic_verification/measurement_modules/test_nonlinear_analyzer.py
+++ b/tests/logic_verification/measurement_modules/test_nonlinear_analyzer.py
@@ -591,6 +591,7 @@ def test_nonlinear_analyzer_module_measurement(qtbot):
 
     # Mock run_play_rec to immediately return dummy data in offline mode to avoid PlayRecSession timeouts in tests
     import numpy as np
+
     analyzer.run_play_rec = lambda out_data, **kwargs: np.zeros((len(out_data), 2), dtype=np.float32)
 
     worker = DummyWorker()


### PR DESCRIPTION
## Summary

- prevent delayed compact-widget auto-fit callbacks from resizing the measurement console workspace
- preserve the existing console size while instruments are docked
- add a regression test for delayed adjustSize calls
- format all Python sources with Ruff (33 previously unformatted files)

## Root cause

During workspace restoration, compact mode is reapplied after widgets are hosted in the console. Some instruments defer a window auto-fit callback, so their window resolves to the measurement console and collapses the whole dock workspace shortly after it first appears.

## Verification

- ./.venv/bin/ruff check .
- ./.venv/bin/ruff format --check .
- formatting-only AST comparison: no semantic differences across 33 files
- ./.venv/bin/mypy src main_gui.py
- ./.venv/bin/python scripts/check_trn_keys.py
- npx markdownlint-cli2 **/*.md #node_modules
- ./.venv/bin/pytest: 1275 passed, 6 skipped
- ./.venv/bin/python scripts/check_ui_size_limits.py