### PR TITLE
fix: use black goniometer plot background

### DIFF
--- a/src/gui/widgets/goniometer.py
+++ b/src/gui/widgets/goniometer.py
@@ -639,7 +639,7 @@ class GoniometerWidget(QWidget, CompactableWidgetInterface, SplittableWidgetInte
         self.plot_widget.setXRange(-1.1, 1.1, padding=0.0)
         self.plot_widget.setYRange(-1.1, 1.1, padding=0.0)
         self.plot_widget.setMouseEnabled(x=False, y=False)
-        self.plot_widget.setBackground("#111111")
+        self.plot_widget.setBackground("#000000")
         self.plot_widget.setFrameShape(QFrame.Shape.NoFrame)
         self.plot_widget.setStyleSheet("border: none;")
         self.plot_widget.getPlotItem().layout.setContentsMargins(0, 0, 0, 0)
@@ -1367,7 +1367,7 @@ class GoniometerWidget(QWidget, CompactableWidgetInterface, SplittableWidgetInte
     def apply_theme(self, theme_name: str) -> None:
         if theme_name == "system" and self.app is not None and hasattr(self.app, "theme_manager"):
             theme_name = self.app.theme_manager.get_effective_theme()
-        background = "#111111" if theme_name == "dark" else "#fafafa"
+        background = "#000000" if theme_name == "dark" else "#fafafa"
         self.plot_widget.setBackground(background)
         self.toggle_btn.setStyleSheet(STYLE_TOGGLE_BTN_DARK if theme_name == "dark" else STYLE_TOGGLE_BTN_LIGHT)
         label_color = "#bbbbbb" if theme_name == "dark" else "#444444"

--- a/tests/logic_verification/gui/test_goniometer_widget.py
+++ b/tests/logic_verification/gui/test_goniometer_widget.py
@@ -107,6 +107,19 @@ def test_plot_guides_axes_and_grid_defaults_and_toggles(widget):
     assert not left_axis.grid
 
 
+def test_plot_background_matches_theme(widget):
+    def background_name() -> str:
+        return widget.plot_widget.backgroundBrush().color().name()
+
+    assert background_name() == "#000000"
+
+    widget.apply_theme("light")
+    assert background_name() == "#fafafa"
+
+    widget.apply_theme("dark")
+    assert background_name() == "#000000"
+
+
 def test_measurement_actions_are_large_and_belong_to_control_panel(widget):
     assert not hasattr(widget, "measurement_group")
     assert widget.controls_group.isAncestorOf(widget.toggle_btn)


### PR DESCRIPTION
## Summary

- Change the Goniometer plot background from #111111 to pure black in initialization and dark theme application.
- Add a GUI regression test covering default, light, and dark theme backgrounds.

## Validation

- QT_QPA_PLATFORM=offscreen ./.venv/bin/pytest -q (1356 passed, 6 skipped, 29 subtests passed)
- ./.venv/bin/ruff check .
- ./.venv/bin/ruff format --check .
- ./.venv/bin/mypy src main_gui.py
- ./.venv/bin/python scripts/check_trn_keys.py
- npx markdownlint-cli2 "**/*.md" "#node_modules"
- ./.venv/bin/python scripts/check_ui_size_limits.py

Closes #2063