### PR TITLE
Fix goniometer display skips at high sample rates

### DIFF
--- a/src/assets/lang/de.json
+++ b/src/assets/lang/de.json
@@ -2261,6 +2261,7 @@
     "Resume Display": "Anzeige fortsetzen",
     "Running": "Läuft",
     "Show Axes": "Achsen anzeigen",
+    "Show Center Crosshair": "Mittleres Fadenkreuz anzeigen",
     "Show Direction Guides": "Richtungshinweise anzeigen",
     "Show Grid": "Raster anzeigen",
     "Stopped — last value": "Gestoppt — letzter Wert",

--- a/src/assets/lang/en.json
+++ b/src/assets/lang/en.json
@@ -2261,6 +2261,7 @@
     "Resume Display": "Resume Display",
     "Running": "Running",
     "Show Axes": "Show Axes",
+    "Show Center Crosshair": "Show Center Crosshair",
     "Show Direction Guides": "Show Direction Guides",
     "Show Grid": "Show Grid",
     "Stopped — last value": "Stopped — last value",

--- a/src/assets/lang/es.json
+++ b/src/assets/lang/es.json
@@ -2261,6 +2261,7 @@
     "Resume Display": "Reanudar visualización",
     "Running": "En ejecución",
     "Show Axes": "Mostrar ejes",
+    "Show Center Crosshair": "Mostrar retícula central",
     "Show Direction Guides": "Mostrar guías de dirección",
     "Show Grid": "Mostrar cuadrícula",
     "Stopped — last value": "Detenido — último valor",

--- a/src/assets/lang/fr.json
+++ b/src/assets/lang/fr.json
@@ -2261,6 +2261,7 @@
     "Resume Display": "Reprendre l’affichage",
     "Running": "En cours",
     "Show Axes": "Afficher les axes",
+    "Show Center Crosshair": "Afficher le réticule central",
     "Show Direction Guides": "Afficher les repères de direction",
     "Show Grid": "Afficher la grille",
     "Stopped — last value": "Arrêté — dernière valeur",

--- a/src/assets/lang/ja.json
+++ b/src/assets/lang/ja.json
@@ -2261,6 +2261,7 @@
     "Resume Display": "表示を再開",
     "Running": "取得中",
     "Show Axes": "軸を表示",
+    "Show Center Crosshair": "中央の十字線を表示",
     "Show Direction Guides": "方向案内を表示",
     "Show Grid": "グリッドを表示",
     "Stopped — last value": "停止中 — 最終値",

--- a/src/assets/lang/ko.json
+++ b/src/assets/lang/ko.json
@@ -2261,6 +2261,7 @@
     "Resume Display": "표시 재개",
     "Running": "실행 중",
     "Show Axes": "축 표시",
+    "Show Center Crosshair": "중앙 십자선 표시",
     "Show Direction Guides": "방향 안내 표시",
     "Show Grid": "그리드 표시",
     "Stopped — last value": "정지됨 — 마지막 값",

--- a/src/assets/lang/pt.json
+++ b/src/assets/lang/pt.json
@@ -2261,6 +2261,7 @@
     "Resume Display": "Retomar exibição",
     "Running": "Em execução",
     "Show Axes": "Mostrar eixos",
+    "Show Center Crosshair": "Mostrar retículo central",
     "Show Direction Guides": "Mostrar guias de direção",
     "Show Grid": "Mostrar grade",
     "Stopped — last value": "Parado — último valor",

--- a/src/assets/lang/ru.json
+++ b/src/assets/lang/ru.json
@@ -2261,6 +2261,7 @@
     "Resume Display": "Возобновить отображение",
     "Running": "Выполняется",
     "Show Axes": "Показать оси",
+    "Show Center Crosshair": "Показать центральное перекрестие",
     "Show Direction Guides": "Показать указатели направлений",
     "Show Grid": "Показать сетку",
     "Stopped — last value": "Остановлено — последнее значение",

--- a/src/assets/lang/zh.json
+++ b/src/assets/lang/zh.json
@@ -2261,6 +2261,7 @@
     "Resume Display": "恢复显示",
     "Running": "运行中",
     "Show Axes": "显示坐标轴",
