### PR TITLE
docs: update goniometer display options

### DIFF
--- a/docs/widgets/goniometer.en.md
+++ b/docs/widgets/goniometer.en.md
@@ -77,7 +77,8 @@ The meter displays `—` and a reason instead of confusing an unavailable result
 - **Persistence**: Sets the Density decay time from 0.05 to 5.0 seconds. The decay is independent of display FPS.
 - **Glow**: Applies display-only blur to Density mode.
 - **Color Palette**: Selects Green, Fire, Ice, or Viridis, each with ordered luminance.
-- **Show Direction Guides**: Shows the Mono, Anti-phase, Left, and Right direction guides. It is on by default.
+- **Show Center Crosshair**: Shows a crosshair intersecting the center of the display. It is on by default.
+- **Show Direction Guides**: Shows the Mono, Anti-phase, Left, and Right direction guides. It is off by default.
 - **Show Axes**: Shows numeric ticks and axis lines without coordinate-name labels. It is off by default.
 - **Show Grid**: Shows the plot grid. It is on by default.
 

--- a/docs/widgets/goniometer.md
+++ b/docs/widgets/goniometer.md
@@ -77,7 +77,8 @@ X軸へLeft、Y軸へRightをそのまま割り当てるXYオシロスコープ�
 - **Persistence**: Densityの残光時定数を0.05～5.0秒で設定します。描画FPSには依存しません。
 - **Glow**: Density表示だけに適用するぼかし量です。解析データには影響しません。
 - **Color Palette**: Green、Fire、Ice、Viridisから、明度が順序を持つ配色を選択します。
-- **Show Direction Guides**: Mono、Anti-phase、Left、Rightの方向案内を表示します。既定はONです。
+- **Show Center Crosshair**: 画面中心を交差する十字線を表示します。既定はONです。
+- **Show Direction Guides**: Mono、Anti-phase、Left、Rightの方向案内を表示します。既定はOFFです。
 - **Show Axes**: 数値目盛りと軸線を表示します。座標名ラベルは表示しません。既定はOFFです。
 - **Show Grid**: プロットのグリッドを表示します。既定はONです。
 


### PR DESCRIPTION
This PR updates the Goniometer widget documentation to align with recent changes:

- Added documentation for the new "Show Center Crosshair" setting.
- Updated the default state of "Show Direction Guides" to OFF to match the recent implementation update (commit `45dc5872` / `eb6a6c4f`).
- Applied changes to both English and Japanese markdown files.

---
*PR created automatically by Jules for task [12501250609729722384](https://jules.google.com/task/12501250609729722384) started by @youtube-at-vach*