### PR TITLE
Harden calibration integrity and virtual stream timing

### DIFF
--- a/src/core/audio_engine.py
+++ b/src/core/audio_engine.py
@@ -65,18 +65,26 @@ class VirtualStream:
         indata = np.zeros((self.blocksize, self.channels[0]), dtype="float32")
         outdata = np.zeros((self.blocksize, self.channels[1]), dtype="float32")
 
-        next_call_time = time.time()
+        # Pace the stream with a monotonic clock so NTP/manual wall-clock
+        # adjustments cannot stall it or create a callback burst.
+        next_call_time = time.monotonic()
 
         while self.active and not self._stop_event.is_set():
-            t = time.time()
+            now = time.monotonic()
             # Drift correction: if we are falling behind, catch up just a bit, but don't spiral
-            if t > next_call_time + 0.1:
-                next_call_time = t
+            if now > next_call_time + 0.1:
+                next_call_time = now
 
             # Sleep until next Tick
-            to_sleep = next_call_time - t
+            to_sleep = next_call_time - now
             if to_sleep > 0:
-                self._stop_event.wait(to_sleep)
+                # Event.wait() returns true when stop() interrupts the sleep.
+                # Never emit one final stale block after shutdown was requested.
+                if self._stop_event.wait(to_sleep):
+                    break
+
+            if not self.active or self._stop_event.is_set():
+                break
 
             next_call_time += interval
 
@@ -95,7 +103,8 @@ class VirtualStream:
 
                 status = sd.CallbackFlags()
 
-                self.callback(indata, outdata, self.blocksize, _DummyTime(t, interval), status)
+                callback_time = time.time()
+                self.callback(indata, outdata, self.blocksize, _DummyTime(callback_time, interval), status)
 
                 # In Virtual Mode, `indata` is usually zeros, UNLESS the callback filled it?
                 # master_callback expects indata from "Hardware".

--- a/src/core/calibration.py
+++ b/src/core/calibration.py
@@ -61,9 +61,13 @@ class CalibrationManager:
             try:
                 with open(self.config_path, "r") as f:
                     data = json.load(f)
-                    self.input_sensitivity = data.get("input_sensitivity", 1.0)
+                    self.input_sensitivity, input_sensitivity_valid = self._validated_float(
+                        data.get("input_sensitivity", 1.0), 1.0, positive=True
+                    )
                     if "input_sensitivity_is_calibrated" in data:
-                        self.input_sensitivity_is_calibrated = bool(data.get("input_sensitivity_is_calibrated"))
+                        self.input_sensitivity_is_calibrated = input_sensitivity_valid and bool(
+                            data.get("input_sensitivity_is_calibrated")
+                        )
                     else:
                         # Legacy files did not record this state. A non-default
                         # sensitivity could only be entered through calibration
@@ -73,25 +77,35 @@ class CalibrationManager:
                             self.input_sensitivity_is_calibrated = abs(float(self.input_sensitivity) - 1.0) > 1e-12
                         except Exception:
                             self.input_sensitivity_is_calibrated = False
-                    self.output_gain = data.get("output_gain", 1.0)
+                    self.output_gain, output_gain_valid = self._validated_float(
+                        data.get("output_gain", 1.0), 1.0, positive=True
+                    )
                     # New flag (backward compatible)
                     if "output_gain_is_calibrated" in data:
-                        self.output_gain_is_calibrated = bool(data.get("output_gain_is_calibrated"))
+                        self.output_gain_is_calibrated = output_gain_valid and bool(
+                            data.get("output_gain_is_calibrated")
+                        )
                     else:
                         # Heuristic for older files: treat non-default values as calibrated.
                         try:
                             self.output_gain_is_calibrated = abs(float(self.output_gain) - 1.0) > 1e-12
                         except Exception:
                             self.output_gain_is_calibrated = False
-                    self.frequency_calibration = data.get("frequency_calibration", 1.0)
-                    self.frequency_calibration_1pps = data.get("frequency_calibration_1pps", 1.0)
-                    self.frequency_calibration_source = data.get("frequency_calibration_source", "basic")
-                    self.lockin_gain_offset = data.get("lockin_gain_offset", 0.0)
+                    self.frequency_calibration, _ = self._validated_float(
+                        data.get("frequency_calibration", 1.0), 1.0, positive=True
+                    )
+                    self.frequency_calibration_1pps, _ = self._validated_float(
+                        data.get("frequency_calibration_1pps", 1.0), 1.0, positive=True
+                    )
+                    source = data.get("frequency_calibration_source", "basic")
+                    self.frequency_calibration_source = source if source in ("basic", "1pps") else "basic"
+                    self.lockin_gain_offset, _ = self._validated_float(data.get("lockin_gain_offset", 0.0), 0.0)
 
                     # New format
                     if "spl_offset_db" in data:
                         try:
-                            self.spl_offset_db = float(data.get("spl_offset_db"))
+                            value = float(data.get("spl_offset_db"))
+                            self.spl_offset_db = value if np.isfinite(value) else None
                         except Exception:
                             self.spl_offset_db = None
 
@@ -107,7 +121,8 @@ class CalibrationManager:
                                     entry = None
                             if isinstance(entry, dict) and "offset_db" in entry:
                                 try:
