### PR TITLE
Fix logarithmic plot axes to use 1-2-5 ticks

### DIFF
--- a/src/gui/widgets/advanced_distortion_meter.py
+++ b/src/gui/widgets/advanced_distortion_meter.py
@@ -1,6 +1,5 @@
 import logging
 import numpy as np
-import pyqtgraph as pg
 from PyQt6.QtCore import Qt, QTimer, QRunnable, QThreadPool, QObject, pyqtSignal
 from PyQt6.QtWidgets import (
     QApplication,
@@ -23,6 +22,7 @@ from src.core.localization import tr
 from src.measurement_modules.base import MeasurementModule
 from src.core.fft_manager import fft_manager
 from src.core.utils import amplitude_to_linear, linear_to_amplitude
+from src.gui.widgets.instrument_plot import InstrumentPlotWidget
 
 
 logger = logging.getLogger(__name__)
@@ -507,7 +507,7 @@ class AdvancedDistortionMeterWidget(QWidget):
         # --- Right Panel: Plots ---
         right_panel = QVBoxLayout()
 
-        self.plot_widget = pg.PlotWidget()
+        self.plot_widget = InstrumentPlotWidget()
         self.plot_widget.setLabel("left", tr("Amplitude"), units="dB")
         self.plot_widget.setLabel("bottom", tr("Frequency"), units="Hz")
         self.plot_widget.setLogMode(x=True, y=False)

--- a/src/gui/widgets/distortion_analyzer.py
+++ b/src/gui/widgets/distortion_analyzer.py
@@ -32,6 +32,7 @@ from src.measurement_modules.base import MeasurementModule
 from src.core.fft_manager import fft_manager
 from src.core.utils import amplitude_to_linear, linear_to_amplitude
 from src.gui.widgets.comparable_interface import ComparableWidgetInterface
+from src.gui.widgets.instrument_plot import logarithmic_ticks_125
 from src.core.comparison_manager import ComparisonTrace, AxisMetadata, CalibrationInfo
 
 
@@ -1091,9 +1092,7 @@ class DistortionAnalyzerWidget(QWidget, ComparableWidgetInterface):
             self.sweep_plot.setYRange(np.log10(0.0001), np.log10(100))
 
             # Setup log ticks for Percent
-            percent_ticks = [100, 10, 1, 0.1, 0.01, 0.001, 0.0001]
-            ticks_log = [(np.log10(t), f"{t:g}%") for t in percent_ticks]
-            y_axis.setTicks([ticks_log])
+            y_axis.setTicks([logarithmic_ticks_125(0.0001, 100, suffix="%")])
         else:
             self.sweep_plot.setLabel("left", tr("THD+N"), units="dB")
             x_log = self._is_sweep_x_log()

--- a/src/gui/widgets/feedforward_compensator.py
+++ b/src/gui/widgets/feedforward_compensator.py
@@ -29,6 +29,7 @@ from src.measurement_modules.base import MeasurementModule
 from src.core.analysis import AudioCalc
 from src.gui.styles import MONOSPACE_FONT_FAMILY
 from src.core.transmission_logic import apply_octave_smoothing
+from src.gui.widgets.instrument_plot import InstrumentPlotWidget
 
 logger = logging.getLogger(__name__)
 
@@ -1096,7 +1097,7 @@ class FeedforwardCompensatorWidget(QWidget):
         sim_layout.addWidget(self.lbl_sim_results)
 
         # Plot Widget
-        self.plot_sim = pg.PlotWidget(title=tr("Spectrum Comparison"))
+        self.plot_sim = InstrumentPlotWidget(title=tr("Spectrum Comparison"))
         self.plot_sim.setLabel("bottom", "Frequency", units="Hz")
         self.plot_sim.setLabel("left", "Magnitude", units="dBr")
         self.plot_sim.showGrid(x=True, y=True, alpha=0.3)
@@ -1194,7 +1195,7 @@ class FeedforwardCompensatorWidget(QWidget):
         lin_layout.setSpacing(5)
 
         # Magnitude Plot
-        self.plot_lin_mag = pg.PlotWidget(title=tr("Magnitude Response"))
+        self.plot_lin_mag = InstrumentPlotWidget(title=tr("Magnitude Response"))
         self.plot_lin_mag.setLabel("bottom", tr("Frequency"), units="Hz")
         self.plot_lin_mag.setLabel("left", tr("Magnitude"), units="dB")
         self.plot_lin_mag.showGrid(x=True, y=True, alpha=0.3)
@@ -1207,7 +1208,7 @@ class FeedforwardCompensatorWidget(QWidget):
         lin_layout.addWidget(self.plot_lin_mag, stretch=1)
 
         # Phase Plot
-        self.plot_lin_phase = pg.PlotWidget(title=tr("Phase Response"))
+        self.plot_lin_phase = InstrumentPlotWidget(title=tr("Phase Response"))
         self.plot_lin_phase.setLabel("bottom", tr("Frequency"), units="Hz")
         self.plot_lin_phase.setLabel("left", tr("Phase"), units="deg")
         self.plot_lin_phase.showGrid(x=True, y=True, alpha=0.3)

--- a/src/gui/widgets/frequency_counter.py
+++ b/src/gui/widgets/frequency_counter.py
@@ -29,6 +29,7 @@ from src.core.localization import tr
 from src.measurement_modules.base import MeasurementModule
 from src.gui.styles import MONOSPACE_FONT_FAMILY
 from src.gui.widgets.compactable_interface import CompactableWidgetInterface
+from src.gui.widgets.instrument_plot import InstrumentPlotWidget
 
 
 logger = logging.getLogger(__name__)
@@ -604,7 +605,7 @@ class FrequencyCounterWidget(QWidget, CompactableWidgetInterface):
         self.tab_widget.addTab(self.plot_widget, tr("Frequency Drift"))
 
         # Tab 2: Allan Deviation
-        self.allan_plot = pg.PlotWidget(title=tr("Allan Deviation"))
+        self.allan_plot = InstrumentPlotWidget(title=tr("Allan Deviation"))
         self.allan_plot.setLabel("left", tr("Sigma_y(tau)"))
         self.allan_plot.setLabel("bottom", tr("Tau"), units="s")
         self.allan_plot.showGrid(x=True, y=True)

--- a/src/gui/widgets/impedance_analyzer.py
+++ b/src/gui/widgets/impedance_analyzer.py
@@ -37,6 +37,7 @@ from src.core.audio_engine import AudioEngine
 from src.core.localization import tr
 from src.core.utils import format_si, resource_path
 from src.measurement_modules.base import MeasurementModule
+from src.gui.widgets.instrument_plot import InstrumentPlotWidget
 
 logger = logging.getLogger(__name__)
 
@@ -1244,7 +1245,7 @@ class ImpedanceAnalyzerWidget(QWidget):
         right_layout = QVBoxLayout(right_panel)
 
         # 1. Plot
-        self.plot_widget = pg.PlotWidget(title=tr("Impedance Z(f)"))
+        self.plot_widget = InstrumentPlotWidget(title=tr("Impedance Z(f)"))
         self.plot_widget.setLabel("bottom", tr("Frequency"), units="Hz")
         self.plot_widget.setLabel("left", tr("|Z|"), units="Ohm")
         self.plot_widget.showGrid(x=True, y=True, alpha=0.3)

--- a/src/gui/widgets/instrument_plot.py
+++ b/src/gui/widgets/instrument_plot.py
@@ -1,0 +1,62 @@
+import math
+
+import pyqtgraph as pg
+
+
+def logarithmic_ticks_125(minimum: float, maximum: float, suffix: str = "") -> list[tuple[float, str]]:
+    """Return labelled log-domain tick positions for a positive linear range."""
+    lower, upper = sorted((float(minimum), float(maximum)))
+    if not math.isfinite(lower) or not math.isfinite(upper) or lower <= 0:
+        return []
+
+    return [
+        (math.log10(value), f"{value:g}{suffix}")
+        for decade in range(math.floor(math.log10(lower)), math.ceil(math.log10(upper)) + 1)
+        for mantissa in InstrumentAxisItem._MAJOR_MANTISSAS
+        if lower <= (value := mantissa * 10.0**decade) <= upper
+    ]
+
+
+class InstrumentAxisItem(pg.AxisItem):
+    """Axis whose logarithmic major ticks follow the instrument 1-2-5 series."""
+
+    _MAJOR_MANTISSAS = (1.0, 2.0, 5.0)
+    _MINOR_MANTISSAS = (3.0, 4.0, 6.0, 7.0, 8.0, 9.0)
+
+    def logTickValues(self, minVal, maxVal, size, stdTicks):
+        del size, stdTicks
+        lower, upper = sorted((float(minVal), float(maxVal)))
+        if not math.isfinite(lower) or not math.isfinite(upper):
+            return []
+
+        first_decade = math.floor(lower)
+        last_decade = math.ceil(upper)
+        major = self._log_ticks(lower, upper, first_decade, last_decade, self._MAJOR_MANTISSAS)
+        minor = self._log_ticks(lower, upper, first_decade, last_decade, self._MINOR_MANTISSAS)
+        return [(None, major), (None, minor)]
+
+    @staticmethod
+    def _log_ticks(lower, upper, first_decade, last_decade, mantissas):
+        return [
+            position
+            for decade in range(first_decade, last_decade + 1)
+            for mantissa in mantissas
+            if lower <= (position := decade + math.log10(mantissa)) <= upper
+        ]
+
+
+class InstrumentPlotWidget(pg.PlotWidget):
+    """Plot widget with guideline-compliant linear and logarithmic axes."""
+
+    def __init__(self, parent=None, background="default", plotItem=None, **kwargs):
+        plot_item = plotItem
+        if plot_item is None:
+            plot_item = pg.PlotItem(
+                axisItems={
+                    orientation: InstrumentAxisItem(orientation) for orientation in ("left", "bottom", "right", "top")
+                },
+                **kwargs,
+            )
+            plot_item.hideAxis("right")
+            plot_item.hideAxis("top")
+        super().__init__(parent=parent, background=background, plotItem=plot_item)

--- a/src/gui/widgets/lock_in_amplifier.py
+++ b/src/gui/widgets/lock_in_amplifier.py
@@ -32,6 +32,7 @@ from typing import List
 from src.gui.widgets.comparable_interface import ComparableWidgetInterface
 from src.core.comparison_manager import ComparisonTrace, AxisMetadata, CalibrationInfo
 from src.core.utils import amplitude_to_linear, linear_to_amplitude
+from src.gui.widgets.instrument_plot import InstrumentPlotWidget
 
 
 logger = logging.getLogger(__name__)
@@ -1174,7 +1175,7 @@ class LockInAmplifierWidget(QWidget, ComparableWidgetInterface):
         cal_layout.addWidget(cal_settings, stretch=1)
 
         # Plot
-        self.cal_plot = pg.PlotWidget(title=tr("Calibration Map"))
+        self.cal_plot = InstrumentPlotWidget(title=tr("Calibration Map"))
         self.cal_plot.setLabel("bottom", tr("Frequency"), units="Hz")
         self.cal_plot.setLabel("left", tr("Correction"), units="dB")
         self.cal_plot.showGrid(x=True, y=True, alpha=0.3)

--- a/src/gui/widgets/lockin_spectrum_finder.py
+++ b/src/gui/widgets/lockin_spectrum_finder.py
@@ -39,6 +39,7 @@ from src.measurement_modules.base import MeasurementModule
 from src.gui.styles import MONOSPACE_FONT_FAMILY
 from src.gui.widgets.compactable_interface import CompactableWidgetInterface
 from src.gui.widgets.splittable_interface import SplittableWidgetInterface
+from src.gui.widgets.instrument_plot import InstrumentPlotWidget
 
 logger = logging.getLogger(__name__)
 
@@ -1395,7 +1396,7 @@ class LockInSpectrumFinderWidget(QWidget, CompactableWidgetInterface, Splittable
         # RIGHT: Plot
         self.display_widget = QWidget()
         right_panel = QVBoxLayout(self.display_widget)
-        self.plot = pg.PlotWidget(title=tr("Lock-in Spectrum"))
+        self.plot = InstrumentPlotWidget(title=tr("Lock-in Spectrum"))
         self.plot.setLabel("bottom", tr("Frequency"), units="Hz")
         self.plot.setLabel("left", tr("Amplitude"), units=self.module.display_unit)
         self.plot.showGrid(x=True, y=True)

--- a/src/gui/widgets/network_analyzer.py
+++ b/src/gui/widgets/network_analyzer.py
@@ -41,6 +41,7 @@ from src.core.utils import amplitude_to_linear, linear_to_amplitude
 from src.measurement_modules.base import MeasurementModule
 from typing import List
 from src.gui.widgets.comparable_interface import ComparableWidgetInterface
+from src.gui.widgets.instrument_plot import InstrumentPlotWidget, logarithmic_ticks_125
 from src.core.comparison_manager import ComparisonTrace, AxisMetadata, CalibrationInfo
 
 logger = logging.getLogger(__name__)
@@ -1156,7 +1157,7 @@ class NetworkAnalyzerWidget(QWidget, ComparableWidgetInterface):
     def _create_bode_tab(self) -> QWidget:
         bode_tab = QWidget()
         plot_layout = QVBoxLayout(bode_tab)
-        self.mag_plot = pg.PlotWidget(title=tr("Magnitude Response"))
+        self.mag_plot = InstrumentPlotWidget(title=tr("Magnitude Response"))
         self.mag_plot.setLabel("left", tr("Magnitude"), units="dB")
         self.mag_plot.setLabel("bottom", tr("Frequency"), units="Hz")
         self.mag_plot.setLogMode(x=True, y=False)
@@ -1185,7 +1186,7 @@ class NetworkAnalyzerWidget(QWidget, ComparableWidgetInterface):
 
         plot_layout.addWidget(self.mag_plot)
 
-        self.phase_plot = pg.PlotWidget(title=tr("Phase Response"))
+        self.phase_plot = InstrumentPlotWidget(title=tr("Phase Response"))
         self.phase_plot.setLabel("left", tr("Phase"), units="deg")
         self.phase_plot.setLabel("bottom", tr("Frequency"), units="Hz")
         self.phase_plot.setLogMode(x=True, y=False)
@@ -1250,7 +1251,7 @@ class NetworkAnalyzerWidget(QWidget, ComparableWidgetInterface):
     def _create_harmonics_tab(self) -> QWidget:
         harmonics_tab = QWidget()
         harmonics_layout = QVBoxLayout(harmonics_tab)
-        self.harmonics_plot = pg.PlotWidget(title=tr("Harmonic Distortion"))
+        self.harmonics_plot = InstrumentPlotWidget(title=tr("Harmonic Distortion"))
         self.harmonics_plot.setLabel("left", tr("Level"), units="dB")
         self.harmonics_plot.setLabel("bottom", tr("Frequency"), units="Hz")
         self.harmonics_plot.setLogMode(x=True, y=False)
@@ -2157,9 +2158,7 @@ class NetworkAnalyzerWidget(QWidget, ComparableWidgetInterface):
         if checked:
             self.harmonics_plot.setLogMode(x=True, y=True)
             self.harmonics_plot.setYRange(np.log10(0.0001), np.log10(100))
-            percent_ticks = [100, 10, 1, 0.1, 0.01, 0.001, 0.0001]
-            ticks_log = [(np.log10(t), f"{t:g}%") for t in percent_ticks]
-            y_axis.setTicks([ticks_log])
+            y_axis.setTicks([logarithmic_ticks_125(0.0001, 100, suffix="%")])
         else:
             self.harmonics_plot.setLogMode(x=True, y=False)
             y_axis.setTicks(None)

--- a/src/gui/widgets/nonlinear_analyzer.py
+++ b/src/gui/widgets/nonlinear_analyzer.py
@@ -30,6 +30,7 @@ from scipy.signal import (
 from src.core.audio_engine import AudioEngine
 from src.core.localization import tr
 from src.measurement_modules.base import MeasurementModule
+from src.gui.widgets.instrument_plot import InstrumentPlotWidget
 from src.core.nonlinear_analyzer_core import (
     generate_sss_and_inverse,
     process_amplitude_responses,
@@ -837,7 +838,7 @@ class NonlinearAnalyzerWidget(QWidget):
         # Tab 1: Magnitude Response (Bode Plot)
         self.mag_tab = QWidget()
         mag_layout = QVBoxLayout(self.mag_tab)
-        self.mag_plot = pg.PlotWidget(title=tr("Bode Magnitude Response"))
+        self.mag_plot = InstrumentPlotWidget(title=tr("Bode Magnitude Response"))
         self.mag_plot.setLabel("left", tr("Gain"), units="dB")
         self.mag_plot.setLabel("bottom", tr("Frequency"), units="Hz")
         self.mag_plot.setLogMode(True, False)
@@ -848,7 +849,7 @@ class NonlinearAnalyzerWidget(QWidget):
         # Tab 2: Phase Response
         self.phase_tab = QWidget()
         phase_layout = QVBoxLayout(self.phase_tab)
-        self.phase_plot = pg.PlotWidget(title=tr("Bode Phase Response"))
+        self.phase_plot = InstrumentPlotWidget(title=tr("Bode Phase Response"))
         self.phase_plot.setLabel("left", tr("Phase"), units="deg")
         self.phase_plot.setLabel("bottom", tr("Frequency"), units="Hz")
         self.phase_plot.setLogMode(True, False)

--- a/src/gui/widgets/nonlinear_response_analyzer.py
+++ b/src/gui/widgets/nonlinear_response_analyzer.py
@@ -23,6 +23,7 @@ from scipy.signal import freqz, fftconvolve, chirp as signal_chirp
 from src.core.audio_engine import AudioEngine
 from src.core.localization import tr
 from src.measurement_modules.base import MeasurementModule
+from src.gui.widgets.instrument_plot import InstrumentPlotWidget
 from src.core.nonlinear_response_analyzer_core import (
     generate_schroeder_multisine,
     generate_gaussian_noise,
@@ -580,13 +581,13 @@ class NonlinearResponseAnalyzerWidget(QWidget):
         lti_layout = QVBoxLayout(self.lti_tab)
         lti_layout.setContentsMargins(2, 2, 2, 2)
 
-        self.lti_mag_plot = pg.PlotWidget(title=tr("LTI Block Magnitude Response"))
+        self.lti_mag_plot = InstrumentPlotWidget(title=tr("LTI Block Magnitude Response"))
         self.lti_mag_plot.setLabel("left", tr("Magnitude"), units="dB")
         self.lti_mag_plot.setLabel("bottom", tr("Frequency"), units="Hz")
         self.lti_mag_plot.setLogMode(x=True, y=False)
         self.lti_mag_plot.showGrid(x=True, y=True)
 
-        self.lti_phase_plot = pg.PlotWidget(title=tr("LTI Block Phase Response"))
+        self.lti_phase_plot = InstrumentPlotWidget(title=tr("LTI Block Phase Response"))
         self.lti_phase_plot.setLabel("left", tr("Phase"), units="degrees")
         self.lti_phase_plot.setLabel("bottom", tr("Frequency"), units="Hz")
         self.lti_phase_plot.setLogMode(x=True, y=False)

--- a/src/gui/widgets/plot_comparer.py
+++ b/src/gui/widgets/plot_comparer.py
@@ -31,6 +31,7 @@ from src.core.audio_engine import AudioEngine
 from src.core.localization import tr
 from src.core.comparison_manager import ComparisonManager
 from src.gui.styles import MONOSPACE_FONT_FAMILY
+from src.gui.widgets.instrument_plot import logarithmic_ticks_125
 
 logger = logging.getLogger(__name__)
 
@@ -1681,9 +1682,7 @@ class PlotComparerWidget(QWidget):
         if getattr(self, "is_log_y", False):
             # If the primary visible trace uses percent, set log ticks
             if first_trace.y_axis and first_trace.y_axis.display_unit == "%":
-                percent_ticks = [100, 10, 1, 0.1, 0.01, 0.001, 0.0001]
-                ticks_log = [(np.log10(t), f"{t:g}%") for t in percent_ticks]
-                y1_axis.setTicks([ticks_log])
+                y1_axis.setTicks([logarithmic_ticks_125(0.0001, 100, suffix="%")])
                 # Set range from 0.0001% to 100%
                 self.plot_widget.setYRange(np.log10(0.0001), np.log10(100))
 

--- a/src/gui/widgets/response_viewer.py
+++ b/src/gui/widgets/response_viewer.py
@@ -25,6 +25,7 @@ from scipy.signal import savgol_filter
 from src.core.localization import tr
 from src.measurement_modules.base import MeasurementModule
 from src.core.hammerstein_model import load_hammerstein_model, get_active_model, has_active_model
+from src.gui.widgets.instrument_plot import InstrumentAxisItem, InstrumentPlotWidget
 
 logger = logging.getLogger(__name__)
 
@@ -328,7 +329,7 @@ class ResponseViewerWidget(QWidget):
         bode_layout = QVBoxLayout(self.tab_bode)
         bode_layout.setContentsMargins(2, 2, 2, 2)
 
-        self.mag_plot = pg.PlotWidget(title=tr("Bode Magnitude Response (PHM Separation)"))
+        self.mag_plot = InstrumentPlotWidget(title=tr("Bode Magnitude Response (PHM Separation)"))
         self.mag_plot.setLabel("left", tr("Gain"), units="dB")
         self.mag_plot.setLabel("bottom", tr("Frequency"), units="Hz")
         self.mag_plot.setLogMode(True, False)
@@ -336,7 +337,7 @@ class ResponseViewerWidget(QWidget):
         self.mag_plot.addLegend(offset=(10, 10))
         bode_layout.addWidget(self.mag_plot)
 
-        self.phase_plot = pg.PlotWidget(title=tr("Bode Phase Response (PHM Separation)"))
+        self.phase_plot = InstrumentPlotWidget(title=tr("Bode Phase Response (PHM Separation)"))
         self.phase_plot.setLabel("left", tr("Phase"), units="deg")
         self.phase_plot.setLabel("bottom", tr("Frequency"), units="Hz")
         self.phase_plot.setLogMode(True, False)
@@ -364,7 +365,10 @@ class ResponseViewerWidget(QWidget):
         map_layout.setContentsMargins(2, 2, 2, 2)
 
         self.map_graphics_widget = pg.GraphicsLayoutWidget()
-        self.map_plot_item = self.map_graphics_widget.addPlot(title=tr("Nonlinear Distortion Map"))
+        self.map_plot_item = self.map_graphics_widget.addPlot(
+            title=tr("Nonlinear Distortion Map"),
+            axisItems={orientation: InstrumentAxisItem(orientation) for orientation in ("left", "bottom")},
+        )
         self.map_plot_item.setLabel("left", tr("Input Amplitude"), units="dBFS")
         self.map_plot_item.setLabel("bottom", tr("Frequency"), units="Hz")
         self.map_plot_item.setLogMode(True, False)
@@ -414,7 +418,7 @@ class ResponseViewerWidget(QWidget):
         curves_layout.setSpacing(5)
 
         # Left plot: Distortion vs Frequency (at fixed amplitude ref_amp)
-        self.curve_freq_plot = pg.PlotWidget(title=tr("Distortion vs Frequency (at Reference Amplitude)"))
+        self.curve_freq_plot = InstrumentPlotWidget(title=tr("Distortion vs Frequency (at Reference Amplitude)"))
         self.curve_freq_plot.setLabel("left", tr("Level"), units="dB")
         self.curve_freq_plot.setLabel("bottom", tr("Frequency"), units="Hz")
         self.curve_freq_plot.setLogMode(True, False)
@@ -512,7 +516,7 @@ class ResponseViewerWidget(QWidget):
         sim_layout.addWidget(sim_left_panel)
 
         # Simulator plot (right side of simulator tab)
-        self.sim_plot = pg.PlotWidget(title=tr("Output Prediction Spectrum"))
+        self.sim_plot = InstrumentPlotWidget(title=tr("Output Prediction Spectrum"))
         self.sim_plot.setLabel("left", tr("Amplitude"), units="dBFS")
         self.sim_plot.setLabel("bottom", tr("Frequency"), units="Hz")
         self.sim_plot.setLogMode(True, False)
@@ -632,7 +636,7 @@ class ResponseViewerWidget(QWidget):
         bode_col_layout.setContentsMargins(0, 0, 0, 0)
         bode_col_layout.setSpacing(5)
 
-        self.wie_mag_plot = pg.PlotWidget(title=tr("Wiener Kernel Magnitude Response"))
+        self.wie_mag_plot = InstrumentPlotWidget(title=tr("Wiener Kernel Magnitude Response"))
         self.wie_mag_plot.setLabel("left", tr("Gain"), units="dB")
         self.wie_mag_plot.setLabel("bottom", tr("Frequency"), units="Hz")
         self.wie_mag_plot.setLogMode(True, False)
@@ -640,7 +644,7 @@ class ResponseViewerWidget(QWidget):
         self.wie_mag_plot.addLegend(offset=(10, 10))
         bode_col_layout.addWidget(self.wie_mag_plot)
 
-        self.wie_phase_plot = pg.PlotWidget(title=tr("Wiener Kernel Phase Response"))
+        self.wie_phase_plot = InstrumentPlotWidget(title=tr("Wiener Kernel Phase Response"))
         self.wie_phase_plot.setLabel("left", tr("Phase"), units="deg")
         self.wie_phase_plot.setLabel("bottom", tr("Frequency"), units="Hz")
         self.wie_phase_plot.setLogMode(True, False)

--- a/src/gui/widgets/spectrogram.py
+++ b/src/gui/widgets/spectrogram.py
@@ -25,6 +25,7 @@ from src.gui.widgets.compactable_interface import CompactableWidgetInterface
 from src.gui.widgets.splittable_interface import SplittableWidgetInterface
 from src.core.fft_manager import fft_manager, WARMUP_SIZES
 from src.gui.styles import STYLE_TOGGLE_BTN_DARK, STYLE_TOGGLE_BTN_LIGHT
+from src.gui.widgets.instrument_plot import InstrumentAxisItem
 
 ORIENTATION_TIME_X = "time_x"
 ORIENTATION_FREQUENCY_X = "frequency_x"
@@ -436,7 +437,10 @@ class SpectrogramWidget(QWidget, CompactableWidgetInterface, SplittableWidgetInt
         self.win = pg.GraphicsLayoutWidget()
 
         # Plot Item
-        self.plot = self.win.addPlot(title=tr("Spectrogram"))
+        self.plot = self.win.addPlot(
+            title=tr("Spectrogram"),
+            axisItems={orientation: InstrumentAxisItem(orientation) for orientation in ("left", "bottom")},
+        )
         self.plot.setLabel("left", tr("Frequency"), units="Hz")
         self.plot.setLabel("bottom", tr("Time"), units="frames")
         self.plot.setLogMode(False, True)  # Default: Log Y-axis

--- a/src/gui/widgets/stereo_alignment_monitor.py
+++ b/src/gui/widgets/stereo_alignment_monitor.py
@@ -23,6 +23,7 @@ from src.core.audio_engine import AudioEngine
 from src.core.localization import tr
 from src.measurement_modules.base import MeasurementModule
 from src.gui.widgets.compactable_interface import CompactableWidgetInterface
+from src.gui.widgets.instrument_plot import InstrumentPlotWidget
 
 
 class StereoAlignmentMonitor(MeasurementModule):
@@ -276,7 +277,7 @@ class StereoAlignmentMonitorWidget(QWidget, CompactableWidgetInterface):
         viz_layout = QVBoxLayout()
 
         # 1. FFT Difference Plot
-        self.fft_plot = pg.PlotWidget(title=tr("L/R Difference FFT (Tone Color Shift)"))
+        self.fft_plot = InstrumentPlotWidget(title=tr("L/R Difference FFT (Tone Color Shift)"))
         self.fft_plot.setLogMode(x=True, y=False)
         self.fft_plot.setLabel("bottom", tr("Frequency"), units="Hz")
         self.fft_plot.setLabel("left", tr("Magnitude"), units="dBFS")
@@ -294,7 +295,7 @@ class StereoAlignmentMonitorWidget(QWidget, CompactableWidgetInterface):
         viz_layout.addWidget(self.fft_plot, stretch=2)
 
         # 2. Band-specific Correlation Plot
-        self.corr_plot = pg.PlotWidget(title=tr("Band-specific Phase Correlation"))
+        self.corr_plot = InstrumentPlotWidget(title=tr("Band-specific Phase Correlation"))
         self.corr_plot.setLogMode(x=True, y=False)
         self.corr_plot.setLabel("bottom", tr("Frequency"), units="Hz")
         self.corr_plot.setLabel("left", tr("Correlation"))

--- a/tests/logic_verification/gui/widgets/test_instrument_plot.py
+++ b/tests/logic_verification/gui/widgets/test_instrument_plot.py
@@ -1,0 +1,27 @@
+import math
+
+from src.gui.widgets.instrument_plot import InstrumentAxisItem, InstrumentPlotWidget, logarithmic_ticks_125
+
+
+def test_log_axis_major_ticks_follow_125_series(qtbot):
+    del qtbot
+    axis = InstrumentAxisItem("bottom")
+
+    levels = axis.logTickValues(math.log10(20), math.log10(20_000), 600, [])
+
+    major_values = [round(10**position) for position in levels[0][1]]
+    assert major_values == [20, 50, 100, 200, 500, 1_000, 2_000, 5_000, 10_000, 20_000]
+
+
+def test_instrument_plot_installs_preferred_axes(qtbot):
+    plot = InstrumentPlotWidget()
+    qtbot.addWidget(plot)
+
+    for orientation in ("left", "bottom", "right", "top"):
+        assert isinstance(plot.getPlotItem().getAxis(orientation), InstrumentAxisItem)
+
+
+def test_labelled_log_ticks_follow_125_series():
+    ticks = logarithmic_ticks_125(0.01, 10, suffix="%")
+
+    assert [label for _, label in ticks] == ["0.01%", "0.02%", "0.05%", "0.1%", "0.2%", "0.5%", "1%", "2%", "5%", "10%"]


### PR DESCRIPTION
## Summary

- add shared instrument plot axes whose logarithmic major ticks follow the 1-2-5 series
- apply the axes to plot widgets that relied on PyQtGraph decade-only logarithmic ticks, including switchable X/Y frequency axes
- update logarithmic percentage axes and add regression coverage for tick generation and axis installation

## Validation

- `./.venv/bin/ruff check .`
- `./.venv/bin/ruff format --check .`
- `./.venv/bin/mypy src main_gui.py`
- `./.venv/bin/python scripts/check_trn_keys.py`
- `npx markdownlint-cli2 "**/*.md" "#node_modules"`
- `./.venv/bin/pytest` (1324 passed, 6 hardware-only skipped)
- `./.venv/bin/python scripts/check_ui_size_limits.py`