+    "Show Center Crosshair": "显示中央十字线",
     "Show Direction Guides": "显示方向指引",
     "Show Grid": "显示网格",
     "Stopped — last value": "已停止 — 最后值",

--- a/src/gui/widgets/goniometer.py
+++ b/src/gui/widgets/goniometer.py
@@ -87,12 +87,15 @@ class Goniometer(MeasurementModule):
 
     silence_threshold_dbfs = -80.0
     clip_threshold = 1.0
+    reference_sample_rate = 48000.0
+    reference_buffer_size = 4096
 
     def __init__(self, audio_engine: AudioEngine):
         self.audio_engine = audio_engine
 
         # User settings
-        self.buffer_size = 4096
+        sample_rate = self._sample_rate()
+        self.buffer_size = self._buffer_size_for_sample_rate(sample_rate)
         self.manual_gain = 1.0
         self.auto_gain = False
         self.effective_gain = 1.0
@@ -104,7 +107,8 @@ class Goniometer(MeasurementModule):
         self.mapping_mode = "ms"
         self.invert_x = False
         self.invert_y = False
-        self.show_direction_guides = True
+        self.show_center_crosshair = True
+        self.show_direction_guides = False
         self.show_axes = False
         self.show_grid = True
 
@@ -116,6 +120,7 @@ class Goniometer(MeasurementModule):
 
         # Single-producer ring buffer. The callback writes; the GUI only copies.
         self._ring = np.zeros((self.buffer_size, 2), dtype=np.float64)
+        self._ring_sample_rate = sample_rate
         self._write_index = 0
         self._ring_count = 0
         self._total_samples = 0
@@ -203,12 +208,27 @@ class Goniometer(MeasurementModule):
         try:
             rate = float(self.audio_engine.sample_rate)
         except (AttributeError, TypeError, ValueError):
-            return 48000.0
-        return rate if rate > 0.0 else 48000.0
+            return self.reference_sample_rate
+        return rate if math.isfinite(rate) and rate > 0.0 else self.reference_sample_rate
 
-    def _reset_realtime_state(self) -> None:
+    @classmethod
+    def _buffer_size_for_sample_rate(cls, sample_rate: float, minimum_size: int = 0) -> int:
+        """Keep the ring's history duration constant across sample rates."""
+        scaled_size = math.ceil(cls.reference_buffer_size * sample_rate / cls.reference_sample_rate)
+        return max(cls.reference_buffer_size, scaled_size, int(minimum_size))
+
+    def _reset_realtime_state(self, sample_rate: float | None = None, minimum_buffer_size: int = 0) -> None:
         self._generation += 1
-        self._ring.fill(0.0)
+        if sample_rate is not None:
+            target_size = self._buffer_size_for_sample_rate(sample_rate, minimum_buffer_size)
+            if target_size != self.buffer_size:
+                self.buffer_size = target_size
+                self._ring = np.zeros((self.buffer_size, 2), dtype=np.float64)
+            else:
+                self._ring.fill(0.0)
+            self._ring_sample_rate = sample_rate
+        else:
+            self._ring.fill(0.0)
         self._write_index = 0
         self._ring_count = 0
         self._total_samples = 0
@@ -230,7 +250,7 @@ class Goniometer(MeasurementModule):
         if self.is_running:
             self._reset_requested = True
         else:
-            self._reset_realtime_state()
+            self._reset_realtime_state(self._sample_rate())
 
     def start_analysis(self) -> bool:
         if self.is_running:
@@ -238,7 +258,7 @@ class Goniometer(MeasurementModule):
 
         self.run_state = GoniometerRunState.STARTING
         self.error_message = None
-        self._reset_realtime_state()
+        self._reset_realtime_state(self._sample_rate())
         self.heatmap.fill(0.0)
 
         try:
@@ -305,15 +325,22 @@ class Goniometer(MeasurementModule):
         del time_info
         outdata.fill(0)
 
-        if self._reset_requested:
-            self._reset_realtime_state()
+        sample_rate = self._sample_rate()
+        sample_rate_changed = sample_rate != self._ring_sample_rate
 
         if indata.ndim != 2 or indata.shape[0] == 0 or indata.shape[1] == 0:
+            if self._reset_requested or sample_rate_changed:
+                self._reset_realtime_state(sample_rate)
             return
 
         sample_count = min(int(frames), int(indata.shape[0]))
         if sample_count <= 0:
+            if self._reset_requested or sample_rate_changed:
+                self._reset_realtime_state(sample_rate)
             return
+
+        if self._reset_requested or sample_rate_changed or sample_count > self.buffer_size:
+            self._reset_realtime_state(sample_rate, sample_count)
 
         left = indata[:sample_count, 0]
         mono_input = indata.shape[1] < 2
@@ -357,14 +384,14 @@ class Goniometer(MeasurementModule):
             self.quality_flags |= GoniometerQualityFlag.IO_ERROR
 
         if clipped_left or clipped_right or io_invalid:
-            invalid_samples = max(1, int(self.correlation_response_seconds * self._sample_rate()))
+            invalid_samples = max(1, int(self.correlation_response_seconds * sample_rate))
             self._invalid_until_sample = max(
                 self._invalid_until_sample,
                 self._total_samples + invalid_samples,
             )
 
         tau = max(self.correlation_response_seconds, 0.001)
-        alpha = math.exp(-sample_count / (self._sample_rate() * tau))
+        alpha = math.exp(-sample_count / (sample_rate * tau))
         one_minus_alpha = 1.0 - alpha
         self._energy_left = alpha * self._energy_left + one_minus_alpha * energy_left
         self._energy_right = alpha * self._energy_right + one_minus_alpha * energy_right