-                                    self.spl_offset_db = float(entry.get("offset_db"))
+                                    value = float(entry.get("offset_db"))
+                                    self.spl_offset_db = value if np.isfinite(value) else None
                                 except Exception:
                                     self.spl_offset_db = None
 
@@ -121,6 +136,17 @@ class CalibrationManager:
                     )
             except Exception as e:
                 self.logger.error("Failed to load calibration: %s", e)
+
+    @staticmethod
+    def _validated_float(value, default, *, positive=False):
+        """Return a finite calibration value and whether the input was valid."""
+        try:
+            result = float(value)
+        except (TypeError, ValueError, OverflowError):
+            return float(default), False
+        if not np.isfinite(result) or (positive and result <= 0):
+            return float(default), False
+        return result, True
 
     def save(self):
         # Synchronize current settings to the active profile if one is selected
@@ -180,13 +206,19 @@ class CalibrationManager:
         except Exception:
             raise ValueError("Invalid SPL calibration values") from None
 
+        if not np.isfinite(measured_dbfs_c) or not np.isfinite(measured_spl_db):
+            raise ValueError("Invalid SPL calibration values")
+
         offset_db = measured_spl_db - measured_dbfs_c
         self.spl_offset_db = float(offset_db)
         self.save()
 
     def get_spl_offset_db(self):
         try:
-            return None if self.spl_offset_db is None else float(self.spl_offset_db)
+            if self.spl_offset_db is None:
+                return None
+            offset = float(self.spl_offset_db)
+            return offset if np.isfinite(offset) else None
         except Exception:
             return None
 
@@ -195,7 +227,10 @@ class CalibrationManager:
         off = self.get_spl_offset_db()
         if off is None:
             return None
-        return float(dbfs_c) + off
+        dbfs_c = float(dbfs_c)
+        if not np.isfinite(dbfs_c):
+            raise ValueError("Invalid dBFS value")
+        return dbfs_c + off
 
     def set_input_sensitivity(self, v_per_fs):
         """Sets input sensitivity in Volts (Peak) corresponding to 1.0 FS."""
@@ -230,11 +265,17 @@ class CalibrationManager:
 
     def set_frequency_calibration(self, factor):
         """Sets the frequency calibration factor (multiplier)."""
+        factor, valid = self._validated_float(factor, 1.0, positive=True)
+        if not valid:
+            raise ValueError("Invalid frequency calibration factor")
         self.frequency_calibration = factor
         self.save()
 
     def set_frequency_calibration_1pps(self, factor):
         """Sets the 1PPS-derived frequency calibration factor (multiplier)."""
+        factor, valid = self._validated_float(factor, 1.0, positive=True)
+        if not valid:
+            raise ValueError("Invalid 1PPS frequency calibration factor")
         self.frequency_calibration_1pps = factor
         self.save()
 
@@ -253,7 +294,10 @@ class CalibrationManager:
     def set_lockin_gain_offset(self, offset):
         """Sets the gain offset for the lock-in amplifier in dB."""
         try:
-            self.lockin_gain_offset = float(offset)
+            value = float(offset)
+            if not np.isfinite(value):
+                raise ValueError("gain offset must be finite")
+            self.lockin_gain_offset = value
             self.save()
         except (ValueError, TypeError) as e:
             self.logger.warning("Invalid lock-in gain offset provided: %s", e)
@@ -308,22 +352,39 @@ class CalibrationManager:
 
     def _apply_calibration_snapshot(self, snapshot):
         """Apply a complete profile snapshot while preserving legacy defaults."""
-        self.input_sensitivity = snapshot.get("input_sensitivity", 1.0)
+        self.input_sensitivity, input_sensitivity_valid = self._validated_float(
+            snapshot.get("input_sensitivity", 1.0), 1.0, positive=True
+        )
         if "input_sensitivity_is_calibrated" in snapshot:
-            self.input_sensitivity_is_calibrated = bool(snapshot.get("input_sensitivity_is_calibrated"))
+            self.input_sensitivity_is_calibrated = input_sensitivity_valid and bool(
+                snapshot.get("input_sensitivity_is_calibrated")
+            )
         else:
             try:
                 self.input_sensitivity_is_calibrated = abs(float(self.input_sensitivity) - 1.0) > 1e-12
             except Exception:
                 self.input_sensitivity_is_calibrated = False
 
