### PR TITLE
Fix measurement console grid sizing

### DIFF
--- a/src/gui/measurement_console.py
+++ b/src/gui/measurement_console.py
@@ -12,6 +12,7 @@ import base64
 import binascii
 import logging
 import re
+from collections.abc import Sequence
 from enum import Enum
 from typing import TYPE_CHECKING
 
@@ -304,6 +305,7 @@ class MeasurementConsoleWindow(QMainWindow):
         self._compact_screen_layout_active = False
         self._pre_compact_screen_dock_state: bytes | None = None
         self._screen_change_connected = False
+        self._preset_layout_generation = 0
         self._stop_all_generation = 0
         self._stop_all_queue: list[int] = []
         self._stop_all_active = False
@@ -851,6 +853,7 @@ class MeasurementConsoleWindow(QMainWindow):
         return True
 
     def _prepare_for_preset(self) -> list[InstrumentDockWidget]:
+        self._preset_layout_generation += 1
         docks = list(self._docks.values())
         for dock in docks:
             if dock.isFloating():
@@ -939,7 +942,36 @@ class MeasurementConsoleWindow(QMainWindow):
             dock.show()
         for dock in docks[:4]:
             dock.raise_()
+        generation = self._preset_layout_generation
+        self._equalize_two_by_two(docks, generation)
+        # QMainWindow performs another dock-layout pass after newly inserted
+        # docks become visible.  Reapply the ratios on the next event-loop turn
+        # so instrument-specific size hints cannot collapse either grid row.
+        QTimer.singleShot(
+            0,
+            lambda arranged=tuple(docks), current=generation: self._equalize_two_by_two(arranged, current),
+        )
         self._schedule_visible_state_snapshot()
+
+    def _equalize_two_by_two(self, docks: Sequence[InstrumentDockWidget], generation: int) -> None:
+        """Give the preset's columns and rows equal shares of the workspace."""
+        if (
+            self._closing
+            or generation != self._preset_layout_generation
+            or not docks
+            or any(dock not in self._docks.values() for dock in docks)
+        ):
+            return
+
+        column_width = max(1, self.width() // 2)
+        row_height = max(1, self.height() // 2)
+
+        if len(docks) >= 2:
+            self.resizeDocks(docks[:2], [column_width, column_width], Qt.Orientation.Horizontal)
+        if len(docks) >= 3:
+            self.resizeDocks([docks[0], docks[2]], [row_height, row_height], Qt.Orientation.Vertical)
+        if len(docks) >= 4:
+            self.resizeDocks([docks[1], docks[3]], [row_height, row_height], Qt.Orientation.Vertical)
 
     def _schedule_visible_state_snapshot(self) -> None:
         from PyQt6 import sip

--- a/tests/logic_verification/gui/test_measurement_console.py
+++ b/tests/logic_verification/gui/test_measurement_console.py
@@ -147,6 +147,36 @@ def test_console_hosts_compact_widgets_in_two_columns(qtbot):
     assert sorted(host.returned) == [0, 1, 2, 3]
 
 
+def test_two_by_two_grid_equalizes_columns_and_rows(qtbot, monkeypatch):
+    host = _ConsoleHostStub([_DummyWrapper() for _ in range(4)])
+    console = MeasurementConsoleWindow(host)
+    for index in range(4):
+        console.add_module(index, arrange=False)
+
+    resize_calls = []
+    original_resize_docks = console.resizeDocks
+
+    def record_resize(docks, sizes, orientation) -> None:
+        resize_calls.append((tuple(docks), tuple(sizes), orientation))
+        original_resize_docks(docks, sizes, orientation)
+
+    monkeypatch.setattr(console, "resizeDocks", record_resize)
+    console.arrange_two_by_two()
+    qtbot.waitUntil(lambda: len(resize_calls) >= 6)
+
+    first_pass = resize_calls[:3]
+    assert first_pass[0][0] == (console._docks[0], console._docks[1])
+    assert first_pass[0][1][0] == first_pass[0][1][1]
+    assert first_pass[0][2] is Qt.Orientation.Horizontal
+    assert first_pass[1][0] == (console._docks[0], console._docks[2])
+    assert first_pass[1][1][0] == first_pass[1][1][1]
+    assert first_pass[1][2] is Qt.Orientation.Vertical
+    assert first_pass[2][0] == (console._docks[1], console._docks[3])
+    assert first_pass[2][1][0] == first_pass[2][1][1]
+    assert first_pass[2][2] is Qt.Orientation.Vertical
+    console.close()
+
+
 def test_side_by_side_uses_two_tabbed_columns_for_four_instruments(qtbot):
     host = _ConsoleHostStub([_DummyWrapper() for _ in range(4)])
     console = MeasurementConsoleWindow(host)


### PR DESCRIPTION
## Summary

- give the measurement console 2 x 2 preset equal column widths and row heights
- reapply sizing after Qt completes its deferred dock layout while ignoring stale preset callbacks
- add regression coverage for horizontal and vertical dock equalization

## Testing

- ./.venv/bin/ruff check .
- ./.venv/bin/ruff format --check .
- ./.venv/bin/mypy src main_gui.py
- ./.venv/bin/python scripts/check_trn_keys.py
- npx markdownlint-cli2 "**/*.md" "#node_modules"
- ./.venv/bin/pytest (1325 passed, 6 skipped)
- ./.venv/bin/python scripts/check_ui_size_limits.py