@@ -791,6 +818,11 @@ class GoniometerWidget(QWidget, CompactableWidgetInterface, SplittableWidgetInte
         self.invert_y_chk.toggled.connect(self.on_invert_y_changed)
         layout.addWidget(self.invert_y_chk)
 
+        self.center_crosshair_chk = QCheckBox(tr("Show Center Crosshair"))
+        self.center_crosshair_chk.setChecked(self.module.show_center_crosshair)
+        self.center_crosshair_chk.toggled.connect(self.on_center_crosshair_changed)
+        layout.addWidget(self.center_crosshair_chk)
+
         self.direction_guides_chk = QCheckBox(tr("Show Direction Guides"))
         self.direction_guides_chk.setChecked(self.module.show_direction_guides)
         self.direction_guides_chk.toggled.connect(self.on_direction_guides_changed)
@@ -853,6 +885,10 @@ class GoniometerWidget(QWidget, CompactableWidgetInterface, SplittableWidgetInte
         self.module.show_direction_guides = bool(checked)
         self._update_reference_lines()
 
+    def on_center_crosshair_changed(self, checked: bool) -> None:
+        self.module.show_center_crosshair = bool(checked)
+        self._update_reference_lines()
+
     def on_axes_changed(self, checked: bool) -> None:
         self.module.show_axes = bool(checked)
         self._update_axis_display()
@@ -883,6 +919,8 @@ class GoniometerWidget(QWidget, CompactableWidgetInterface, SplittableWidgetInte
 
     def _update_reference_lines(self) -> None:
         self._clear_direction_labels()
+        self.ref_line_a.setVisible(self.module.show_center_crosshair)
+        self.ref_line_b.setVisible(self.module.show_center_crosshair)
         if self.module.mapping_mode == "lr":
             sx = -1 if self.module.invert_x else 1
             sy = -1 if self.module.invert_y else 1

--- a/tests/logic_verification/analysis/test_goniometer_logic.py
+++ b/tests/logic_verification/analysis/test_goniometer_logic.py
@@ -141,6 +141,29 @@ def test_ring_buffer_wraps_chronologically_and_reports_display_drop():
     np.testing.assert_allclose(snapshot.audio[:, 1], -sample_numbers[-module.buffer_size :])
 
 
+def test_ring_buffer_history_duration_scales_for_192khz():
+    module = Goniometer(MockAudioEngine(sample_rate=192000))
+
+    assert module.buffer_size == 16384
+    assert module.buffer_size / 192000 == pytest.approx(4096 / 48000)
+
+
+def test_192khz_display_intervals_do_not_report_dropped_samples():
+    sample_rate = 192000
+    module = Goniometer(MockAudioEngine(sample_rate=sample_rate))
+    frames_per_display = math.ceil(sample_rate * 0.033)
+    silence = np.zeros((frames_per_display, 2), dtype=np.float64)
+    consumed = 0
+
+    for _ in range(4):
+        _invoke(module, silence)
+        snapshot = module.get_snapshot(since_total_samples=consumed)
+
+        assert snapshot is not None
+        assert snapshot.display_dropped_samples == 0
+        consumed = snapshot.total_samples
+
+
 def _correlation_after_transition(block_size: int) -> float:
     sample_rate = 48000
     module = Goniometer(MockAudioEngine(sample_rate))

--- a/tests/logic_verification/gui/test_goniometer_widget.py
+++ b/tests/logic_verification/gui/test_goniometer_widget.py
@@ -50,7 +50,8 @@ def test_widget_restores_model_settings(qtbot):
     module.auto_gain = True
     module.trace_mode = "Density"
     module.persistence_seconds = 1.25
-    module.show_direction_guides = False
+    module.show_center_crosshair = False
+    module.show_direction_guides = True
     module.show_axes = True
     module.show_grid = False
 
@@ -63,7 +64,10 @@ def test_widget_restores_model_settings(qtbot):
     assert not widget.gain_slider.isEnabled()
     assert widget.trace_combo.currentData() == "Density"
     assert widget.persistence_label.text() == "1.25 s"
-    assert not widget.direction_guides_chk.isChecked()
+    assert not widget.center_crosshair_chk.isChecked()
+    assert widget.direction_guides_chk.isChecked()
+    assert not widget.ref_line_a.isVisible()
+    assert not widget.ref_line_b.isVisible()
     assert widget.axes_chk.isChecked()
     assert not widget.grid_chk.isChecked()
 
@@ -73,8 +77,11 @@ def test_plot_guides_axes_and_grid_defaults_and_toggles(widget):
     bottom_axis = plot_item.getAxis("bottom")
     left_axis = plot_item.getAxis("left")
 
-    assert widget.direction_guides_chk.isChecked()
-    assert len(widget._direction_labels) == 4
+    assert widget.center_crosshair_chk.isChecked()
+    assert widget.ref_line_a.isVisible()
+    assert widget.ref_line_b.isVisible()
+    assert not widget.direction_guides_chk.isChecked()
+    assert widget._direction_labels == []
     assert not widget.axes_chk.isChecked()
     assert not bottom_axis.style["showValues"]
     assert not left_axis.style["showValues"]
@@ -84,11 +91,14 @@ def test_plot_guides_axes_and_grid_defaults_and_toggles(widget):
     assert bottom_axis.grid
     assert left_axis.grid
 
-    widget.direction_guides_chk.setChecked(False)
+    widget.center_crosshair_chk.setChecked(False)
+    widget.direction_guides_chk.setChecked(True)
     widget.axes_chk.setChecked(True)
     widget.grid_chk.setChecked(False)
 
-    assert widget._direction_labels == []
+    assert not widget.ref_line_a.isVisible()
+    assert not widget.ref_line_b.isVisible()
+    assert len(widget._direction_labels) == 4
     assert bottom_axis.style["showValues"]
     assert left_axis.style["showValues"]
     assert bottom_axis.labelText == ""


### PR DESCRIPTION
## Summary

- scale the goniometer display ring buffer with the active sample rate so it keeps a constant history duration
- reconfigure the buffer safely when the sample rate changes or an audio callback exceeds the current capacity
- separate the center crosshair toggle from optional direction guides and add translations
- add regression coverage for 192 kHz display intervals and guide visibility

## Verification

- `./.venv/bin/ruff check .`
- `./.venv/bin/ruff format --check .`
- `./.venv/bin/mypy src main_gui.py`
- `./.venv/bin/python scripts/check_trn_keys.py`
- `npx markdownlint-cli2 "**/*.md" "#node_modules"`
- `./.venv/bin/python scripts/check_ui_size_limits.py`
- `./.venv/bin/pytest` (1321 passed, 6 hardware-only skipped)