-        self.output_gain = snapshot.get("output_gain", 1.0)
-        self.output_gain_is_calibrated = bool(snapshot.get("output_gain_is_calibrated", False))
-        self.frequency_calibration = snapshot.get("frequency_calibration", 1.0)
-        self.frequency_calibration_1pps = snapshot.get("frequency_calibration_1pps", 1.0)
-        self.frequency_calibration_source = snapshot.get("frequency_calibration_source", "basic")
-        self.lockin_gain_offset = snapshot.get("lockin_gain_offset", 0.0)
-        self.spl_offset_db = snapshot.get("spl_offset_db", None)
+        self.output_gain, output_gain_valid = self._validated_float(
+            snapshot.get("output_gain", 1.0), 1.0, positive=True
+        )
+        self.output_gain_is_calibrated = output_gain_valid and bool(snapshot.get("output_gain_is_calibrated", False))
+        self.frequency_calibration, _ = self._validated_float(
+            snapshot.get("frequency_calibration", 1.0), 1.0, positive=True
+        )
+        self.frequency_calibration_1pps, _ = self._validated_float(
+            snapshot.get("frequency_calibration_1pps", 1.0), 1.0, positive=True
+        )
+        source = snapshot.get("frequency_calibration_source", "basic")
+        self.frequency_calibration_source = source if source in ("basic", "1pps") else "basic"
+        self.lockin_gain_offset, _ = self._validated_float(snapshot.get("lockin_gain_offset", 0.0), 0.0)
+        spl_offset = snapshot.get("spl_offset_db", None)
+        if spl_offset is None:
+            self.spl_offset_db = None
+        else:
+            self.spl_offset_db, spl_offset_valid = self._validated_float(spl_offset, 0.0)
+            if not spl_offset_valid:
+                self.spl_offset_db = None
 
     @staticmethod
     def _profile_device_metadata(

--- a/tests/logic_verification/core/test_calibration.py
+++ b/tests/logic_verification/core/test_calibration.py
@@ -75,6 +75,84 @@ def test_set_sensitivities(calibration_manager):
         calibration_manager.set_output_gain(-1.0)
 
 
+def test_invalid_persisted_calibration_values_fail_closed(temp_config_path):
+    """Corrupt calibration data must not silently contaminate measurements."""
+    with open(temp_config_path, "w", encoding="utf-8") as f:
+        json.dump(
+            {
+                "input_sensitivity": -2.0,
+                "input_sensitivity_is_calibrated": True,
+                "output_gain": "invalid",
+                "output_gain_is_calibrated": True,
+                "frequency_calibration": float("nan"),
+                "frequency_calibration_1pps": -1.0,
+                "frequency_calibration_source": "invalid",
+                "lockin_gain_offset": float("inf"),
+                "spl_offset_db": float("inf"),
+            },
+            f,
+        )
+
+    manager = CalibrationManager(config_filename=temp_config_path)
+
+    assert manager.input_sensitivity == 1.0
+    assert manager.input_sensitivity_is_calibrated is False
+    assert manager.output_gain == 1.0
+    assert manager.output_gain_is_calibrated is False
+    assert manager.frequency_calibration == 1.0
+    assert manager.frequency_calibration_1pps == 1.0
+    assert manager.frequency_calibration_source == "basic"
+    assert manager.lockin_gain_offset == 0.0
+    assert manager.get_spl_offset_db() is None
+
+
+@pytest.mark.parametrize("invalid_factor", [0.0, -1.0, float("nan"), float("inf"), "invalid"])
+def test_frequency_calibration_setters_reject_invalid_values(calibration_manager, invalid_factor):
+    with pytest.raises(ValueError):
+        calibration_manager.set_frequency_calibration(invalid_factor)
+    with pytest.raises(ValueError):
+        calibration_manager.set_frequency_calibration_1pps(invalid_factor)
+
+    assert calibration_manager.frequency_calibration == 1.0
+    assert calibration_manager.frequency_calibration_1pps == 1.0
+
+
+@pytest.mark.parametrize("invalid_value", [float("nan"), float("inf"), float("-inf")])
+def test_spl_calibration_rejects_non_finite_values(calibration_manager, invalid_value):
+    with pytest.raises(ValueError):
+        calibration_manager.set_spl_calibration(invalid_value, 94.0)
+    with pytest.raises(ValueError):
+        calibration_manager.set_spl_calibration(-20.0, invalid_value)
+
+    assert calibration_manager.get_spl_offset_db() is None
+
+
+def test_invalid_profile_values_fail_closed(calibration_manager):
+    calibration_manager.profiles["Corrupt"] = {
+        "input_sensitivity": float("nan"),
+        "input_sensitivity_is_calibrated": True,
+        "output_gain": -1.0,
+        "output_gain_is_calibrated": True,
+        "frequency_calibration": float("inf"),
+        "frequency_calibration_1pps": 0.0,
+        "frequency_calibration_source": "invalid",
+        "lockin_gain_offset": "invalid",
+        "spl_offset_db": float("nan"),
+    }
+
+    calibration_manager.load_profile("Corrupt")
+
+    assert calibration_manager.input_sensitivity == 1.0
+    assert calibration_manager.input_sensitivity_is_calibrated is False
+    assert calibration_manager.output_gain == 1.0
+    assert calibration_manager.output_gain_is_calibrated is False
+    assert calibration_manager.frequency_calibration == 1.0
+    assert calibration_manager.frequency_calibration_1pps == 1.0
+    assert calibration_manager.frequency_calibration_source == "basic"
+    assert calibration_manager.lockin_gain_offset == 0.0
+    assert calibration_manager.get_spl_offset_db() is None
+
+
 @pytest.mark.parametrize(
     ("legacy_sensitivity", "expected_calibrated"),
     [(1.0, False), (2.0, True)],

--- a/tests/logic_verification/core/test_virtual_stream_timing.py
+++ b/tests/logic_verification/core/test_virtual_stream_timing.py
@@ -53,21 +53,19 @@ class TestVirtualStreamTiming(unittest.TestCase):
         # 2. Loop 1: t = t0 + 0.01. to_sleep = t0 - (t0+0.01) = -0.01. No sleep. next_call_time += 0.1 -> 1000.1.
         # 3. Loop 2: t = t0 + 0.02. to_sleep = 1000.1 - 1000.02 = 0.08. Sleep(0.08). next_call_time += 0.1 -> 1000.2.
 
-        mock_time.time.side_effect = [
+        mock_time.monotonic.side_effect = [
             t0,  # init next_call_time
             t0 + 0.01,  # 1st loop t
             t0 + 0.02,  # 2nd loop t
         ]
+        mock_time.time.side_effect = [2000.01, 2000.10]
 
-        # Stop loop after 2nd iteration (when wait is called)
-        self.stream._stop_event.wait = MagicMock()
-
-        def wait_side_effect(duration):
-            if self.stream._stop_event.wait.call_count >= 1:
+        def callback_side_effect(*_args):
+            if self.callback.call_count == 2:
                 self.stream.active = False
-            return True
 
-        self.stream._stop_event.wait.side_effect = wait_side_effect
+        self.callback.side_effect = callback_side_effect
+        self.stream._stop_event.wait = MagicMock(return_value=False)
 
         self.stream.active = True
         self.stream._run_loop()
@@ -97,19 +95,19 @@ class TestVirtualStreamTiming(unittest.TestCase):
         # 3. Loop 2: t = 1000.51.
         #    to_sleep = 1000.6 - 1000.51 = 0.09. Sleep(0.09).
 
-        mock_time.time.side_effect = [
+        mock_time.monotonic.side_effect = [
             t0,  # init
             t0 + 0.5,  # 1st loop t (lag)
             t0 + 0.51,  # 2nd loop t
         ]
+        mock_time.time.side_effect = [2000.5, 2000.6]
 
-        self.stream._stop_event.wait = MagicMock()
+        def callback_side_effect(*_args):
+            if self.callback.call_count == 2:
+                self.stream.active = False
 
-        def wait_side_effect(duration):
-            self.stream.active = False
-            return True
-
-        self.stream._stop_event.wait.side_effect = wait_side_effect
+        self.callback.side_effect = callback_side_effect
+        self.stream._stop_event.wait = MagicMock(return_value=False)
 
         self.stream.active = True
         self.stream._run_loop()
@@ -125,24 +123,16 @@ class TestVirtualStreamTiming(unittest.TestCase):
     def test_run_loop_callback_exception(self, mock_time):
         """Verify loop continues after callback exception."""
         t0 = 1000.0
-        mock_time.time.return_value = t0
+        mock_time.monotonic.return_value = t0
+        mock_time.time.return_value = 2000.0
 
-        # Callback raises exception on first call, succeeds on second
-        self.callback.side_effect = [ValueError("Test Error"), None]
+        def callback_side_effect(*_args):
+            if self.callback.call_count == 1:
+                raise ValueError("Test Error")
+            self.stream.active = False
 
-        # Stop loop after 2 iterations
-        # logic:
-        # Loop 1: sleep not called (init). callback called (1).
-        # Loop 2: sleep called. call_count is 1. Set active=False. callback called (2).
-        # Loop terminates.
-        self.stream._stop_event.wait = MagicMock()
-
-        def wait_side_effect(duration):
-            if self.callback.call_count >= 1:
-                self.stream.active = False
-            return True
-
-        self.stream._stop_event.wait.side_effect = wait_side_effect
+        self.callback.side_effect = callback_side_effect
+        self.stream._stop_event.wait = MagicMock(return_value=False)
 
         self.stream.active = True
         self.stream._run_loop()
@@ -156,7 +146,9 @@ class TestVirtualStreamTiming(unittest.TestCase):
     def test_callback_arguments(self, mock_time):
         """Verify callback arguments."""
         t0 = 1000.0
-        mock_time.time.return_value = t0
+        wall_time = 2000.0
+        mock_time.monotonic.return_value = t0
+        mock_time.time.return_value = wall_time
 
         # Stop after 1 iteration
         def callback_side_effect(indata, outdata, frames, time_info, status):
@@ -170,9 +162,9 @@ class TestVirtualStreamTiming(unittest.TestCase):
             self.assertTrue(np.all(outdata == 0))
 
             # Verify time info
-            self.assertEqual(time_info.currentTime, t0)
-            self.assertEqual(time_info.inputBufferAdcTime, t0)
-            self.assertEqual(time_info.outputBufferDacTime, t0 + self.interval)
+            self.assertEqual(time_info.currentTime, wall_time)
+            self.assertEqual(time_info.inputBufferAdcTime, wall_time)
+            self.assertEqual(time_info.outputBufferDacTime, wall_time + self.interval)
 
         self.callback.side_effect = callback_side_effect
 
@@ -180,6 +172,46 @@ class TestVirtualStreamTiming(unittest.TestCase):
         self.stream._run_loop()
 
         self.assertEqual(self.callback.call_count, 1)
+
+    @patch("src.core.audio_engine.time")
+    def test_stop_during_wait_does_not_emit_stale_callback(self, mock_time):
+        """A stop request while sleeping must cancel the pending audio block."""
+        t0 = 1000.0
+        mock_time.monotonic.side_effect = [t0, t0 + 0.01, t0 + 0.02]
+        mock_time.time.return_value = 2000.0
+
+        def stop_on_wait(_duration):
+            self.stream.active = False
+            self.stream._stop_event.set()
+            return True
+
+        self.stream._stop_event.wait = MagicMock(side_effect=stop_on_wait)
+        self.callback.side_effect = lambda *_args: None
+        self.stream.active = True
+        self.stream._run_loop()
+
+        self.assertEqual(self.callback.call_count, 1)
+
+    @patch("src.core.audio_engine.time")
+    def test_wall_clock_adjustment_does_not_change_pacing(self, mock_time):
+        """Wall-clock jumps affect timestamps, not callback scheduling."""
+        t0 = 1000.0
+        mock_time.monotonic.side_effect = [t0, t0, t0 + 0.02]
+        mock_time.time.side_effect = [2000.0, 1000.0]
+        self.stream._stop_event.wait = MagicMock(return_value=False)
+
+        def callback_side_effect(*_args):
+            if self.callback.call_count == 2:
+                self.stream.active = False
+
+        self.callback.side_effect = callback_side_effect
+        self.stream.active = True
+        self.stream._run_loop()
+
+        self.assertEqual(self.callback.call_count, 2)
+        self.stream._stop_event.wait.assert_called_once()
+        wait_seconds = self.stream._stop_event.wait.call_args.args[0]
+        self.assertAlmostEqual(wait_seconds, 0.08, places=9)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- reject non-finite, non-positive, and malformed calibration values before they can affect measurements
- fail closed when loading corrupted calibration files or profiles, including calibrated-state flags
- pace virtual audio with a monotonic clock and cancel pending callbacks immediately on stop
- add regressions for corrupt calibration data, wall-clock jumps, and stop-during-wait races

## Risk addressed
Malformed persisted calibration previously propagated NaN, infinity, negative, or string values into frequency, voltage, SPL, and lock-in results while still appearing calibrated. Virtual mode also emitted one extra block after a stop request and used wall time for pacing, making it vulnerable to clock adjustments.

## Verification
- All checks passed!
- 496 files already formatted
- src/core/comparison_manager.py:177: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
src/core/export/manager.py:22: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
src/core/realtime_sss_core.py:144: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
src/core/realtime_sss_core.py:145: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
src/core/realtime_sss_core.py:146: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
src/core/realtime_sss_core.py:147: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
Success: no issues found in 97 source files
- === Translation Check Script ===
Loaded 2272 keys from en.json
Found 2272 unique tr() keys in 97 source files.

--- Check 1: Missing keys in en.json (Used in Code) ---
OK

--- Check 2: Unused keys in en.json (Not used in Code) ---
OK

--- Check 3: Missing translations in other languages (Compared to en.json) ---
OK

--- Check 4: Duplicate Keys (Warning) ---
OK

--- Check 5: Untranslated Placeholders (English values left as placeholder) ---
OK

=== Result ===
TEST PASSED
- markdownlint-cli2 v0.23.2 (markdownlint v0.41.1)
Finding: **/*.md !node_modules !site/ !.git/ !node_modules/ !**/node_modules/** !.venv/ !.github/deepwiki/
Linting: 150 files
Summary: 0 issues in 0 files
- ============================= test session starts ==============================
platform darwin -- Python 3.12.13, pytest-9.0.3, pluggy-1.6.0
PyQt6 6.11.0 -- Qt runtime 6.11.1 -- Qt compiled 6.11.0
rootdir: /Users/vach/MeasureLab
configfile: pytest.ini
testpaths: tests
plugins: json-report-1.5.0, metadata-3.1.1, qt-4.5.0
collected 1353 items

tests/core/export/test_csv_exporter.py .........                         [  0%]
tests/core/export/test_json_exporter.py ....                             [  0%]
tests/core/export/test_manager.py .....                                  [  1%]
tests/core/test_core_fft_manager.py ............                         [  2%]
tests/core/test_core_frequency_analysis.py .......                       [  2%]
tests/core/test_core_hammerstein_model.py ....                           [  3%]
tests/core/test_realtime_sss_core.py ...............                     [  4%]
tests/hardware/test_audio_metrics.py ss                                  [  4%]
tests/hardware/test_linearity.py s                                       [  4%]
tests/hardware/test_lockin_accuracy.py s                                 [  4%]
tests/hardware/test_lockin_phase_stability.py s                          [  4%]
tests/hardware/test_multitone_distortion.py s                            [  4%]
tests/logic_verification/analysis/test_analysis_a_weighting_cache.py ... [  4%]
...                                                                      [  5%]
tests/logic_verification/analysis/test_analysis_cache.py ....            [  5%]
tests/logic_verification/analysis/test_analysis_lockin.py ...            [  5%]
tests/logic_verification/analysis/test_analyze_harmonics.py .....        [  5%]
tests/logic_verification/analysis/test_antigravity_fixes.py .......      [  6%]
tests/logic_verification/analysis/test_boxcar_logic.py ............      [  7%]
tests/logic_verification/analysis/test_burst_delay.py .                  [  7%]
tests/logic_verification/analysis/test_burst_windowed.py .               [  7%]
tests/logic_verification/analysis/test_c_weighting_design.py .....       [  7%]
tests/logic_verification/analysis/test_distortion.py ...........         [  8%]
tests/logic_verification/analysis/test_distortion_averaging.py .         [  8%]
tests/logic_verification/analysis/test_filters.py .............          [  9%]
tests/logic_verification/analysis/test_frequency_analysis.py .........   [ 10%]
tests/logic_verification/analysis/test_frequency_optimization.py ....... [ 10%]
.......                                                                  [ 11%]
tests/logic_verification/analysis/test_goniometer_logic.py ............. [ 12%]
..                                                                       [ 12%]
tests/logic_verification/analysis/test_harmonic_boundary.py .            [ 12%]
tests/logic_verification/analysis/test_imd.py ................           [ 13%]
tests/logic_verification/analysis/test_lockin_comprehensive.py ......... [ 14%]
                                                                         [ 14%]
tests/logic_verification/analysis/test_lufs_meter_logic.py ............. [ 15%]
.                                                                        [ 15%]
tests/logic_verification/analysis/test_multitone_tdn.py .......          [ 15%]
tests/logic_verification/analysis/test_noise_profile_logic.py .......... [ 16%]
...                                                                      [ 16%]
tests/logic_verification/analysis/test_optimization_buffers.py ....      [ 17%]
tests/logic_verification/analysis/test_resample.py ....                  [ 17%]
tests/logic_verification/analysis/test_spdr.py ..........                [ 18%]
tests/logic_verification/analysis/test_spectrum_rms_accuracy.py ..       [ 18%]
tests/logic_verification/analysis/test_time_array.py ....                [ 18%]
tests/logic_verification/analysis/test_validate_audio_file_size.py ...   [ 18%]
tests/logic_verification/core/test_analysis.py .......................   [ 20%]
tests/logic_verification/core/test_audio_engine.py ..................... [ 22%]
...........................                                              [ 24%]
tests/logic_verification/core/test_bit_depth_estimator.py .............. [ 25%]
..                                                                       [ 25%]
tests/logic_verification/core/test_calibration.py ...................... [ 26%]
..                                                                       [ 27%]
tests/logic_verification/core/test_calibration_alignment.py .            [ 27%]
tests/logic_verification/core/test_calibration_manager.py .............. [ 28%]
..............                                                           [ 29%]
tests/logic_verification/core/test_calibration_profiles.py .......       [ 29%]
tests/logic_verification/core/test_comparison_manager.py ....            [ 30%]
tests/logic_verification/core/test_config_manager.py .................   [ 31%]
tests/logic_verification/core/test_config_manager_logic.py ............. [ 32%]
....                                                                     [ 32%]
tests/logic_verification/core/test_event_detector.py ................... [ 33%]
.................                                                        [ 35%]
tests/logic_verification/core/test_event_statistics.py ....              [ 35%]
tests/logic_verification/core/test_fft_manager.py .............          [ 36%]
tests/logic_verification/core/test_frequency_calibration.py .            [ 36%]
tests/logic_verification/core/test_hammerstein_model.py .                [ 36%]
tests/logic_verification/core/test_licff_smoothing.py .                  [ 36%]
tests/logic_verification/core/test_localization_logic.py ...........     [ 37%]
tests/logic_verification/core/test_ltc.py .............                  [ 38%]
tests/logic_verification/core/test_nonlinear_response_analyzer.py ...... [ 38%]
                                                                         [ 38%]
tests/logic_verification/core/test_offline_engine.py .                   [ 39%]
tests/logic_verification/core/test_pid_controller.py ........            [ 39%]
tests/logic_verification/core/test_predistortion.py ....                 [ 39%]
tests/logic_verification/core/test_ring_buffer.py ...........            [ 40%]
tests/logic_verification/core/test_ring_buffer_mismatch.py .             [ 40%]
tests/logic_verification/core/test_session_manager.py .                  [ 40%]
tests/logic_verification/core/test_sonifier.py ........                  [ 41%]
tests/logic_verification/core/test_theme_manager.py ................     [ 42%]
tests/logic_verification/core/test_timecode_calibration.py .             [ 42%]
tests/logic_verification/core/test_transmission.py ..................... [ 44%]
...                                                                      [ 44%]
tests/logic_verification/core/test_update_checker.py ............        [ 45%]
tests/logic_verification/core/test_utils.py .................            [ 46%]
tests/logic_verification/core/test_utils_resource.py .....               [ 47%]
tests/logic_verification/core/test_virtual_stream_timing.py ......       [ 47%]
tests/logic_verification/core/test_window_functions.py ..                [ 47%]
tests/logic_verification/generators/test_pink_noise.py ....              [ 47%]
tests/logic_verification/generators/test_signal_generator_logic.py ..... [ 48%]
...............................                                          [ 50%]
tests/logic_verification/generators/test_signal_generator_update_bug.py . [ 50%]
.                                                                        [ 50%]
tests/logic_verification/gui/test_amp_clamping.py .                      [ 50%]
tests/logic_verification/gui/test_basic_split.py ..........              [ 51%]
tests/logic_verification/gui/test_bit_depth_analyzer.py .                [ 51%]
tests/logic_verification/gui/test_bnim_meter.py ................         [ 52%]
tests/logic_verification/gui/test_compact_modes.py .........             [ 53%]
tests/logic_verification/gui/test_detachable_wrapper_split_actions.py .. [ 53%]
.....                                                                    [ 53%]
tests/logic_verification/gui/test_event_detector_widget.py ............. [ 54%]
..............................                                           [ 57%]
tests/logic_verification/gui/test_frequency_counter_reset.py ......      [ 57%]
tests/logic_verification/gui/test_goniometer_widget.py ................. [ 58%]
.                                                                        [ 58%]
tests/logic_verification/gui/test_hrtf_dos.py ..                         [ 59%]
tests/logic_verification/gui/test_hrtf_player_resample.py ...            [ 59%]
tests/logic_verification/gui/test_impedance_analyzer_details.py .        [ 59%]
tests/logic_verification/gui/test_linearity_analyzer_error.py .          [ 59%]
tests/logic_verification/gui/test_lockin_spectrum_finder_split.py ...... [ 59%]
                                                                         [ 59%]
tests/logic_verification/gui/test_log_viewer_logic.py ...                [ 60%]
tests/logic_verification/gui/test_loopback_finder.py ...............     [ 61%]
tests/logic_verification/gui/test_loopback_finder_ui_stop.py ..          [ 61%]
tests/logic_verification/gui/test_lufs_meter.py .......                  [ 61%]
tests/logic_verification/gui/test_lufs_meter_compact.py .                [ 61%]
tests/logic_verification/gui/test_main_window_activity.py .........      [ 62%]
tests/logic_verification/gui/test_main_window_format_sample_rate.py .    [ 62%]
tests/logic_verification/gui/test_main_window_lazy_imports.py .....      [ 63%]
tests/logic_verification/gui/test_measurement_console.py ............... [ 64%]
.........                                                                [ 64%]
tests/logic_verification/gui/test_missing_widget_capability_paths.py ... [ 65%]
                                                                         [ 65%]
tests/logic_verification/gui/test_network_analyzer.py ...............    [ 66%]
tests/logic_verification/gui/test_noise_profiler_gui_logic.py .          [ 66%]
tests/logic_verification/gui/test_noise_profiler_widget_logic.py .....   [ 66%]
tests/logic_verification/gui/test_nonlinear_analyzer_gui.py ...          [ 66%]
tests/logic_verification/gui/test_one_pps_monitor.py .............       [ 67%]
tests/logic_verification/gui/test_oscilloscope_calibration_display.py .. [ 67%]
.                                                                        [ 67%]
tests/logic_verification/gui/test_oscilloscope_cleanup.py .              [ 68%]
tests/logic_verification/gui/test_oscilloscope_compact_mode.py ...       [ 68%]
tests/logic_verification/gui/test_oscilloscope_features.py ....          [ 68%]
tests/logic_verification/gui/test_oscilloscope_math.py .....             [ 68%]
tests/logic_verification/gui/test_play_rec_session_cleanup.py ..         [ 69%]
tests/logic_verification/gui/test_plot_comparer.py ........              [ 69%]
tests/logic_verification/gui/test_pyinstaller_imports.py ..              [ 69%]
tests/logic_verification/gui/test_raw_time_series_formatting.py .....    [ 70%]
tests/logic_verification/gui/test_recorder_player_logic.py ...........   [ 71%]
tests/logic_verification/gui/test_recorder_player_race.py .              [ 71%]
tests/logic_verification/gui/test_recorder_save_optimization.py ..       [ 71%]
tests/logic_verification/gui/test_settings_jack_logic.py .               [ 71%]
tests/logic_verification/gui/test_settings_math.py ....                  [ 71%]
tests/logic_verification/gui/test_settings_structure.py .                [ 71%]
tests/logic_verification/gui/test_sound_level_meter.py ...........       [ 72%]
tests/logic_verification/gui/test_sound_quality_analyzer.py ....         [ 72%]
tests/logic_verification/gui/test_spectrogram.py ....................    [ 74%]
tests/logic_verification/gui/test_spectrogram_integration.py .           [ 74%]
tests/logic_verification/gui/test_spectrogram_split.py ...               [ 74%]
tests/logic_verification/gui/test_spectrum_analyzer_split.py ......      [ 75%]
tests/logic_verification/gui/test_startup_logic.py .                     [ 75%]
tests/logic_verification/gui/test_timecode_monitor.py ....               [ 75%]
tests/logic_verification/gui/test_transient_analyzer.py ................ [ 76%]
                                                                         [ 76%]
tests/logic_verification/gui/test_transient_ringing_analysis.py ...      [ 76%]
tests/logic_verification/gui/test_ultrasound_modulator.py ......         [ 77%]
tests/logic_verification/gui/test_waveform_loop_player.py .....          [ 77%]
tests/logic_verification/gui/test_widget_capabilities.py ............... [ 78%]
................................                                         [ 81%]
tests/logic_verification/gui/widgets/test_advanced_distortion_meter.py . [ 81%]
.....                                                                    [ 81%]
tests/logic_verification/gui/widgets/test_arbitrary_harmonic_generator.py . [ 81%]
.........                                                                [ 82%]
tests/logic_verification/gui/widgets/test_distortion_analyzer_widget.py . [ 82%]
...                                                                      [ 82%]
tests/logic_verification/gui/widgets/test_feedforward_compensator.py ... [ 82%]
.........                                                                [ 83%]
tests/logic_verification/gui/widgets/test_impedance_analyzer.py .....    [ 83%]
tests/logic_verification/gui/widgets/test_instrument_plot.py ...         [ 84%]
tests/logic_verification/gui/widgets/test_kalman_filter_1d.py ...        [ 84%]
tests/logic_verification/gui/widgets/test_lock_in_modeler.py ........... [ 85%]
                                                                         [ 85%]
tests/logic_verification/gui/widgets/test_measurement_control_layouts.py . [ 85%]
.                                                                        [ 85%]
tests/logic_verification/gui/widgets/test_response_viewer_contours.py .. [ 85%]
                                                                         [ 85%]
tests/logic_verification/gui/widgets/test_response_viewer_io_compression.py . [ 85%]
...                                                                      [ 85%]
tests/logic_verification/gui/widgets/test_response_viewer_noise_floor.py . [ 85%]
..                                                                       [ 85%]
tests/logic_verification/gui/widgets/test_response_viewer_wiener.py .... [ 86%]
.                                                                        [ 86%]
tests/logic_verification/gui/widgets/test_settings.py ...                [ 86%]
tests/logic_verification/gui/widgets/test_settings_calibration_profiles.py . [ 86%]
.......                                                                  [ 87%]
tests/logic_verification/gui/widgets/test_signal_generator.py .......... [ 87%]
..........                                                               [ 88%]
tests/logic_verification/gui/widgets/test_spatial_binaural_mixer.py .... [ 88%]
                                                                         [ 88%]
tests/logic_verification/gui/widgets/test_welcome.py .....               [ 89%]
tests/logic_verification/instruments/test_advanced_distortion_meter_mim.py . [ 89%]
.                                                                        [ 89%]
tests/logic_verification/instruments/test_advanced_distortion_worker.py . [ 89%]
..                                                                       [ 89%]
tests/logic_verification/instruments/test_allan_worker.py ...            [ 89%]
tests/logic_verification/instruments/test_distortion_analyzer_worker.py . [ 89%]
.                                                                        [ 89%]
tests/logic_verification/instruments/test_frequency_counter_logic.py ... [ 90%]
......                                                                   [ 90%]
tests/logic_verification/instruments/test_impedance_analyzer_dynamic_buffer.py . [ 90%]
......                                                                   [ 91%]
tests/logic_verification/instruments/test_impedance_analyzer_window.py . [ 91%]
.                                                                        [ 91%]
tests/logic_verification/instruments/test_impedance_calibration.py ..... [ 91%]
                                                                         [ 91%]
tests/logic_verification/instruments/test_linearity_analyzer_logic.py .. [ 91%]
........                                                                 [ 92%]
tests/logic_verification/instruments/test_linearity_buffer_optimization.py . [ 92%]
.                                                                        [ 92%]
tests/logic_verification/instruments/test_lockin_amplifier_logic.py ...  [ 92%]
tests/logic_verification/instruments/test_lockin_counter.py ....         [ 93%]
tests/logic_verification/instruments/test_lockin_decimals.py .           [ 93%]
tests/logic_verification/instruments/test_lockin_harmonic_analyzer.py .. [ 93%]
......                                                                   [ 93%]
tests/logic_verification/instruments/test_lockin_spectrum_finder_sonification.py . [ 93%]
..                                                                       [ 93%]
tests/logic_verification/instruments/test_oscilloscope_logic.py ........ [ 94%]
.........                                                                [ 95%]
tests/logic_verification/instruments/test_spectrum_analyzer.py ......    [ 95%]
tests/logic_verification/instruments/test_spectrum_analyzer_refactor.py . [ 95%]
......                                                                   [ 96%]
tests/logic_verification/instruments/test_timecode_monitor_ltc.py ....   [ 96%]
tests/logic_verification/instruments/test_timecode_monitor_optimization.py . [ 96%]
                                                                         [ 96%]
tests/logic_verification/measurement_modules/test_lockin_vs_nonlinear.py . [ 96%]
                                                                         [ 96%]
tests/logic_verification/measurement_modules/test_nonlinear_analyzer.py . [ 96%]
........                                                                 [ 97%]
tests/regression/test_signal_generator_switch.py ..                      [ 97%]
tests/security/test_arbitrary_harmonic_generator_security.py .           [ 97%]
tests/security/test_calibration_path_traversal.py .                      [ 97%]
tests/security/test_calibration_permissions.py .                         [ 97%]
tests/security/test_config_json_type.py ..                               [ 97%]
tests/security/test_config_path_resolution.py ..........                 [ 98%]
tests/security/test_config_permissions.py .                              [ 98%]
tests/security/test_config_traversal.py ..                               [ 98%]
tests/security/test_impedance_analyzer_security.py .                     [ 98%]
tests/security/test_math_renderer_security.py ...                        [ 99%]
tests/security/test_recorder_memory.py ...                               [ 99%]
tests/security/test_screenshot_permissions.py .                          [ 99%]
tests/security/test_unbounded_loading.py ....                            [ 99%]
tests/security/test_update_xss.py .                                      [ 99%]
tests/security/test_wisdom_security.py ....                              [100%]

=========================== short test summary info ============================
SKIPPED [2] tests/hardware/test_audio_metrics.py: need --hardware option to run
SKIPPED [1] tests/hardware/test_linearity.py: need --hardware option to run
SKIPPED [1] tests/hardware/test_lockin_accuracy.py: need --hardware option to run
SKIPPED [1] tests/hardware/test_lockin_phase_stability.py: need --hardware option to run
SKIPPED [1] tests/hardware/test_multitone_distortion.py: need --hardware option to run
================== 1347 passed, 6 skipped in 65.42s (0:01:05) ================== (1347 passed, 6 hardware-only skipped)